### PR TITLE
Switch order of literals to prevent NullPointerException

### DIFF
--- a/benchmark/benchmark-client/src/main/java/com/accenture/services/BenchmarkService.java
+++ b/benchmark/benchmark-client/src/main/java/com/accenture/services/BenchmarkService.java
@@ -203,7 +203,7 @@ public class BenchmarkService implements LambdaFunction {
                     po.send(sender, util.getLocalTimestamp()+ WARNING+e.getMessage());
                     return false;
                 }
-                if (!(url.getPath().isEmpty() || url.getPath().equals("/api/event"))) {
+                if (!(url.getPath().isEmpty() || "/api/event".equals(url.getPath()))) {
                     po.send(sender, util.getLocalTimestamp()+
                             " WARN: Invalid target. It should be http or https with host and port");
                     return false;
@@ -293,8 +293,8 @@ public class BenchmarkService implements LambdaFunction {
     private BenchmarkRequest parseCommand(List<String> parts) {
         Utility util = Utility.getInstance();
         if (parts.size() == 4 &&
-                ((parts.get(0).equals(ASYNC) || parts.get(0).equals(ECHO) || parts.get(0).equals(HTTP)) &&
-                    parts.get(2).equals(PAYLOAD) &&
+                ((ASYNC.equals(parts.get(0)) || ECHO.equals(parts.get(0)) || HTTP.equals(parts.get(0))) &&
+                    PAYLOAD.equals(parts.get(2)) &&
                     util.isDigits(parts.get(1)) && util.isDigits(parts.get(3)))) {
                 int count = util.str2int(parts.get(1));
                 int size = util.str2int(parts.get(3));

--- a/connectors/core/cloud-connector/src/main/java/org/platformlambda/cloud/services/ServiceQuery.java
+++ b/connectors/core/cloud-connector/src/main/java/org/platformlambda/cloud/services/ServiceQuery.java
@@ -82,7 +82,7 @@ public class ServiceQuery implements LambdaFunction {
 
         } else if (FIND.equals(type) && headers.containsKey(ROUTE)) {
             String route = headers.get(ROUTE);
-            if (route.equals("*")) {
+            if ("*".equals(route)) {
                 if (input instanceof List) {
                     return exists((List<String>) input);
                 } else {

--- a/connectors/core/service-monitor/src/main/java/org/platformlambda/services/AdditionalInfo.java
+++ b/connectors/core/service-monitor/src/main/java/org/platformlambda/services/AdditionalInfo.java
@@ -187,7 +187,7 @@ public class AdditionalInfo implements LambdaFunction {
     private Map<String, Object> filterInfo(Map<String, Object> info) {
         Map<String, Object> result = new HashMap<>();
         for (String key : info.keySet()) {
-            if (!key.equals(ID)) {
+            if (!ID.equals(key)) {
                 result.put(key, info.get(key));
             }
         }

--- a/connectors/core/service-monitor/src/main/java/org/platformlambda/services/TopicController.java
+++ b/connectors/core/service-monitor/src/main/java/org/platformlambda/services/TopicController.java
@@ -258,7 +258,7 @@ public class TopicController implements LambdaFunction {
     private String nextTopic(String appOrigin) throws IOException {
         for (String t: allTopics) {
             String value = topicStore.get(t);
-            if (value.equals(AVAILABLE)) {
+            if (AVAILABLE.equals(value)) {
                 topicStore.put(t, appOrigin);
                 return t;
             }

--- a/connectors/core/service-monitor/src/main/java/org/platformlambda/ws/MonitorService.java
+++ b/connectors/core/service-monitor/src/main/java/org/platformlambda/ws/MonitorService.java
@@ -302,7 +302,7 @@ public class MonitorService implements LambdaFunction {
     private void updateInfo(Map<String, Object> info, Map<String, String> headers) {
         Utility util = Utility.getInstance();
         for (String key : headers.keySet()) {
-            if (!key.equals(ID) && !key.equals(MONITOR)) {
+            if (!ID.equals(key) && !MONITOR.equals(key)) {
                 // normalize numbers
                 String value = headers.get(key);
                 if (util.isNumeric(value)) {

--- a/examples/lambda-example/src/main/java/org/platformlambda/services/HelloGeneric.java
+++ b/examples/lambda-example/src/main/java/org/platformlambda/services/HelloGeneric.java
@@ -56,7 +56,7 @@ public class HelloGeneric implements TypedLambdaFunction<AsyncHttpRequest, Objec
         log.info("Got session information {}", input.getSessionInfo());
         // simple validation
         String id = input.getPathParameter("id");
-        if (id.equals("1")) {
+        if ("1".equals(id)) {
             // To set status, key-values or parametric types, we can use EventEnvelope as a result wrapper
             EventEnvelope result = new EventEnvelope();
             ObjectWithGenericType<SamplePoJo> genericObject = new ObjectWithGenericType<>();

--- a/examples/lambda-example/src/main/java/org/platformlambda/services/HelloPoJo.java
+++ b/examples/lambda-example/src/main/java/org/platformlambda/services/HelloPoJo.java
@@ -48,7 +48,7 @@ public class HelloPoJo implements LambdaFunction {
         if (id == null) {
             throw new IllegalArgumentException("Missing parameter 'id'");
         }
-        if (id.equals("1")) {
+        if ("1".equals(id)) {
             // return some place-holder values to demonstrate the PoJo can be transported over the network
             SamplePoJo mock = new SamplePoJo(1, "Simple PoJo class", "100 World Blvd, Planet Earth");
             // set current timestamp to indicate that the object is a new one

--- a/system/platform-core/src/main/java/org/platformlambda/automation/config/RoutingEntry.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/config/RoutingEntry.java
@@ -173,7 +173,7 @@ public class RoutingEntry {
             if (configuredItem.startsWith("{") && configuredItem.endsWith("}")) {
                 continue;
             }
-            if (configuredItem.equals("*")) {
+            if ("*".equals(configuredItem)) {
                 continue;
             }
             // case-insensitive comparison using lowercase
@@ -478,7 +478,7 @@ public class RoutingEntry {
                     String key = m+":"+nUrl;
                     routes.put(key, info);
                     // OPTIONS method is not traced
-                    if (m.equals(OPTIONS_METHOD)) {
+                    if (OPTIONS_METHOD.equals(m)) {
                         log.info("{} {} -> {}, timeout={}s", m, nUrl, info.services, info.timeoutSeconds);
                     } else if (info.defaultAuthService != null) {
                         log.info("{} {} -> {} -> {}, timeout={}s, tracing={}",
@@ -580,7 +580,7 @@ public class RoutingEntry {
     }
 
     private boolean validWildcard(String wildcard) {
-        if (wildcard.equals("*")) {
+        if ("*".equals(wildcard)) {
             return true;
         }
         if (!wildcard.endsWith("*")) {

--- a/system/platform-core/src/main/java/org/platformlambda/automation/http/HttpRequestHandler.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/http/HttpRequestHandler.java
@@ -237,7 +237,7 @@ public class HttpRequestHandler implements Handler<HttpServerRequest> {
             }
             event.setTo(EventEmitter.ACTUATOR_SERVICES+"@"+origin);
         }
-        String when = parts.get(1).equals(NOW) ? NOW : LATER;
+        String when = NOW.equals(parts.get(1)) ? NOW : LATER;
         event.setHeader(WHEN, when);
         try {
             po.send(event);

--- a/system/platform-core/src/main/java/org/platformlambda/automation/services/ServiceGateway.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/services/ServiceGateway.java
@@ -390,7 +390,7 @@ public class ServiceGateway {
              * Single-value HTTP header is assumed.
              */
             String value = headerMap.get(key);
-            if (key.equalsIgnoreCase(COOKIE)) {
+            if (COOKIE.equalsIgnoreCase(key)) {
                 hasCookies = true;
             } else {
                 headers.put(key.toLowerCase(), value);
@@ -504,9 +504,9 @@ public class ServiceGateway {
                         sendRequestToService(request, requestEvent.setHttpRequest(req));
                     }
                 }).endHandler(done -> inputComplete.set(true));
-            } else if (contentType.equals(APPLICATION_FORM_URLENCODED) ||
+            } else if (APPLICATION_FORM_URLENCODED.equals(contentType) ||
                     contentType.startsWith(TEXT_HTML) || contentType.startsWith(TEXT_PLAIN)) {
-                final boolean urlEncodeParameters = contentType.equals(APPLICATION_FORM_URLENCODED);
+                final boolean urlEncodeParameters = APPLICATION_FORM_URLENCODED.equals(contentType);
                 request.bodyHandler(block -> {
                     byte[] b = block.getBytes(0, block.length());
                     requestBody.write(b, 0, b.length);

--- a/system/platform-core/src/main/java/org/platformlambda/automation/services/ServiceResponseHandler.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/services/ServiceResponseHandler.java
@@ -111,17 +111,17 @@ public class ServiceResponseHandler implements TypedLambdaFunction<EventEnvelope
                          * 1. "stream" and "timeout" are reserved as stream ID and read timeout in seconds
                          * 2. "trace_id" and "trace_path" should be dropped from HTTP response headers
                          */
-                        if (key.equals(STREAM) && value.startsWith(STREAM_PREFIX) &&
+                        if (STREAM.equals(key) && value.startsWith(STREAM_PREFIX) &&
                                 value.contains(INPUT_STREAM_SUFFIX)) {
                             streamId = value;
-                        } else if (key.equalsIgnoreCase(TIMEOUT)) {
+                        } else if (TIMEOUT.equalsIgnoreCase(key)) {
                             streamTimeout = value;
-                        } else if (key.equalsIgnoreCase(CONTENT_TYPE)) {
+                        } else if (CONTENT_TYPE.equalsIgnoreCase(key)) {
                             if (!httpHead) {
                                 contentType = value.toLowerCase();
                                 response.putHeader(CONTENT_TYPE, contentType);
                             }
-                        } else if (key.equalsIgnoreCase(SET_COOKIE)) {
+                        } else if (SET_COOKIE.equalsIgnoreCase(key)) {
                             httpUtil.setCookies(response, value);
                         } else {
                             resHeaders.put(key, value);

--- a/system/platform-core/src/main/java/org/platformlambda/core/serializers/SimpleMapper.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/serializers/SimpleMapper.java
@@ -44,7 +44,7 @@ public class SimpleMapper {
     private SimpleMapper() {
         // Camel or snake case
         AppConfigReader config = AppConfigReader.getInstance();
-        boolean snake = config.getProperty(SNAKE_CASE_SERIALIZATION, "true").equals("true");
+        boolean snake = "true".equals(config.getProperty(SNAKE_CASE_SERIALIZATION, "true"));
         if (snake) {
             log.info("{} enabled", SNAKE_CASE_SERIALIZATION);
         }

--- a/system/platform-core/src/main/java/org/platformlambda/core/serializers/SimpleXmlWriter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/serializers/SimpleXmlWriter.java
@@ -37,7 +37,7 @@ public class SimpleXmlWriter {
     public String write(Object map) {
         String className = map.getClass().getSimpleName();
         // className hierarchy filtering: dot for subclass and dollar-sign for nested class
-        String root = className.equals("HashMap") ? "root" : className;
+        String root = "HashMap".equals(className) ? "root" : className;
         return write(root.toLowerCase(), map);
     }
 

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java
@@ -110,7 +110,7 @@ public class EventEmitter {
             });
         }
         // load route substitution table if any
-        if (config.getProperty(ROUTE_SUBSTITUTION_FEATURE, "false").equals("true")) {
+        if ("true".equals(config.getProperty(ROUTE_SUBSTITUTION_FEATURE, "false"))) {
             platform.getEventExecutor().submit(this::loadRouteSubstitution);
         }
     }
@@ -330,7 +330,7 @@ public class EventEmitter {
      * @throws IOException in case route is not found
      */
     public TargetRoute discover(String to, boolean endOfRoute) throws IOException {
-        boolean checkCloud = !endOfRoute && !to.equals(CLOUD_CONNECTOR);
+        boolean checkCloud = !endOfRoute && !CLOUD_CONNECTOR.equals(to);
         Platform platform = Platform.getInstance();
         if (to.contains("@")) {
             int at = to.indexOf('@');
@@ -626,7 +626,7 @@ public class EventEmitter {
             /*
              * The target is the same memory space. We will route it to the cloud connector if broadcast.
              */
-            if (Platform.isCloudSelected() && event.getBroadcastLevel() == 1 && !to.equals(CLOUD_CONNECTOR)) {
+            if (Platform.isCloudSelected() && event.getBroadcastLevel() == 1 && !CLOUD_CONNECTOR.equals(to)) {
                 TargetRoute cloud = getCloudRoute();
                 if (cloud != null) {
                     if (cloud.isCloud()) {

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/Platform.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/Platform.java
@@ -728,10 +728,10 @@ public class Platform {
         String hash = util.getUTF(crypto.getMd5(util.getUTF(message)));
         if (!cache.exists(hash)) {
             cache.put(hash, true);
-            if (level.equals("error")) {
+            if ("error".equals(level)) {
                 log.warn(message);
             }
-            if (level.equals("info")) {
+            if ("info".equals(level)) {
                 log.info(message);
             }
         }

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
@@ -244,7 +244,7 @@ public class WorkerHandler {
                         }
                         for (Map.Entry<String, String> kv: headers.entrySet()) {
                             String k = kv.getKey();
-                            if (!k.equals(MY_ROUTE) && !k.equals(MY_TRACE_ID) && !k.equals(MY_TRACE_PATH)) {
+                            if (!MY_ROUTE.equals(k) && !MY_TRACE_ID.equals(k) && !MY_TRACE_PATH.equals(k)) {
                                 response.setHeader(k, kv.getValue());
                             }
                         }

--- a/system/platform-core/src/main/java/org/platformlambda/core/util/ElasticQueue.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/util/ElasticQueue.java
@@ -150,7 +150,7 @@ public class ElasticQueue implements AutoCloseable {
             for (File f : files) {
                 String name = f.getName();
                 if (name.startsWith("je.stat.") && name.endsWith(".csv")
-                        && !name.equals("je.stat.csv") && now - f.lastModified() > ONE_DAY) {
+                        && !"je.stat.csv".equals(name) && now - f.lastModified() > ONE_DAY) {
                     outdated.add(f);
                 }
             }

--- a/system/platform-core/src/main/java/org/platformlambda/core/websocket/server/MinimalistHttpHandler.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/websocket/server/MinimalistHttpHandler.java
@@ -156,7 +156,7 @@ public class MinimalistHttpHandler implements Handler<HttpServerRequest> {
             }
         }
         if (!processed) {
-            if (uri.equals("/")) {
+            if ("/".equals(uri)) {
                 Map<String, Object> instruction = new HashMap<>();
                 List<String> endpoints = new ArrayList<>();
                 instruction.put(MESSAGE, "Minimalist HTTP server supports these admin endpoints");
@@ -192,7 +192,7 @@ public class MinimalistHttpHandler implements Handler<HttpServerRequest> {
         EventEnvelope event = new EventEnvelope().setHeader(TYPE, type);
         event.setTo(EventEmitter.ACTUATOR_SERVICES+"@"+origin);
         event.setHeader(USER, System.getProperty("user.name"));
-        String when = parts.get(1).equals(NOW) ? NOW : LATER;
+        String when = NOW.equals(parts.get(1)) ? NOW : LATER;
         event.setHeader(WHEN, when);
         po.sendLater(event, new Date(System.currentTimeMillis() + GRACE_PERIOD));
         String message = type+" request sent to " + origin;

--- a/system/rest-spring-2/src/main/java/org/platformlambda/servlets/SuspendResume.java
+++ b/system/rest-spring-2/src/main/java/org/platformlambda/servlets/SuspendResume.java
@@ -59,7 +59,7 @@ public class SuspendResume {
             event.setTo(EventEmitter.ACTUATOR_SERVICES+"@"+origin);
         }
         List<String> path = Utility.getInstance().split(request.getPathInfo(), "/");
-        String when = !path.isEmpty() && path.get(0).equals(NOW) ? NOW : LATER;
+        String when = !path.isEmpty() && NOW.equals(path.get(0)) ? NOW : LATER;
         event.setHeader(WHEN, when);
         po.send(event);
         String message = type+" request sent to " + origin;

--- a/system/rest-spring-3/src/main/java/org/platformlambda/servlets/SuspendResume.java
+++ b/system/rest-spring-3/src/main/java/org/platformlambda/servlets/SuspendResume.java
@@ -59,7 +59,7 @@ public class SuspendResume {
             event.setTo(EventEmitter.ACTUATOR_SERVICES+"@"+origin);
         }
         List<String> path = Utility.getInstance().split(request.getPathInfo(), "/");
-        String when = !path.isEmpty() && path.get(0).equals(NOW) ? NOW : LATER;
+        String when = !path.isEmpty() && NOW.equals(path.get(0)) ? NOW : LATER;
         event.setHeader(WHEN, when);
         po.send(event);
         String message = type+" request sent to " + origin;


### PR DESCRIPTION
This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [http://cwe.mitre.org/data/definitions/476.html](http://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Ccitizenjosh%2Fmercury%7C07b055a762be3ba3394b1905784e5997f6a42c09)

<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->