### PR TITLE
ci: Rust workspace quality gates for the PR process

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,46 @@
+name: rust
+
+# The workspace quality gates, exactly as the port's convention defines
+# "done" (memory/continuity.md → Conventions): cargo fmt clean, clippy with
+# zero warnings across all targets, and the full workspace test suite.
+#
+# Deliberately unfiltered by paths: this workflow is intended as a required
+# check under branch protection, and a path-filtered required check leaves
+# docs-only PRs stuck waiting for a run that never starts. The cargo cache
+# keeps docs-only runs cheap.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (stable + clippy + rustfmt)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Format check
+        run: cargo fmt --all --check
+
+      - name: Clippy (zero warnings)
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Test workspace
+        run: cargo test --workspace

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -392,7 +392,9 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   maintainer repurposed `github.com/Accenture/mercury` (the original Java v1–v3 repo; legacy
   releases kept as branches) as the official Rust home; the full R&D history (122 commits)
   was merged onto it (`--allow-unrelated-histories`, branch `graduation`), README
-  de-privatized + legacy section preserved, MkDocs publishing automated (gh-deploy on main).
+  de-privatized + legacy section preserved, MkDocs publishing automated (gh-deploy on main);
+  **PR [#147](https://github.com/Accenture/mercury/pull/147) MERGED** (true merge commit —
+  history intact).
   Thereafter the regular PR process applies (no more direct pushes to main). The private
   R&D repo (acn-ericlaw/mercury) freezes as the prototyping archive. → serves: vision-mercury
   <!-- id: bp-graduate-to-accenture | created: 2026-07-15 | last_used: 2026-07-20 | uses: 4 | tier: active | origin: 2026-07-15-215538.md -->

--- a/memory/sessions/2026-07-20-174741.md
+++ b/memory/sessions/2026-07-20-174741.md
@@ -35,6 +35,14 @@ graduated to its official home.
   decision 2026-07-20). The Java side still owes a new mercury-composable release (post
   #203) — maintainer's next item.
 
+Also: graduation **PR [#147](https://github.com/Accenture/mercury/pull/147) MERGED** —
+a true merge commit (`a4f1dac4`); the 122-commit history is live on the official main.
+First post-graduation PR follows immediately: **Rust CI** (`.github/workflows/rust.yml`,
+branch `ci/rust-workspace`) — fmt check + clippy `-D warnings` + full workspace tests,
+deliberately path-unfiltered so it can serve as a REQUIRED check under branch protection
+(a path-filtered required check strands docs-only PRs); gates verified green in the fresh
+official clone (206 tests / clippy 0 / fmt clean).
+
 ## Memory References
 
 - bp-graduate-to-accenture — executed (ceremony complete; PR pending merge)


### PR DESCRIPTION
## What

Adds `.github/workflows/rust.yml` — the Rust workspace quality gates, run on every PR
and push to main:

1. `cargo fmt --all --check`
2. `cargo clippy --workspace --all-targets -- -D warnings` (zero-warning policy)
3. `cargo test --workspace`

Stable toolchain, cargo caching, 30-minute timeout. The workflow is deliberately
**path-unfiltered** so it can serve as a required check under branch protection — a
path-filtered required check leaves docs-only PRs stuck waiting for a run that never
starts; the cache keeps such runs cheap. Verified green in this clone before pushing:
**206 tests, clippy 0 warnings, fmt clean.**

Also records the graduation PR #147 merge in the shared memory layer
(`memory/continuity.md` + the session log), per the repo's memory protocol.

## Why

These three gates are the port's definition of "done" — enforced locally on every one
of the 49 increments (memory/continuity.md → Conventions) but never needed as CI while
the R&D repo took direct pushes. The graduation switched this repo to the regular PR
process, so the gates move into CI: this run itself is the first live execution.

Co-Authored-By: Claude Code <noreply@anthropic.com>