### PR TITLE
upgrading JavaDoc 3.0.0 to 3.0.1 due to NullPointerException

### DIFF
--- a/connectors/hazelcast/hazelcast-connector/pom.xml
+++ b/connectors/hazelcast/hazelcast-connector/pom.xml
@@ -79,7 +79,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1</version>
                  <configuration>
                 	<source>1.8</source>
                 </configuration>

--- a/connectors/kafka/kafka-connector/pom.xml
+++ b/connectors/kafka/kafka-connector/pom.xml
@@ -78,7 +78,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1</version>
                 <configuration>
                 	<source>1.8</source>
                 </configuration>

--- a/extensions/rest-automation/pom.xml
+++ b/extensions/rest-automation/pom.xml
@@ -90,7 +90,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1</version>
                 <configuration>
                     <source>1.8</source>
                 </configuration>

--- a/language-packs/language-connector/pom.xml
+++ b/language-packs/language-connector/pom.xml
@@ -90,7 +90,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1</version>
                 <configuration>
                 	<source>1.8</source>
                 </configuration>

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -153,7 +153,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1</version>
                 <configuration>
                 	<source>1.8</source>
                 </configuration>

--- a/system/rest-spring/pom.xml
+++ b/system/rest-spring/pom.xml
@@ -178,7 +178,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1</version>
                  <configuration>
                 	<source>1.8</source>
                 </configuration>


### PR DESCRIPTION
using a JDK 10 or newer caused a NullPointer Exception in JavaDoc 3.0.0
JavaDoc Plugin: https://issues.apache.org/jira/browse/MJAVADOC-517