### PR TITLE
adding GitLab CI and code coverage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,2 @@
+include:
+  - template: Code-Quality.gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,16 +50,7 @@ test_and_coverage:
         paths:
             - jacoco
         expire_in: 30 days
- 
-project_info:
-    stage: package
-    script:
-        - mvn $MAVEN_CLI_OPTS site -f system/platform-core
-        - mv system/platform-core/target/site project_info
-    artifacts:
-        paths:
-            - project_info
-        expire_in: 30 days
+
  
 javadoc: 
     stage: package
@@ -75,12 +66,10 @@ pages:
     stage: deploy
     dependencies:
         - test_and_coverage
-        - project_info
         - javadoc
     script:
-        - mkdir -p public/coverage public/projectinfo public/docs
+        - mkdir -p public/coverage public/docs
         - mv jacoco/* public/coverage
-        - mv project_info/* public/projectinfo
         - mv apidocs/* public/docs
     artifacts:
         paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ build:
 test_and_coverage:
     stage: test
     script:
-        - mvn $MAVEN_CLI_OPTS test
+        - mvn $MAVEN_CLI_OPTS test -f system/platform-core
         - ls -la
         - ls -la target
         - ls -la target/site

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ test_and_coverage:
     artifacts:
         reports:
             junit:
-                - target/surefire-reports/TEST-*.xml
+                - system/platform-core/target/surefire-reports/TEST-*.xml
         paths:
             - target/jacoco
         expire_in: 30 days

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,10 +39,7 @@ test_and_coverage:
     stage: test
     script:
         - mvn $MAVEN_CLI_OPTS test -f system/platform-core
-        - ls -la
-        - ls -la system/platform-core/target
-        - ls -la system/platform-core/target/site
-        - ls -la system/platform-core/target/site/jacoco
+        - ls -la system/platform-core/target/surefire-reports
         - cat system/platform-core/target/site/jacoco/index.html
         - mv system/platform-core/target/site/jacoco target/jacoco/
     coverage: '/Total.*?([0-9]{1,3})%/'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ variables:
     MAVEN_OPTS: "-Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository -Djava.awt.headless=true"
 
 cache:
-    key: $CI_PIPELINE_ID
+    key: $CI_PIPELINE_IID
     policy: pull
     paths:
     - $CI_PROJECT_DIR/.m2/repository # cache maven repository across all jobs
@@ -23,10 +23,34 @@ stages:
 build:
     stage: build
     script:
-        - mvn clean install -f system/platform-core
-        - mvn clean install -f system/rest-core
-        - mvn clean install -f system/rest-spring
-        - mvn clean install -f system/rest-spring
-        - mvn clean install -f connectors/hazelcast/hazelcast-connector
-        - mvn clean install -f connectors/kafka/kafka-connector
+        - mvn $MAVEN_CLI_OPTS clean compile -f system/platform-core
+        - mvn $MAVEN_CLI_OPTS clean compile -f system/rest-core
+        - mvn $MAVEN_CLI_OPTS clean compile -f system/rest-spring
+        - mvn $MAVEN_CLI_OPTS clean compile -f system/rest-spring
+        - mvn $MAVEN_CLI_OPTS clean compile -f connectors/hazelcast/hazelcast-connector
+        - mvn $MAVEN_CLI_OPTS clean compile -f connectors/kafka/kafka-connector
+    cache:
+        key: $CI_PIPELINE_IID
+        policy: push # this is the only job that needs to publish to the cache, therefore it is overriding the policy
+        paths:
+            - $CI_PROJECT_DIR/.m2/repository
+            
+test_and_coverage:
+    stage: test
+    script:
+        - mvn $MAVEN_CLI_OPTS test
+        - ls -la
+        - ls -la target
+        - ls -la target/site
+        - ls -la target/site/jacoco
+        - cat target/site/jacoco/index.html
+        - mv target/site/jacoco target/jacoco/
+    coverage: '/Total.*?([0-9]{1,3})%/'
+    artifacts:
+        reports:
+            junit:
+                - target/surefire-reports/TEST-*.xml
+        paths:
+            - target/jacoco
+        expire_in: 30 days
  

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: maven:3.6.1-jdk-11
+image: maven:3.6.1-jdk-8
 
 variables:
     MAVEN_CLI_OPTS: "--show-version"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,7 @@ test_and_coverage:
 project_info:
     stage: package
     script:
-        - mvn $MAVEN_CLI_OPTS site
+        - mvn $MAVEN_CLI_OPTS site -f system/platform-core
         - mv system/platform-core/target/site project_info
     artifacts:
         paths:
@@ -64,7 +64,7 @@ project_info:
 javadoc: 
     stage: package
     script: 
-        - mvn $MAVEN_CLI_OPTS javadoc:javadoc
+        - mvn $MAVEN_CLI_OPTS javadoc:javadoc -f system/platform-core
         - mv system/platform-core/target/site/apidocs apidocs
     artifacts:
         paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,13 +41,49 @@ test_and_coverage:
         - mvn $MAVEN_CLI_OPTS test -f system/platform-core
         - ls -la system/platform-core/target/surefire-reports
         - cat system/platform-core/target/site/jacoco/index.html
-        - mv system/platform-core/target/site/jacoco target/jacoco/
+        - mv system/platform-core/target/site/jacoco jacoco
     coverage: '/Total.*?([0-9]{1,3})%/'
     artifacts:
         reports:
             junit:
                 - system/platform-core/target/surefire-reports/TEST-*.xml
         paths:
-            - target/jacoco
+            - jacoco
         expire_in: 30 days
+ 
+project_info:
+    stage: package
+    script:
+        - mvn $MAVEN_CLI_OPTS site
+        - mv system/platform-core/target/site project_info
+    artifacts:
+        paths:
+            - project_info
+        expire_in: 30 days
+ 
+javadoc: 
+    stage: package
+    script: 
+        - mvn $MAVEN_CLI_OPTS javadoc:javadoc
+        - mv system/platform-core/target/site/apidocs apidocs
+    artifacts:
+        paths:
+            - apidocs
+        expire_in: 30 days
+        
+pages:
+    stage: deploy
+    dependencies:
+        - test_and_coverage
+        - project_info
+        - javadoc
+    script:
+        - mkdir -p public/coverage public/projectinfo public/docs
+        - mv jacoco/* public/coverage
+        - mv project_info/* public/projectinfo
+        - mv apidocs/* public/docs
+    artifacts:
+        paths:
+        - public
+        expire_in: 90 days
  

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,12 +23,12 @@ stages:
 build:
     stage: build
     script:
-        - mvn $MAVEN_CLI_OPTS clean compile -f system/platform-core
-        - mvn $MAVEN_CLI_OPTS clean compile -f system/rest-core
-        - mvn $MAVEN_CLI_OPTS clean compile -f system/rest-spring
-        - mvn $MAVEN_CLI_OPTS clean compile -f system/rest-spring
-        - mvn $MAVEN_CLI_OPTS clean compile -f connectors/hazelcast/hazelcast-connector
-        - mvn $MAVEN_CLI_OPTS clean compile -f connectors/kafka/kafka-connector
+        - mvn $MAVEN_CLI_OPTS clean compile install -f system/platform-core
+        - mvn $MAVEN_CLI_OPTS clean compile install -f system/rest-core
+        - mvn $MAVEN_CLI_OPTS clean compile install -f system/rest-spring
+        - mvn $MAVEN_CLI_OPTS clean compile install -f system/rest-spring
+        - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/hazelcast/hazelcast-connector
+        - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/kafka/kafka-connector
     cache:
         key: $CI_PIPELINE_IID
         policy: push # this is the only job that needs to publish to the cache, therefore it is overriding the policy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,2 +1,32 @@
+image: maven:3.6.1-jdk-11
+
+variables:
+    MAVEN_CLI_OPTS: "--show-version"
+    MAVEN_OPTS: "-Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository -Djava.awt.headless=true"
+
+cache:
+    key: $CI_PIPELINE_ID
+    policy: pull
+    paths:
+    - $CI_PROJECT_DIR/.m2/repository # cache maven repository across all jobs
+
 include:
-  - template: Code-Quality.gitlab-ci.yml
+    - template: Code-Quality.gitlab-ci.yml
+  
+ 
+stages:
+    - build
+    - test
+    - package
+    - deploy
+    
+build:
+    stage: build
+    script:
+        - mvn clean install -f system/platform-core
+        - mvn clean install -f system/rest-core
+        - mvn clean install -f system/rest-spring
+        - mvn clean install -f system/rest-spring
+        - mvn clean install -f connectors/hazelcast/hazelcast-connector
+        - mvn clean install -f connectors/kafka/kafka-connector
+ 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,11 +40,11 @@ test_and_coverage:
     script:
         - mvn $MAVEN_CLI_OPTS test -f system/platform-core
         - ls -la
-        - ls -la target
-        - ls -la target/site
-        - ls -la target/site/jacoco
-        - cat target/site/jacoco/index.html
-        - mv target/site/jacoco target/jacoco/
+        - ls -la system/platform-core/target
+        - ls -la system/platform-core/target/site
+        - ls -la system/platform-core/target/site/jacoco
+        - cat system/platform-core/target/site/jacoco/index.html
+        - mv system/platform-core/target/site/jacoco target/jacoco/
     coverage: '/Total.*?([0-9]{1,3})%/'
     artifacts:
         reports:

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -163,7 +163,25 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
adding initial version of CI-pipeline.

**Building binaries**
In order to verify that the code compiles correctly, GitLab CI has been added.

**JavaDoc and Unit Test Reports**
Furthermore the job builds the existing [JavaDoc](https://skofgar.gitlab.io/mercury/docs/), a new [coverage report](https://skofgar.gitlab.io/mercury/coverage/) and displays them as [GitLab pages (see badges)](https://gitlab.com/skofgar/mercury). Also, GitLab CI will be able to read the surefire reports and display code coverage and unit test results directly inside merge requests (on GitLab). Example: https://gitlab.com/skofgar/mercury/merge_requests/5

**Code Quality**
Furthermore the Code Climate tool has been added to create a _Code Quality_ report, this will help guide and ensure code quality: https://codeclimate.com/github/skofgar/mercury

----
**Pending tasks**
There are a few places that need improvements, such as the first step, the "build" job. Currently it installs all the libraries, but instead that step would only compile source code and pull dependent libraries. I believe that the project will be split up into multiple repositories, in which case that job will become more simple.

Going forward these reports shouldn't necessarily be built in personal projects, but either under Accenture or under a "mercury" generic repository group.