### PR TITLE
dynamic maven versioning to drive releases using git tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,16 +44,11 @@ build:
 .test_and_coverage:
     stage: test
     needs: ['build']
-    script:
-        - mvn $MAVEN_CLI_OPTS test -f system/platform-core
-        - ls -la system/platform-core/target/surefire-reports
-        - cat system/platform-core/target/site/jacoco/index.html
-        - mv system/platform-core/target/site/jacoco jacoco
     coverage: '/Total.*?([0-9]{1,3})%/'
     artifacts:
         reports:
             junit:
-                - /**/target/surefire-reports/TEST-*.xml
+                - $CI_PROJECT_DIR/**/target/surefire-reports/TEST-*.xml
         paths:
             - jacoco
         expire_in: 30 days
@@ -69,7 +64,7 @@ platform_test:
 rest_test:
   extends: .test_and_coverage
   script:
-      - mvn $MAVEN_CLI_OPTS test -f system/platform-core
+      - mvn $MAVEN_CLI_OPTS test -f system/rest-spring
 
 connector_eventnode_test:
   extends: .test_and_coverage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,16 @@ build:
         paths:
             - $CI_PROJECT_DIR/.m2/repository
 
+build-submodules:
+    stage: build
+    script:
+        - mvn $MAVEN_CLI_OPTS clean compile install
+    # cache:
+    #     key: $CI_PIPELINE_IID
+    #     policy: push # this is the only job that needs to publish to the cache, therefore it is overriding the policy
+    #     paths:
+    #         - $CI_PROJECT_DIR/.m2/repository
+
 
 ############################
 # TEST
@@ -96,6 +106,11 @@ connector_kafka_standalone_test:
   extends: .test_and_coverage
   script:
       - mvn $MAVEN_CLI_OPTS test -f connectors/kafka/kafka-standalone
+
+submodules_test:
+  extends: .test_and_coverage
+  script:
+      - mvn $MAVEN_CLI_OPTS test 
 
 
 ############################

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,7 @@ stages:
 build:
     stage: build
     script:
+        - mvn $MAVEN_CLI_OPTS clean compile install -f system/parent
         - mvn $MAVEN_CLI_OPTS clean compile install
     cache:
         key: $CI_PIPELINE_IID

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,6 +102,25 @@ connector_kafka_standalone_test:
       - mvn $MAVEN_CLI_OPTS test -f connectors/kafka/kafka-standalone
 
 
+############################
+# Publish
+
+.publish:
+  stage: deploy
+  dependencies: ['build']
+  needs: ['build']
+
+snapshot:
+  script:
+    - echo "Publish snapshot"
+    - mvn $MAVEN_CLI_OPTS deploy -s .gitlab_maven_settings.xml -DskipTests -f system/platform-core
+
+release:
+  script:
+    - echo "Publish release"
+    - mvn $MAVEN_CLI_OPTS deploy -s .gitlab_maven_settings.xml -DskipTests -Drevision=$CI_COMMIT_TAG -f system/platform-core
+  only:
+    - tags
 
 ############################
 # JavaDoc

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ stages:
 build:
     stage: build
     script:
+        - mvn $MAVEN_CLI_OPTS clean compile install -f system/parent
         - mvn $MAVEN_CLI_OPTS clean compile install -f system/platform-core
         - mvn $MAVEN_CLI_OPTS clean compile install -f system/rest-spring
         - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/event-node

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,7 +74,7 @@ submodules_test:
 .publish:
   stage: deploy
   dependencies: ['build', 'submodules_test']
-  needs: ['build']
+  needs: ['build', 'submodules_test']
 
 snapshot:
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,11 +77,13 @@ submodules_test:
   needs: ['build', 'submodules_test']
 
 snapshot:
+  extends: .publish
   script:
     - echo "Publish snapshot"
     - mvn $MAVEN_CLI_OPTS deploy -s .gitlab_maven_settings.xml -DskipTests
 
 release:
+  extends: .publish
   script:
     - echo "Publish release"
     - mvn $MAVEN_CLI_OPTS deploy -s .gitlab_maven_settings.xml -DskipTests -Drevision=$CI_COMMIT_TAG -f

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,33 +20,33 @@ stages:
     - package
     - deploy
 
+# build:
+#     stage: build
+#     script:
+#         - mvn $MAVEN_CLI_OPTS clean compile install -f system/parent
+#         - mvn $MAVEN_CLI_OPTS clean compile install -f system/platform-core
+#         - mvn $MAVEN_CLI_OPTS clean compile install -f system/rest-spring
+#         - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/event-node
+#         - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/hazelcast/hazelcast-connector
+#         - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/hazelcast/hazelcast-presence
+#         - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/kafka/kafka-connector
+#         - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/kafka/kafka-presence
+#         - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/kafka/kafka-standalone
+#     cache:
+#         key: $CI_PIPELINE_IID
+#         policy: push # this is the only job that needs to publish to the cache, therefore it is overriding the policy
+#         paths:
+#             - $CI_PROJECT_DIR/.m2/repository
+
 build:
     stage: build
     script:
-        - mvn $MAVEN_CLI_OPTS clean compile install -f system/parent
-        - mvn $MAVEN_CLI_OPTS clean compile install -f system/platform-core
-        - mvn $MAVEN_CLI_OPTS clean compile install -f system/rest-spring
-        - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/event-node
-        - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/hazelcast/hazelcast-connector
-        - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/hazelcast/hazelcast-presence
-        - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/kafka/kafka-connector
-        - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/kafka/kafka-presence
-        - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/kafka/kafka-standalone
+        - mvn $MAVEN_CLI_OPTS clean compile install
     cache:
         key: $CI_PIPELINE_IID
         policy: push # this is the only job that needs to publish to the cache, therefore it is overriding the policy
         paths:
             - $CI_PROJECT_DIR/.m2/repository
-
-build-submodules:
-    stage: build
-    script:
-        - mvn $MAVEN_CLI_OPTS clean compile install
-    # cache:
-    #     key: $CI_PIPELINE_IID
-    #     policy: push # this is the only job that needs to publish to the cache, therefore it is overriding the policy
-    #     paths:
-    #         - $CI_PROJECT_DIR/.m2/repository
 
 
 ############################

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,23 +20,6 @@ stages:
     - package
     - deploy
 
-# build:
-#     stage: build
-#     script:
-#         - mvn $MAVEN_CLI_OPTS clean compile install -f system/parent
-#         - mvn $MAVEN_CLI_OPTS clean compile install -f system/platform-core
-#         - mvn $MAVEN_CLI_OPTS clean compile install -f system/rest-spring
-#         - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/event-node
-#         - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/hazelcast/hazelcast-connector
-#         - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/hazelcast/hazelcast-presence
-#         - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/kafka/kafka-connector
-#         - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/kafka/kafka-presence
-#         - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/kafka/kafka-standalone
-#     cache:
-#         key: $CI_PIPELINE_IID
-#         policy: push # this is the only job that needs to publish to the cache, therefore it is overriding the policy
-#         paths:
-#             - $CI_PROJECT_DIR/.m2/repository
 
 build:
     stage: build
@@ -65,6 +48,10 @@ build:
             - jacoco
         expire_in: 30 days
 
+
+# just test platform core
+# TODO: is it possible to generate coverage report across all modules?
+# The current coverage report is only for the platform core submodule
 platform_test:
   extends: .test_and_coverage
   script:
@@ -73,45 +60,12 @@ platform_test:
       - cat system/platform-core/target/site/jacoco/index.html
       - mv system/platform-core/target/site/jacoco jacoco
 
-rest_test:
-  extends: .test_and_coverage
-  script:
-      - mvn $MAVEN_CLI_OPTS test -f system/rest-spring
 
-connector_eventnode_test:
-  extends: .test_and_coverage
-  script:
-      - mvn $MAVEN_CLI_OPTS test -f connectors/event-node
-
-connector_hazelcast_test:
-  extends: .test_and_coverage
-  script:
-      - mvn $MAVEN_CLI_OPTS test -f connectors/hazelcast/hazelcast-connector
-
-connector_hazelcast_presence_test:
-  extends: .test_and_coverage
-  script:
-      - mvn $MAVEN_CLI_OPTS test -f connectors/hazelcast/hazelcast-presence
-
-connector_kafka_connector_test:
-  extends: .test_and_coverage
-  script:
-      - mvn $MAVEN_CLI_OPTS test -f connectors/kafka/kafka-connector
-
-connector_kafka_presence_test:
-  extends: .test_and_coverage
-  script:
-      - mvn $MAVEN_CLI_OPTS test -f connectors/kafka/kafka-presence
-
-connector_kafka_standalone_test:
-  extends: .test_and_coverage
-  script:
-      - mvn $MAVEN_CLI_OPTS test -f connectors/kafka/kafka-standalone
-
+# test all modules
 submodules_test:
   extends: .test_and_coverage
   script:
-      - mvn $MAVEN_CLI_OPTS test 
+      - mvn $MAVEN_CLI_OPTS test
 
 
 ############################
@@ -119,7 +73,7 @@ submodules_test:
 
 .publish:
   stage: deploy
-  dependencies: ['build']
+  dependencies: ['build', 'submodules_test']
   needs: ['build']
 
 snapshot:
@@ -130,7 +84,7 @@ snapshot:
 release:
   script:
     - echo "Publish release"
-    - mvn $MAVEN_CLI_OPTS deploy -s .gitlab_maven_settings.xml -DskipTests -Drevision=$CI_COMMIT_TAG -f 
+    - mvn $MAVEN_CLI_OPTS deploy -s .gitlab_maven_settings.xml -DskipTests -Drevision=$CI_COMMIT_TAG -f
   only:
     - tags
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 image: maven:3.6.1-jdk-8
 
 variables:
-    MAVEN_CLI_OPTS: "--show-version"
+    MAVEN_CLI_OPTS: "--show-version -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd@HH:mm:ss,SSS"
     MAVEN_OPTS: "-Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository -Djava.awt.headless=true"
 
 cache:
@@ -12,29 +12,38 @@ cache:
 
 include:
     - template: Code-Quality.gitlab-ci.yml
-  
- 
+
+
 stages:
     - build
     - test
     - package
     - deploy
-    
+
 build:
     stage: build
     script:
         - mvn $MAVEN_CLI_OPTS clean compile install -f system/platform-core
         - mvn $MAVEN_CLI_OPTS clean compile install -f system/rest-spring
+        - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/event-node
         - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/hazelcast/hazelcast-connector
+        - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/hazelcast/hazelcast-presence
         - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/kafka/kafka-connector
+        - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/kafka/kafka-presence
+        - mvn $MAVEN_CLI_OPTS clean compile install -f connectors/kafka/kafka-standalone
     cache:
         key: $CI_PIPELINE_IID
         policy: push # this is the only job that needs to publish to the cache, therefore it is overriding the policy
         paths:
             - $CI_PROJECT_DIR/.m2/repository
-            
-test_and_coverage:
+
+
+############################
+# TEST
+
+.test_and_coverage:
     stage: test
+    needs: ['build']
     script:
         - mvn $MAVEN_CLI_OPTS test -f system/platform-core
         - ls -la system/platform-core/target/surefire-reports
@@ -44,27 +53,78 @@ test_and_coverage:
     artifacts:
         reports:
             junit:
-                - system/platform-core/target/surefire-reports/TEST-*.xml
+                - /**/target/surefire-reports/TEST-*.xml
         paths:
             - jacoco
         expire_in: 30 days
 
- 
-javadoc: 
+platform_test:
+  extends: .test_and_coverage
+  script:
+      - mvn $MAVEN_CLI_OPTS test -f system/platform-core
+      - ls -la system/platform-core/target/surefire-reports
+      - cat system/platform-core/target/site/jacoco/index.html
+      - mv system/platform-core/target/site/jacoco jacoco
+
+rest_test:
+  extends: .test_and_coverage
+  script:
+      - mvn $MAVEN_CLI_OPTS test -f system/platform-core
+
+connector_eventnode_test:
+  extends: .test_and_coverage
+  script:
+      - mvn $MAVEN_CLI_OPTS test -f connectors/event-node
+
+connector_hazelcast_test:
+  extends: .test_and_coverage
+  script:
+      - mvn $MAVEN_CLI_OPTS test -f connectors/hazelcast/hazelcast-connector
+
+connector_hazelcast_presence_test:
+  extends: .test_and_coverage
+  script:
+      - mvn $MAVEN_CLI_OPTS test -f connectors/hazelcast/hazelcast-presence
+
+connector_kafka_connector_test:
+  extends: .test_and_coverage
+  script:
+      - mvn $MAVEN_CLI_OPTS test -f connectors/kafka/kafka-connector
+
+connector_kafka_presence_test:
+  extends: .test_and_coverage
+  script:
+      - mvn $MAVEN_CLI_OPTS test -f connectors/kafka/kafka-presence
+
+connector_kafka_standalone_test:
+  extends: .test_and_coverage
+  script:
+      - mvn $MAVEN_CLI_OPTS test -f connectors/kafka/kafka-standalone
+
+
+
+############################
+# JavaDoc
+
+javadoc:
     stage: package
-    script: 
+    dependencies:
+        - build
+    needs: ['build']
+    script:
         - mvn $MAVEN_CLI_OPTS javadoc:javadoc -f system/platform-core
         - mv system/platform-core/target/site/apidocs apidocs
     artifacts:
         paths:
             - apidocs
         expire_in: 30 days
-        
+
 pages:
     stage: deploy
     dependencies:
-        - test_and_coverage
+        - platform_test
         - javadoc
+    needs: ['platform_test', 'javadoc']
     script:
         - mkdir -p public/coverage public/docs
         - mv jacoco/* public/coverage
@@ -73,4 +133,3 @@ pages:
         paths:
         - public
         expire_in: 90 days
- 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,7 @@ release:
   extends: .publish
   script:
     - echo "Publish release"
-    - mvn $MAVEN_CLI_OPTS deploy -s .gitlab_maven_settings.xml -DskipTests -Drevision=$CI_COMMIT_TAG -f
+    - mvn $MAVEN_CLI_OPTS deploy -s .gitlab_maven_settings.xml -DskipTests -Drevision=$CI_COMMIT_TAG
   only:
     - tags
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,12 +108,12 @@ connector_kafka_standalone_test:
 snapshot:
   script:
     - echo "Publish snapshot"
-    - mvn $MAVEN_CLI_OPTS deploy -s .gitlab_maven_settings.xml -DskipTests -f system/platform-core
+    - mvn $MAVEN_CLI_OPTS deploy -s .gitlab_maven_settings.xml -DskipTests
 
 release:
   script:
     - echo "Publish release"
-    - mvn $MAVEN_CLI_OPTS deploy -s .gitlab_maven_settings.xml -DskipTests -Drevision=$CI_COMMIT_TAG -f system/platform-core
+    - mvn $MAVEN_CLI_OPTS deploy -s .gitlab_maven_settings.xml -DskipTests -Drevision=$CI_COMMIT_TAG -f 
   only:
     - tags
 

--- a/.gitlab_maven_settings.xml
+++ b/.gitlab_maven_settings.xml
@@ -1,0 +1,18 @@
+<!-- Reference: https://docs.gitlab.com/ee/user/packages/maven_repository/index.html#create-maven-packages-with-gitlab-cicd-by-using-maven -->
+
+<settings xmlns="http://maven.apache.org/SETTINGS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd">
+  <servers>
+    <server>
+      <id>gitlab-maven</id>
+      <configuration>
+        <httpHeaders>
+          <property>
+            <name>Job-Token</name>
+            <value>${env.CI_JOB_TOKEN}</value>
+          </property>
+        </httpHeaders>
+      </configuration>
+    </server>
+  </servers>
+</settings>

--- a/connectors/event-node/pom.xml
+++ b/connectors/event-node/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>event-node</artifactId>
 
     <packaging>jar</packaging>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <name>Event Node - Platform-in-a-box</name>
 
     <parent>
@@ -18,6 +18,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -39,7 +40,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/connectors/event-node/pom.xml
+++ b/connectors/event-node/pom.xml
@@ -11,9 +11,9 @@
     <name>Event Node - Platform-in-a-box</name>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/connectors/hazelcast/hazelcast-connector/pom.xml
+++ b/connectors/hazelcast/hazelcast-connector/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>hazelcast-connector</artifactId>
 
     <packaging>jar</packaging>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <name>Cloud connector for Hazelcast cluster</name>
 
     <parent>
@@ -18,6 +18,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -39,7 +40,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.hazelcast/hazelcast-client -->

--- a/connectors/hazelcast/hazelcast-connector/pom.xml
+++ b/connectors/hazelcast/hazelcast-connector/pom.xml
@@ -11,9 +11,9 @@
     <name>Cloud connector for Hazelcast cluster</name>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/connectors/hazelcast/hazelcast-presence/pom.xml
+++ b/connectors/hazelcast/hazelcast-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>hazelcast-presence</artifactId>
     <packaging>jar</packaging>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <name>hazelcast-presence-monitor</name>
 
     <parent>
@@ -16,6 +16,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -37,13 +38,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>hazelcast-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/connectors/hazelcast/hazelcast-presence/pom.xml
+++ b/connectors/hazelcast/hazelcast-presence/pom.xml
@@ -9,9 +9,9 @@
     <name>hazelcast-presence-monitor</name>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/connectors/kafka/kafka-connector/pom.xml
+++ b/connectors/kafka/kafka-connector/pom.xml
@@ -11,9 +11,9 @@
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/connectors/kafka/kafka-connector/pom.xml
+++ b/connectors/kafka/kafka-connector/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>kafka-connector</artifactId>
 
     <packaging>jar</packaging>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -18,6 +18,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -39,7 +40,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/connectors/kafka/kafka-presence/pom.xml
+++ b/connectors/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <name>kafka-presence-monitor</name>
 
     <parent>
@@ -16,6 +16,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -37,13 +38,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/connectors/kafka/kafka-presence/pom.xml
+++ b/connectors/kafka/kafka-presence/pom.xml
@@ -9,9 +9,9 @@
     <name>kafka-presence-monitor</name>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/connectors/kafka/kafka-standalone/pom.xml
+++ b/connectors/kafka/kafka-standalone/pom.xml
@@ -11,9 +11,9 @@
     <name>Standalone kafka system for development</name>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/connectors/kafka/kafka-standalone/pom.xml
+++ b/connectors/kafka/kafka-standalone/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>kafka-standalone</artifactId>
 
     <packaging>jar</packaging>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <name>Standalone kafka system for development</name>
 
     <parent>
@@ -18,6 +18,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -39,7 +40,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.zookeeper/zookeeper -->

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>lambda-example</artifactId>
 
     <packaging>jar</packaging>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <name>Example for simple microservices executable</name>
 
     <parent>
@@ -18,6 +18,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -39,25 +40,25 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- select your cloud connector (hazelcast-connector or kafka-connector).
              Not necessary if testing using Event Node.
 
              For convenience, both Kafka and Hazelcast connectors are added so
-             you can select the connector from command line without recompiling from source. 
+             you can select the connector from command line without recompiling from source.
 
 	         For production, please select only one cloud connector to reduce memory footprint. -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>hazelcast-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -11,9 +11,9 @@
     <name>Example for simple microservices executable</name>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/rest-example/pom.xml
+++ b/examples/rest-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-example</artifactId>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
     <name>REST example application</name>
 
@@ -17,6 +17,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -38,25 +39,25 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- select your cloud connector (hazelcast-connector or kafka-connector).
              Not necessary if testing using Event Node.
 
              For convenience, both Kafka and Hazelcast connectors are added so
-             you can select the connector from command line without recompiling from source. 
+             you can select the connector from command line without recompiling from source.
 
 	         For production, please select only one cloud connector to reduce memory footprint. -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>hazelcast-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
         <!-- Tomcat servlet API and implementation are fetched from the rest-spring library.
              For WAR deployment, add tomcat dependency with "provided" scope here -->

--- a/examples/rest-example/pom.xml
+++ b/examples/rest-example/pom.xml
@@ -10,9 +10,9 @@
     <name>REST example application</name>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -11,9 +11,9 @@
     <name>API playground using OpenAPI</name>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>api-playground</artifactId>
 
     <packaging>jar</packaging>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -18,6 +18,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -39,7 +40,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/extensions/distributed-tracer/pom.xml
+++ b/extensions/distributed-tracer/pom.xml
@@ -11,9 +11,9 @@
     <name>Distributed trace processor example</name>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/extensions/distributed-tracer/pom.xml
+++ b/extensions/distributed-tracer/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>distributed-tracer</artifactId>
 
     <packaging>jar</packaging>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <name>Distributed trace processor example</name>
 
     <parent>
@@ -18,6 +18,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -39,7 +40,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- select your cloud connector (hazelcast-connector or kafka-connector).
@@ -52,12 +53,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>hazelcast-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/extensions/rest-automation-app/pom.xml
+++ b/extensions/rest-automation-app/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>rest-automation-app</artifactId>
 
     <packaging>jar</packaging>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <name>REST automation application</name>
 
     <parent>
@@ -18,6 +18,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -39,13 +40,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-automation</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- select your cloud connector (hazelcast-connector or kafka-connector).
@@ -58,12 +59,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>hazelcast-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/extensions/rest-automation-app/pom.xml
+++ b/extensions/rest-automation-app/pom.xml
@@ -11,9 +11,9 @@
     <name>REST automation application</name>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/extensions/rest-automation-lib/pom.xml
+++ b/extensions/rest-automation-lib/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>rest-automation</artifactId>
 
     <packaging>jar</packaging>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <name>REST automation library</name>
 
     <parent>
@@ -18,6 +18,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -40,7 +41,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
@@ -54,13 +55,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>hazelcast-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/rest-automation-lib/pom.xml
+++ b/extensions/rest-automation-lib/pom.xml
@@ -11,9 +11,9 @@
     <name>REST automation library</name>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/extensions/simple-scheduler/pom.xml
+++ b/extensions/simple-scheduler/pom.xml
@@ -11,9 +11,9 @@
     <name>Simple Scheduler</name>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -29,10 +29,6 @@
             <id>central</id>
             <url>https://repo1.maven.org/maven2/</url>
         </repository>
-<!--        <repository>-->
-<!--            <id>your-repo</id>-->
-<!--            <url>https://your_repo_here/artifactory/libs-release</url>-->
-<!--        </repository>-->
     </repositories>
 
     <dependencies>

--- a/extensions/simple-scheduler/pom.xml
+++ b/extensions/simple-scheduler/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>simple-scheduler</artifactId>
 
     <packaging>jar</packaging>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <name>Simple Scheduler</name>
 
     <parent>
@@ -18,6 +18,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -39,7 +40,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- select your cloud connector (hazelcast-connector or kafka-connector).
@@ -52,12 +53,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>hazelcast-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.quartz-scheduler/quartz -->

--- a/extensions/websocket-notification/pom.xml
+++ b/extensions/websocket-notification/pom.xml
@@ -11,9 +11,9 @@
     <name>WebSocket notification example</name>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/extensions/websocket-notification/pom.xml
+++ b/extensions/websocket-notification/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>websocket-notification</artifactId>
 
     <packaging>jar</packaging>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <name>WebSocket notification example</name>
 
     <parent>
@@ -18,6 +18,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -39,7 +40,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- select your cloud connector (hazelcast-connector or kafka-connector).
@@ -52,12 +53,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>hazelcast-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/language-packs/language-connector/pom.xml
+++ b/language-packs/language-connector/pom.xml
@@ -33,7 +33,22 @@
         <!--            <id>your-repo</id>-->
         <!--            <url>https://your_repo_here/artifactory/libs-release</url>-->
         <!--        </repository>-->
+        <repository>
+          <id>gitlab-maven</id>
+          <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+        </repository>
     </repositories>
+
+    <distributionManagement>
+      <repository>
+        <id>gitlab-maven</id>
+        <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+      </repository>
+      <snapshotRepository>
+        <id>gitlab-maven</id>
+        <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+      </snapshotRepository>
+    </distributionManagement>
 
     <dependencies>
 

--- a/language-packs/language-connector/pom.xml
+++ b/language-packs/language-connector/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>language-connector</artifactId>
 
     <packaging>jar</packaging>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <name>Language Connector for Python and others</name>
 
     <parent>
@@ -18,6 +18,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -39,25 +40,25 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- select your cloud connector (hazelcast-connector or kafka-connector).
              Not necessary if testing using Event Node.
 
              For convenience, both Kafka and Hazelcast connectors are added so
-             you can select the connector from command line without recompiling from source. 
+             you can select the connector from command line without recompiling from source.
 
 	         For production, please select only one cloud connector to reduce memory footprint. -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>hazelcast-connector</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/pom.xml
+++ b/pom.xml
@@ -29,4 +29,15 @@
         <module>examples/lambda-example</module>
         <module>examples/rest-example</module>
     </modules>
+
+    <distributionManagement>
+      <repository>
+        <id>gitlab-maven</id>
+        <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+      </repository>
+      <snapshotRepository>
+        <id>gitlab-maven</id>
+        <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+      </snapshotRepository>
+    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,26 +29,4 @@
         <module>examples/lambda-example</module>
         <module>examples/rest-example</module>
     </modules>
-
-    <repositories>
-        <repository>
-            <id>central</id>
-            <url>https://repo1.maven.org/maven2/</url>
-        </repository>
-        <repository>
-          <id>gitlab-maven</id>
-          <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
-        </repository>
-    </repositories>
-
-    <distributionManagement>
-      <repository>
-        <id>gitlab-maven</id>
-        <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
-      </repository>
-      <snapshotRepository>
-        <id>gitlab-maven</id>
-        <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
-      </snapshotRepository>
-    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,16 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0</version>
+
+    <!-- Dynamic Versioning  -->
+    <!-- Using ${revision} allows the version number to be overriden
+    by using the `-Drevision=...` flag.
+    (e.g. mvn package -DskipTests -Drevision=1.12.66 ) -->
+    <version>${revision}</version>
+    <properties>
+        <revision>1.12-SNAPSHOT</revision>
+    </properties>
+
     <name>Parent Mercury</name>
     <modules>
         <!-- Libraries -->
@@ -30,6 +39,7 @@
         <module>examples/rest-example</module>
     </modules>
 
+    <!-- Configure releases to GitLab Maven Registry -->
     <distributionManagement>
       <repository>
         <id>gitlab-maven</id>

--- a/pom.xml
+++ b/pom.xml
@@ -29,5 +29,26 @@
         <module>examples/lambda-example</module>
         <module>examples/rest-example</module>
     </modules>
-</project>
 
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+        <repository>
+          <id>gitlab-maven</id>
+          <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+      <repository>
+        <id>gitlab-maven</id>
+        <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+      </repository>
+      <snapshotRepository>
+        <id>gitlab-maven</id>
+        <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+      </snapshotRepository>
+    </distributionManagement>
+</project>

--- a/system/parent/pom.xml
+++ b/system/parent/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.platformlambda</groupId>
+    <artifactId>mercury-parent</artifactId>
+    <version>${revision}</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <revision>1.12-SNAPSHOT</revision>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.3.3.RELEASE</version>
+        <relativePath/>
+    </parent>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+        <repository>
+          <id>gitlab-maven</id>
+          <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+      <repository>
+        <id>gitlab-maven</id>
+        <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+      </repository>
+      <snapshotRepository>
+        <id>gitlab-maven</id>
+        <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+      </snapshotRepository>
+    </distributionManagement>
+
+</project>

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -16,9 +16,9 @@
 
     <!-- Use Spring Boot as a parent to fetch the correct Spring Framework modules -->
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -30,7 +30,22 @@
         <!--            <id>your-repo</id>-->
         <!--            <url>https://your_repo_here/artifactory/libs-release</url>-->
         <!--        </repository>-->
+        <repository>
+          <id>gitlab-maven</id>
+          <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+        </repository>
     </repositories>
+
+    <distributionManagement>
+      <repository>
+        <id>gitlab-maven</id>
+        <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+      </repository>
+      <snapshotRepository>
+        <id>gitlab-maven</id>
+        <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+      </snapshotRepository>
+    </distributionManagement>
 
     <dependencies>
 

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -7,9 +7,10 @@
     <artifactId>platform-core</artifactId>
 
     <packaging>jar</packaging>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <name>Mercury core library</name>
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/system/rest-spring/pom.xml
+++ b/system/rest-spring/pom.xml
@@ -31,10 +31,6 @@
             <id>central</id>
             <url>https://repo1.maven.org/maven2/</url>
         </repository>
-        <!--        <repository>-->
-        <!--            <id>your-repo</id>-->
-        <!--            <url>https://your_repo_here/artifactory/libs-release</url>-->
-        <!--        </repository>-->
     </repositories>
 
     <dependencies>

--- a/system/rest-spring/pom.xml
+++ b/system/rest-spring/pom.xml
@@ -13,9 +13,9 @@
     <description>Preconfigured spring boot with proper serializers, exception handlers and loaders</description>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>mercury-parent</artifactId>
+        <version>1.12-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/system/rest-spring/pom.xml
+++ b/system/rest-spring/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring</artifactId>
-    <version>1.12.65</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <name>rest-spring</name>
@@ -20,6 +20,7 @@
     </parent>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hazelcast.version>4.0.1</hazelcast.version>
         <java.version>1.8</java.version>
@@ -103,7 +104,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>1.12.65</version>
+            <version>1.12-SNAPSHOT</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.jboss.resteasy/resteasy-jaxrs -->
         <!-- DO NOT import resteasy-servlet-initializer because RestLoader will do the initialization -->


### PR DESCRIPTION
Hey @ericcwlaw 


## CI Friendly Versioning, based on git tags

I'm proposing to change:

```xml
<version>1.2.3</version>
```

to 

```xml 
<version>${revision}</version>
<properties>
   <revision>1.2-SNAPSHOT</revision>
   ...
</properties>
```

This will change the behaviour of the software to build jar files as `x.x-SNAPSHOT` by default, but when you tag the software (or use `mvn package -Drevision=1.2.3`), then it will create a release. It has the advantage that the git tag and a specific version are tied to each other and you clearly know what are "releases" and what are snapshots.

So you won't actually have to do any manual releases, since the CI pipeline, [in my example GitLab](https://gitlab.com/skofgar/mercury/-/blob/feature/dynamic-versioning/.gitlab-ci.yml#L85), can do these releases for you.

This is based on Maven's ["CI Friendly Versioning"](https://maven.apache.org/maven-ci-friendly.html)


## Releasing Maven Artifacts to GitLab Registry

Furthermore I updated the GitLab CI pipeline accompanying these changes and releasing the resulting JAR's into [the project's GitLab Maven Registry](https://gitlab.com/skofgar/mercury/-/packages) (in my fork). In the future a release to maven-central is desired, but it is more involved. To not make this pull request/review more complex it is not part of this. 


## Parent Pom

Additionally I added a parent-pom under `system/parent/` to drive deployment configuration.


## Next steps

The suggested changes could potentially break some of your builds, depending how you include the jars (version numbers etc). Hence we should discuss and verify that these changes are desired and move the project in the direction you want it to go. 


