### PR TITLE
Fixing flaky test - [platform-core] - org.platformlambda.core.PostOfficeTest#journalYamlTest()

### DIFF
--- a/system/platform-core/src/test/java/org/platformlambda/core/PostOfficeTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/PostOfficeTest.java
@@ -507,8 +507,8 @@ public class PostOfficeTest extends TestBase {
         EventEmitter po = EventEmitter.getInstance();
         List<String> routes = po.getJournaledRoutes();
         Assert.assertEquals(2, routes.size());
-        Assert.assertEquals(ANOTHER_FUNCTION, routes.get(0));
-        Assert.assertEquals(MY_FUNCTION, routes.get(1));
+        Assert.assertTrue(routes.contains(ANOTHER_FUNCTION));
+        Assert.assertTrue(routes.contains(MY_FUNCTION));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### Purpose of this change

This change fixes the following flaky test in the `platform-core` module - [`org.platformlambda.core.PostOfficeTest#journalYamlTest`](https://github.com/Accenture/mercury/blob/e659caf000c2a714d921a52cbc85e13f56cef981/system/platform-core/src/test/java/org/platformlambda/core/PostOfficeTest.java#L504)

### The Issue

When the above test is run using the [nondex maven plugin](https://github.com/TestingResearchIllinois/NonDex) using this command - 

`mvn -pl system/platform-core/ edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.platformlambda.core.PostOfficeTest#journalYamlTest
`

it intermittently throws the following error - 

```
[ERROR] org.platformlambda.core.PostOfficeTest.journalYamlTest  Time elapsed: 0.006 s  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[another].function> but was:<[my.test].function>
```

The aforementioned test exhibits flakiness because it makes index level checks on the elements of the List routes, which has been derived from the keys of a map using [journaledRoutes.keySet()](https://github.com/Accenture/mercury/blob/e659caf000c2a714d921a52cbc85e13f56cef981/system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java#L168) . The type of [journaledRoutes is ConcurrentHashMap<String, Boolean>](https://github.com/Accenture/mercury/blob/e659caf000c2a714d921a52cbc85e13f56cef981/system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java#L78), which is optimized for concurrency and performance, and does not maintain ordering for its key-values.

### My Fix

For the fix, I have changed the test to check if routes contains the required functions, without checking the order. This will check that the content of the list is as required, without failing due to non-deterministic ordering of the Map's keys. 

P.S: Sorting the list within the test and making index level checks is a fix I considered, but I felt that this would make adding more elements to the map a little more complex, as checks would need to be made in the order that the keys are sorted in. This order can change depending upon the order of the keys in the yaml.

I'd love to get feedback on this fix, and please let me know if you'd like further changes!