### PR TITLE
using double for floating point numbers

### DIFF
--- a/system/platform-core/src/main/java/org/platformlambda/core/serializers/SimpleMapper.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/serializers/SimpleMapper.java
@@ -19,6 +19,7 @@
 package org.platformlambda.core.serializers;
 
 import com.google.gson.*;
+import org.msgpack.core.annotations.VisibleForTesting;
 import org.platformlambda.core.util.AppConfigReader;
 import org.platformlambda.core.util.Utility;
 import org.slf4j.Logger;
@@ -309,19 +310,15 @@ public class SimpleMapper {
         return result;
     }
 
-    private Object typedNumber(JsonPrimitive p) {
+    @VisibleForTesting
+    Object typedNumber(JsonPrimitive p) {
         /*
          * For conversion to map or list, type information is lost for numbers.
          * This is a best effort to keep the numbers as int, long, float or double.
          */
         String number = p.getAsString();
         if (number.contains(".")) {
-            double n = p.getAsDouble();
-            if (n < Float.MIN_VALUE || n > Float.MAX_VALUE) {
-                return n;
-            } else {
-                return (float) n;
-            }
+            return p.getAsDouble();
         } else {
             long n = p.getAsLong();
             if (n < Integer.MIN_VALUE || n > Integer.MAX_VALUE) {

--- a/system/platform-core/src/main/java/org/platformlambda/core/serializers/SimpleMapper.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/serializers/SimpleMapper.java
@@ -311,7 +311,7 @@ public class SimpleMapper {
     }
 
     @VisibleForTesting
-    Object typedNumber(JsonPrimitive p) {
+    public Object typedNumber(JsonPrimitive p) {
         /*
          * For conversion to map or list, type information is lost for numbers.
          * This is a best effort to keep the numbers as int, long, float or double.

--- a/system/platform-core/src/test/java/org/platformlambda/core/util/GsonTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/util/GsonTest.java
@@ -42,9 +42,9 @@ public class GsonTest {
         // small long number will be converted to integer
         Assert.assertEquals(Integer.class, m.get("small_long").getClass());
         Assert.assertEquals(Long.class, m.get("long_number").getClass());
-        Assert.assertEquals(Float.class, m.get("float_number").getClass());
+        Assert.assertEquals(Double.class, m.get("float_number").getClass());
         // small double number will be converted to float
-        Assert.assertEquals(Float.class, m.get("small_double").getClass());
+        Assert.assertEquals(Double.class, m.get("small_double").getClass());
         // small double number will be converted to float
         Assert.assertEquals(Double.class, m.get("double_number").getClass());
         Assert.assertEquals(obj.name, m.get("name"));

--- a/system/platform-core/src/test/java/org/platformlambda/core/util/SimpleMapperTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/util/SimpleMapperTest.java
@@ -37,16 +37,16 @@ public class SimpleMapperTest {
 
     @Test
     public void typedNumber_shouldMapDouble() {
-        final JsonPrimitive number = new JsonPrimitive("99999999.123456789");
+        final JsonPrimitive number = new JsonPrimitive("1.12345678");
         Object result = SimpleMapper.getInstance().typedNumber(number);
-        assertThat(result, is(99999999.123456789));
+        assertThat(result, is(1.12345678d));
     }
 
     @Test
     public void typedNumber_shouldMapFloat() {
-        final JsonPrimitive number = new JsonPrimitive("1.1234567");
+        final JsonPrimitive number = new JsonPrimitive("1.12");
         Object result = SimpleMapper.getInstance().typedNumber(number);
-        assertThat(result, is(1.1234567));
+        assertThat(result, is(1.12d));
     }
 
     @Test

--- a/system/platform-core/src/test/java/org/platformlambda/core/util/SimpleMapperTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/util/SimpleMapperTest.java
@@ -18,6 +18,7 @@
 
 package org.platformlambda.core.util;
 
+import com.google.gson.JsonPrimitive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.platformlambda.core.serializers.SimpleMapper;
@@ -29,7 +30,24 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 public class SimpleMapperTest {
+
+    @Test
+    public void typedNumber_shouldMapDouble() {
+        final JsonPrimitive number = new JsonPrimitive("99999999.123456789");
+        Object result = SimpleMapper.getInstance().typedNumber(number);
+        assertThat(result, is(99999999.123456789));
+    }
+
+    @Test
+    public void typedNumber_shouldMapFloat() {
+        final JsonPrimitive number = new JsonPrimitive("1.1234567");
+        Object result = SimpleMapper.getInstance().typedNumber(number);
+        assertThat(result, is(1.1234567));
+    }
 
     @Test
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Comparison of max/min is not enough to determine if a number is a float or double, because the difference is in the precision of decimals. 

**PROBLEM**: The current behavior is casting numbers to float which causes loss of precision. As in the following example using the rest-automation project:
```
curl -X POST \
  http://localhost:8100/api/hello/world \
  -H 'authorization: Basic VFM4MTg5Ok1uZXJfKmVtODhrdw=' \
  -H 'cache-control: no-cache' \
  -H 'content-type: application/json' \
  -H 'postman-token: acc2ba83-886e-965f-e58f-e4eef1c48306' \
  -H 'x-ibm-client-id: d16742ce-6786-4b40-8e7f-39867e729b1d' \
  -H 'x-session-id: c096056d0d714919b80d67b15feaed81' \
  -d ' {
      "code": "double-simple-precision",
      "p_double_value": 121212.123456789,
      "string_value": "1212112.123456789",
      "p_float_value": 1212112.123456789,
      "big_decimal_value": 121212.123456789
    }'
```

response with loss of precision:
```
{
    "headers": {},
    "instance": 4,
    "origin": "2021010299485a0d2073437d9451568535fad019",
    "body": {
        "headers": {
            "sec-fetch-mode": "cors",
            "content-length": "226",
            "x-session-id": "c096056d0d714919b80d67b15feaed81",
            "sec-fetch-site": "none",
            "accept-language": "en-US,en;q=0.9,de;q=0.8,es;q=0.7,ja;q=0.6,pt;q=0.5,fr;q=0.4",
            "postman-token": "c468ddb2-c2fc-0612-c452-f6ec05ace8fd",
            "origin": "chrome-extension://fhbjgbiflinjbdggehcddcbncdddomop",
            "accept": "*/*",
            "x-ibm-client-id": "d16742ce-6786-4b40-8e7f-39867e729b1d",
            "authorization": "Basic VFM4MTg5Ok1uZXJfKmVtODhrdw=",
            "sec-ch-ua": "\"Google Chrome\";v=\"87\", \" Not;A Brand\";v=\"99\", \"Chromium\";v=\"87\"",
            "sec-ch-ua-mobile": "?0",
            "content-type": "application/json",
            "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
            "sec-fetch-dest": "empty"
        },
        "method": "POST",
        "ip": "0:0:0:0:0:0:0:1",
        "https": false,
        "body": {
            "big_decimal_value": 121212.125,
            "code": "double-simple-precision",
            "string_value": "1212112.123456789",
            "p_double_value": 121212.125,
            "p_float_value": 1212112.1
        },
        "url": "/api/hello/world",
        "timeout": 10
    }
}
```

**SOLUTION**
The proposed fix works by always returning doubles:
```
{
    "headers": {},
    "instance": 5,
    "origin": "2021010299485a0d2073437d9451568535fad019",
    "body": {
        "headers": {
            "sec-fetch-mode": "cors",
            "content-length": "226",
            "x-session-id": "c096056d0d714919b80d67b15feaed81",
            "sec-fetch-site": "none",
            "accept-language": "en-US,en;q=0.9,de;q=0.8,es;q=0.7,ja;q=0.6,pt;q=0.5,fr;q=0.4",
            "postman-token": "0fd88e89-ded0-29fd-8f9a-0451acc9c041",
            "origin": "chrome-extension://fhbjgbiflinjbdggehcddcbncdddomop",
            "accept": "*/*",
            "x-ibm-client-id": "d16742ce-6786-4b40-8e7f-39867e729b1d",
            "authorization": "Basic VFM4MTg5Ok1uZXJfKmVtODhrdw=",
            "sec-ch-ua": "\"Google Chrome\";v=\"87\", \" Not;A Brand\";v=\"99\", \"Chromium\";v=\"87\"",
            "sec-ch-ua-mobile": "?0",
            "content-type": "application/json",
            "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
            "sec-fetch-dest": "empty"
        },
        "method": "POST",
        "ip": "0:0:0:0:0:0:0:1",
        "https": false,
        "body": {
            "big_decimal_value": 121212.123456789,
            "code": "double-simple-precision",
            "string_value": "1212112.123456789",
            "p_double_value": 121212.123456789,
            "p_float_value": 1212112.123456789
        },
        "url": "/api/hello/world",
        "timeout": 10
    }
} 
```