### PR TITLE
Flaky Test Fix

### DIFF
--- a/system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ConcurrentMap;
 public class EventEmitter {
     private static final Logger log = LoggerFactory.getLogger(EventEmitter.class);
 
+    private static volatile boolean hasExecuted;
     public static final int ONE_MILLISECOND = 1000000;
     public static final String CLOUD_CONNECTOR = "cloud.connector";
     public static final String CLOUD_SERVICES = "cloud.services";
@@ -83,6 +84,7 @@ public class EventEmitter {
         if (multicast != null) {
             platform.getEventExecutor().submit(() -> {
                 log.info("Loading multicast config from {}", multicast);
+                hasExecuted=true;
                 ConfigReader reader = new ConfigReader();
                 try {
                     reader.load(multicast);
@@ -109,6 +111,14 @@ public class EventEmitter {
         if (config.getProperty(ROUTE_SUBSTITUTION_FEATURE, "false").equals("true")) {
             platform.getEventExecutor().submit(this::loadRouteSubstitution);
         }
+    }
+
+    public static void reset() { // This method is only for testing (test-method: routingTest)
+        hasExecuted = false;
+    }
+
+    public static boolean getExecutedStatus() { // This method is only for testing (test-method: routingTest)
+        return hasExecuted;
     }
 
     public static EventEmitter getInstance() {

--- a/system/platform-core/src/test/java/org/platformlambda/core/MulticastTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/MulticastTest.java
@@ -61,7 +61,7 @@ public class MulticastTest {
         };
         Platform platform = Platform.getInstance();
         final BlockingQueue<Boolean> bench = new ArrayBlockingQueue<>(1);
-        while(!EventEmitter.getExecutedStatus()) {
+        while (!EventEmitter.getExecutedStatus()) {
             Thread.yield();
         }
         platform.waitForProvider("v1.hello.world", 5).onSuccess(bench::offer);

--- a/system/platform-core/src/test/java/org/platformlambda/core/MulticastTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/MulticastTest.java
@@ -44,6 +44,7 @@ public class MulticastTest {
 
     @Test
     public void routingTest() throws IOException, InterruptedException {
+        EventEmitter.reset();
         final EventEmitter po = EventEmitter.getInstance();
         final String[] targets = {"v1.hello.service.1", "v1.hello.service.2"};
         final String TEXT = "ok";
@@ -60,6 +61,9 @@ public class MulticastTest {
         };
         Platform platform = Platform.getInstance();
         final BlockingQueue<Boolean> bench = new ArrayBlockingQueue<>(1);
+        while(!EventEmitter.getExecutedStatus()) {
+            Thread.yield();
+        }
         platform.waitForProvider("v1.hello.world", 5).onSuccess(bench::offer);
         boolean available = Boolean.TRUE.equals(bench.poll(5, TimeUnit.SECONDS));
         Assert.assertTrue(available);


### PR DESCRIPTION
### What changes were proposed in this pull request?

I observe that a test (org.platformlambda.core.MulticastTest.routingTest) is a flaky test than can fail due to the slow execution of system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java#L84. When EventEmitter.java#84 is not executed quick enough, the test method (routingTest) tries to execute the assertion given at Line 65, but it then fails. While it may be possible to fix this flaky test by increasing the waiting time in the test-code, but I believe such a fix might be unstable in a CI environment or when run on different machines, given the dependency on some constant wait time. Hence, I suggest a new way to fix the test by adding some synchronization for the test execution only. I at first identify the code location that needs to be executed before the test should proceed to check assertions (system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java#L84), so I introduce one variable in this test class that is only there to provide some synchronization. Basically, until these statements are executed, I force the thread that the test runs to wait before it proceeds to the assertions.


### Why are the changes needed?

[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 4.818 s <<< FAILURE! - in org.platformlambda.core.MulticastTest
[ERROR] org.platformlambda.core.MulticastTest.routingTest  Time elapsed: 4.015 s  <<< FAILURE!
java.lang.AssertionError
        at org.junit.Assert.fail(Assert.java:87)
        at org.junit.Assert.assertTrue(Assert.java:42)
        at org.junit.Assert.assertTrue(Assert.java:53)
        at org.platformlambda.core.MulticastTest.routingTest(MulticastTest.java:65)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) 
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
        at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
        at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
        at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:316)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:240)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:214)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:155)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
        at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
        at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   MulticastTest.routingTest:65
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

### How was this patch tested?
I run this test more than 1000 times and the test always passes.
