### PR TITLE
Reducing the chance of flaky test failure

### DIFF
--- a/system/platform-core/src/test/java/org/platformlambda/core/ObjectStreamTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/ObjectStreamTest.java
@@ -121,7 +121,7 @@ public class ObjectStreamTest {
         // AsyncObjectStreamReader is non-blocking. Therefore, we must use a blocking queue in a unit test.
         log.info("Beginning of Stream");
         fetchNextBlock(in, 0, bench);
-        Integer count = bench.poll(8, TimeUnit.SECONDS);
+        Integer count = bench.poll(10, TimeUnit.SECONDS);
         Assert.assertNotNull(count);
         Assert.assertEquals(CYCLES, count.intValue());
         Assert.assertTrue(in.isStreamEnd());


### PR DESCRIPTION
**Description:**
This test is flakily fails. I run this test many times and it makes assertion fails. The failure message is as follows.

**Failure:**
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 9.242 s <<< FAILURE! - in org.platformlambda.core.ObjectStreamTest
[ERROR] asyncReadWrite(org.platformlambda.core.ObjectStreamTest)  Time elapsed: 9.21 s  <<< FAILURE!
java.lang.AssertionError
	at org.platformlambda.core.ObjectStreamTest.asyncReadWrite(ObjectStreamTest.java:125)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   ObjectStreamTest.asyncReadWrite:125
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

**Solution:**
This test is fixed with this solution.