### PR TITLE
Adding source to javadoc configuration to compile on JDK 11

### DIFF
--- a/connectors/hazelcast/hazelcast-connector/pom.xml
+++ b/connectors/hazelcast/hazelcast-connector/pom.xml
@@ -80,6 +80,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.0</version>
+                 <configuration>
+                	<source>1.8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/connectors/kafka/kafka-connector/pom.xml
+++ b/connectors/kafka/kafka-connector/pom.xml
@@ -79,6 +79,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.0</version>
+                <configuration>
+                	<source>1.8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -154,7 +154,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.0</version>
-                <executions>
+                <configuration>
+                	<source>1.8</source>
+                </configuration>
+				<executions>
                     <execution>
                         <id>attach-javadocs</id>
                         <goals>

--- a/system/rest-core/pom.xml
+++ b/system/rest-core/pom.xml
@@ -94,6 +94,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.0</version>
+                <configuration>
+                	<source>1.8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/system/rest-spring/pom.xml
+++ b/system/rest-spring/pom.xml
@@ -179,6 +179,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.0</version>
+                 <configuration>
+                	<source>1.8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Configuration change needed to run maven-javadoc-plugin on JDK11.