### PR TITLE
implement closeable to enforce try-resource-finally syntax

### DIFF
--- a/system/platform-core/src/main/java/org/platformlambda/core/websocket/client/PersistentWsClient.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/websocket/client/PersistentWsClient.java
@@ -30,12 +30,17 @@ import org.slf4j.LoggerFactory;
 import javax.websocket.CloseReason;
 import javax.websocket.ContainerProvider;
 import javax.websocket.WebSocketContainer;
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-public class PersistentWsClient extends Thread {
+public class PersistentWsClient extends Thread implements Closeable {
     private static final Logger log = LoggerFactory.getLogger(PersistentWsClient.class);
 
     private static final long WAIT_INTERVAL = 5000;
@@ -205,4 +210,8 @@ public class PersistentWsClient extends Thread {
         normal = false;
     }
 
+    @Override
+    public void close() {
+        this.shutdown();
+    }
 }


### PR DESCRIPTION
enable try-finally syntax sugar:

        try (PersistentWsClient wsClient = new PersistentWsClient(new ElasticsearchLogger(), uri)) {
            wsClient.start();
        }

vs: 

        final PersistentWsClient wsClient = new PersistentWsClient(new ElasticsearchLogger(), uri);
        try {
            wsClient.start();
        } finally {
            wsClient.shutdown();
        }