### PR TITLE
Enforcing Types through TypedLambdaFunction 

### DIFF
--- a/docs/guides/CHAPTER-1.md
+++ b/docs/guides/CHAPTER-1.md
@@ -64,7 +64,7 @@ public class MainApp implements EntryPoint {
 Alternatively, for typed body and response without casting you can use TypedLambdaFunction<T, R>:
 
 ```
-    TypedLambdaFunction<String, Map<String, Object>> lambda = (headers, body, instance) -> {
+    TypedLambdaFunction<String, Map<String, String>> lambda = (headers, body, instance) -> {
         Map<String, String> result = new HashMap<>();
         result.put("body", body);
         return result;

--- a/docs/guides/CHAPTER-1.md
+++ b/docs/guides/CHAPTER-1.md
@@ -61,6 +61,16 @@ public class MainApp implements EntryPoint {
 
 ```
 
+Alternatively, for typed body and response without casting you can use TypedLambdaFunction<T, R>:
+
+```
+    TypedLambdaFunction<String, Map<String, Object>> lambda = (headers, body, instance) -> {
+        Map<String, String> result = new HashMap<>();
+        result.put("body", body);
+        return result;
+    };
+```
+
 ## Calling a function
 
 Unlike traditional programming, you call a function by sending an event instead of calling its method. Mercury resolves routing automatically so events are delivered correctly no matter where the target function is, in the same memory space or another computer elsewhere in the network.

--- a/examples/rest-example/src/main/java/com/accenture/examples/MainApp.java
+++ b/examples/rest-example/src/main/java/com/accenture/examples/MainApp.java
@@ -21,7 +21,7 @@ package com.accenture.examples;
 import com.accenture.examples.services.DemoMath;
 import org.platformlambda.core.annotations.MainApplication;
 import org.platformlambda.core.models.EntryPoint;
-import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.models.TypedLambdaFunction;
 import org.platformlambda.core.system.Platform;
 import org.platformlambda.core.system.ServerPersonality;
 import org.platformlambda.rest.RestServer;
@@ -47,7 +47,7 @@ public class MainApp implements EntryPoint {
 
         Platform platform = Platform.getInstance();
         // you can write simple service using anonymous function
-        LambdaFunction echo = (headers, body, instance) -> {
+        TypedLambdaFunction<Map<String, Object>, Map<String, Object>> echo = (headers, body, instance) -> {
             /*
              * Uncomment the "log.info" statement if you want to see this service receiving the event.
              * (Note that logging takes time so it will affect your function execution time.)
@@ -56,9 +56,9 @@ public class MainApp implements EntryPoint {
 
             // your response object can be a Java primitive, hashmap or PoJo. No need to use JSON internally.
             Map<String, Object> result = new HashMap<>();
-            result.put("headers", headers);
+            result.put("headers", headers.toString());
             result.put("body", body);
-            result.put("instance", instance);
+            result.put("instance", String.valueOf(instance));
             result.put("origin", platform.getOrigin());
             return result;
         };

--- a/system/platform-core/src/main/java/org/platformlambda/core/models/TypedLambdaFunction.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/models/TypedLambdaFunction.java
@@ -20,7 +20,7 @@ package org.platformlambda.core.models;
 
 import java.util.Map;
 
-public interface LambdaFunction extends TypedLambdaFunction<Object, Object> {
+public interface TypedLambdaFunction<T, R> {
 
-    Object handleEvent(Map<String, String> headers, Object body, int instance) throws Exception;
+    R handleEvent(Map<String, String> headers, T body, int instance) throws Exception;
 }

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/Platform.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/Platform.java
@@ -24,9 +24,13 @@ import org.platformlambda.core.annotations.CloudConnector;
 import org.platformlambda.core.annotations.CloudService;
 import org.platformlambda.core.models.CloudSetup;
 import org.platformlambda.core.models.Kv;
-import org.platformlambda.core.models.LambdaFunction;
 import org.platformlambda.core.models.TargetRoute;
-import org.platformlambda.core.util.*;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.util.AppConfigReader;
+import org.platformlambda.core.util.CryptoApi;
+import org.platformlambda.core.util.ManagedCache;
+import org.platformlambda.core.util.SimpleClassScanner;
+import org.platformlambda.core.util.Utility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -259,7 +263,7 @@ public class Platform {
      * @param instances for concurrent processing of events
      * @throws IOException in case of duplicated registration
      */
-    public void register(String route, LambdaFunction lambda, int instances) throws IOException {
+    public void register(String route, TypedLambdaFunction lambda, int instances) throws IOException {
         register(route, lambda, false, instances);
     }
 
@@ -272,7 +276,7 @@ public class Platform {
      * @param instances for concurrent processing of events
      * @throws IOException in case of duplicated registration
      */
-    public void registerPrivate(String route, LambdaFunction lambda, int instances) throws IOException {
+    public void registerPrivate(String route, TypedLambdaFunction lambda, int instances) throws IOException {
         register(route, lambda, true, instances);
     }
 
@@ -295,7 +299,7 @@ public class Platform {
         }
     }
 
-    private void register(String route, LambdaFunction lambda, Boolean isPrivate, Integer instances)
+    private void register(String route, TypedLambdaFunction lambda, Boolean isPrivate, Integer instances)
             throws IOException {
         if (route == null) {
             throw new IOException("Missing service routing path");

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/ServiceDef.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/ServiceDef.java
@@ -19,7 +19,7 @@
 package org.platformlambda.core.system;
 
 import akka.actor.ActorRef;
-import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.models.TypedLambdaFunction;
 import org.platformlambda.core.util.Utility;
 
 import java.util.Date;
@@ -29,14 +29,14 @@ public class ServiceDef {
     private static final int MAX_INSTANCES = 1000;
 
     private final String route;
-    private final LambdaFunction lambda;
+    private final TypedLambdaFunction lambda;
     private final String id;
     private final ActorRef manager;
     private final Date created = new Date();
     private boolean isPrivate = false;
     private int instances = 1;
 
-    public ServiceDef(String route, LambdaFunction lambda, ActorRef manager) {
+    public ServiceDef(String route, TypedLambdaFunction lambda, ActorRef manager) {
         this.id = Utility.getInstance().getUuid();
         this.route = route;
         this.lambda = lambda;
@@ -59,7 +59,7 @@ public class ServiceDef {
         return manager;
     }
 
-    public LambdaFunction getFunction() {
+    public TypedLambdaFunction getFunction() {
         return lambda;
     }
 

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerQueue.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerQueue.java
@@ -27,9 +27,9 @@ import org.platformlambda.core.annotations.EventInterceptor;
 import org.platformlambda.core.annotations.ZeroTracing;
 import org.platformlambda.core.exception.AppException;
 import org.platformlambda.core.models.EventEnvelope;
-import org.platformlambda.core.models.LambdaFunction;
 import org.platformlambda.core.models.ProcessStatus;
 import org.platformlambda.core.models.TraceInfo;
+import org.platformlambda.core.models.TypedLambdaFunction;
 import org.platformlambda.core.util.AppConfigReader;
 import org.platformlambda.core.util.Utility;
 import org.slf4j.Logger;
@@ -139,7 +139,7 @@ public class WorkerQueue extends AbstractActor {
 
     private ProcessStatus processEvent(EventEnvelope event) {
         PostOffice po = PostOffice.getInstance();
-        LambdaFunction f = def.getFunction();
+        TypedLambdaFunction f = def.getFunction();
         try {
             /*
              * Interceptor can read any input (i.e. including case for empty headers and null body).


### PR DESCRIPTION
Introducing TypedLambdaFunction <T, R> with generics to enforce body input type and responses without the need for a manual cast. 
- no need for additional refactoring, existing functionality is preserved because LamdaFunction extends TypedLambdaFunction using Object as the input and response type. 
- tested with rest-example 
- included documentation short code snippet

