### PR TITLE
chore(release): version 4.9.0 — adopt the canonical version line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,56 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
+## Version 4.9.0, 7/20/2026
+
+**Graduation release — and the adoption of the canonical version line.** The version jumps
+from 0.1.0 to **4.9.0** to track `mercury-composable` (Java), with which this engine is
+behavior-synced: the companion REST contract is byte-identical, the graph/flow DSLs are
+shared, and every engine fix since the port began landed in both implementations
+(mercury-composable PRs #187–#204, released there as 4.9.0 the same day). One version, two
+languages.
+
+Everything since 0.1.0, in brief (increments 30–49 — the full record in
+[`docs/INCREMENTS.md`](docs/INCREMENTS.md)):
+
+### Added
+
+1. **The synchronous AI-companion endpoint** `POST /api/companion/{id}/sync` (ADR-0008) —
+   command outcomes in-band (`{ok, output, error, result}`, whole-traversal capture, WS tee
+   for real-time human+AI collaboration), with a truthful contract: whole-output-aware `ok`
+   classification, no silent dedup for RPC callers, `Syntax:` usage hints classify as
+   failures.
+2. **Discovery + contract commands**: `list graphs` / `list flows` / `describe graph
+   {graph-id}` — self-service delegation (list → contract → delegate) with the root
+   `purpose` enforced at compile as living documentation.
+3. **Outbound HTTPS for the async HTTP client** (rustls + OS trust store, per-request
+   `trust_all_cert`) — field-validated end-to-end against a live CA chain. Redirects are
+   deliberately not followed (backend design; documented decision record in
+   `docs/design/platform-core-port.md` §5j).
+4. **Numeric promotion + `f:round`** for the simple-plugin arithmetic family.
+5. **The battle-tested AI-agent documentation**: hardened by 25 fresh-agent exercises
+   across both engines (the last thirteen passing with zero documentation lookups) and
+   kept in lock-step with the Java repo (back-port #203 there).
+6. **The human documentation site** — 20 pages, published at
+   [accenture.github.io/mercury](https://accenture.github.io/mercury/) (automated via
+   `mkdocs gh-deploy` on pushes to main).
+7. **Rust CI quality gates** — fmt + clippy (zero warnings) + the full workspace test
+   suite on every PR.
+
+### Fixed
+
+1. **Join barrier: only valid completions count** — success-only completion marks cleared
+   by `RESET`, and chained joins judged by recorded outcome (latent data-loss bugs found by
+   probe, fixed in both engines).
+2. **Companion `session` limited to the read-only status query** (topology subcommands are
+   a WebSocket-session privilege).
+3. **HTTP-boundary content-type dispatch** mirrors the Java `handlePayload` rules exactly.
+4. Spring-named configuration keys retired: `app.profiles.active` / `application.name`.
+
+**Verified:** 206 workspace tests green, `clippy` zero warnings, `fmt` clean — enforced in
+CI from this release on.
+
+---
 ## Version 0.1.0, 7/18/2026
 
 The first end-to-end port of `mercury-composable` (Java, canonical v4.8.6) to Rust: the three

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "0.1.0"
+version = "4.9.0"
 dependencies = [
  "async-trait",
  "log",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "event-script"
-version = "0.1.0"
+version = "4.9.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "event-script-macros"
-version = "0.1.0"
+version = "4.9.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -355,7 +355,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "0.1.0"
+version = "4.9.0"
 dependencies = [
  "async-trait",
  "event-script",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "0.1.0"
+version = "4.9.0"
 dependencies = [
  "async-trait",
  "log",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph"
-version = "0.1.0"
+version = "4.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph-macros"
-version = "0.1.0"
+version = "4.9.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -563,7 +563,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minigraph-playground"
-version = "0.1.0"
+version = "4.9.0"
 dependencies = [
  "async-trait",
  "event-script",
@@ -650,7 +650,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "platform-core"
-version = "0.1.0"
+version = "4.9.0"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macros"
-version = "0.1.0"
+version = "4.9.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "4.9.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury-composable"

--- a/memory/archive/2026-Q3.md
+++ b/memory/archive/2026-Q3.md
@@ -218,3 +218,21 @@
   direction); behavior semantics stay aligned with the shared grammar.** Rollup #16 in
   `docs/AI-companion-test.md`. → serves: vision-mercury
   <!-- id: ot-help-pages-rewrite | created: 2026-07-18 | last_used: 2026-07-19 | uses: 7 | tier: archive-candidate | origin: 2026-07-18-231641.md -->
+
+## 2026-07-20 — archived via archive-fact (faded)
+
+### Faded facts
+
+- [x] **Profile selection renamed `APP_PROFILES_ACTIVE` / `app.profiles.active` — no alias
+  (increment 37).** Maintainer decision 2026-07-19 (supersedes the 2026-07-15 alias plan; its
+  "foundation robust" gate is met): Spring is irrelevant to the Rust port, so the generic names
+  replace `SPRING_PROFILES_ACTIVE`/`spring.profiles.active` outright — the **one deliberate
+  exception to D9's verbatim-config rule** (a `spring.profiles.active` line in a ported config
+  file does NOT carry over). Mechanism/precedence unchanged (env → override registry →
+  consolidated key; `application-{profile}.yml` overlays). Code + manifest + tests + design doc
+  (§3, §8 Q1 DECIDED) + ledger updated; workspace 202 tests / clippy 0 / fmt clean.
+  **Follow-up DONE same day (maintainer-directed): `spring.application.name` retired too** —
+  `Platform::name()` reads `application.name` alone (Java's own primary key) and the default
+  aligns to Java's `"application"` (was an unnoted `"untitled"` divergence). No Spring-named
+  config key remains live anywhere in the port. → serves: vision-mercury
+  <!-- id: profiles-renamed-app-active | created: 2026-07-19 | last_used: 2026-07-19 | uses: 1 | tier: archive-candidate | supersedes: ot-profiles-alias-backlog | origin: 2026-07-19-215701.md -->

--- a/memory/archive/INDEX.md
+++ b/memory/archive/INDEX.md
@@ -22,3 +22,4 @@
 - ot-profiles-alias-backlog — (backlog) Generic `app.profiles.active` alias for profile selection. Maintainer — superseded by profiles-renamed-app-active — 2026-Q3.md
 - ot-subscribe-via-sync-bug — Bug FIXED (Rust; Java prepared): companion endpoints limit `session` to read-only. Found — faded (completed 2026-07-18, fixed in both engines via PR #194; sslu > archive_window) — 2026-Q3.md
 - ot-help-pages-rewrite — (backlog) Rewrite the interactive help pages for human operators — DONE 2026-07-19. Mainta… — faded — 2026-Q3.md
+- profiles-renamed-app-active — Profile selection renamed `APP_PROFILES_ACTIVE` / `app.profiles.active` — no alias — faded — 2026-Q3.md

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -13,9 +13,9 @@
 ## Project State
 
 - **project:** mercury
-- **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** — regular PR process from here on.
+- **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-20 | agent: Claude Code (2026-07-20-174741)
+- **last_session:** 2026-07-20 | agent: Claude Code (2026-07-20-185216)
 - **last_review:** 2026-07-20 | through 2026-07-20-040852
 - **last_invariant_check:** 2026-07-18 | through 2026-07-18-061457 (confirmed — inv-never-couple-functions + Vision both hold)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -68,7 +68,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Rust layer by layer, foundation → UI (platform-core, then event-script, then active
   knowledge graph), preserving the Java project's behavior. The Java repo is the canonical
   spec (map, don't mirror).
-  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-20 | uses: 57 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-20 | uses: 58 | tier: active | origin: 2026-07-15-215538.md -->
 ## Conventions
 
 > Established with the first code (increment 1, 2026-07-15); enforced from the first commit.
@@ -92,7 +92,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   2026-07-16): annotated functions + `platform_core::auto_start_main!();` with the app's
   `resources/` beside its `Cargo.toml` — never cargo examples inside a library crate.
   Event-script and knowledge-graph demos land as sibling `examples/<name>/` crates.
-  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-20 | uses: 56 | tier: active | origin: 2026-07-15-224707.md -->
+  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-20 | uses: 57 | tier: active | origin: 2026-07-15-224707.md -->
 
 ## Open Threads
 
@@ -360,7 +360,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   mirror, all code in the Rust API, port truths (tokio not virtual threads, `#[preload]` not
   `@PreLoad`, no Kafka/Spring), verified against source. The AI docs stay agent-optimized and
   separate; the in-app help pages are already done. → serves: vision-mercury
-  <!-- id: ot-human-guides-backlog | created: 2026-07-19 | last_used: 2026-07-20 | uses: 7 | tier: active | origin: 2026-07-19-181641.md -->
+  <!-- id: ot-human-guides-backlog | created: 2026-07-19 | last_used: 2026-07-20 | uses: 7 | tier: archive-candidate | origin: 2026-07-19-181641.md -->
 
 - [x] **Discovery commands for deployed flows and graph models — DONE 2026-07-20 (increment 42,
   BOTH ports).** From tut-11 finding #38: the `list` command grows two read-only forms —
@@ -397,7 +397,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   history intact).
   Thereafter the regular PR process applies (no more direct pushes to main). The private
   R&D repo (acn-ericlaw/mercury) freezes as the prototyping archive. → serves: vision-mercury
-  <!-- id: bp-graduate-to-accenture | created: 2026-07-15 | last_used: 2026-07-20 | uses: 4 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: bp-graduate-to-accenture | created: 2026-07-15 | last_used: 2026-07-20 | uses: 5 | tier: active | origin: 2026-07-15-215538.md -->
 - [ ] **(blueprint)** **Synchronous AI-companion feedback** — make the companion a real AI *tool*, not
   a write-then-poll bus. The current `POST /api/companion/{id}` is fire-and-forget (`{status:accepted}`);
   command outcome + errors stream WS-only, so an AI caller is blind (Tut-4: HTTP 200 while the run had
@@ -521,7 +521,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   port notes. Validation: a fresh-agent drive against the JAVA Playground from the
   back-ported docs alone. Java human-doc bugs also parked: flow-schema `error.status` →
   engine's `error.code`. → serves: vision-mercury
-  <!-- id: ot-java-ai-docs-backport | created: 2026-07-20 | last_used: 2026-07-20 | uses: 3 | tier: active | origin: 2026-07-20-163856.md -->
+  <!-- id: ot-java-ai-docs-backport | created: 2026-07-20 | last_used: 2026-07-20 | uses: 4 | tier: active | origin: 2026-07-20-163856.md -->
 
 - [ ] **(knowledge-harvest) Harvest the canonical vision/specs from mercury-composable (Java).**
   **Gate satisfied 2026-07-15** — the maintainer added `~/sandbox/mercury-composable` and
@@ -534,20 +534,6 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   WorkerHandler, serializers), then event-script and knowledge-graph specs + their ADRs.
   → serves: vision-mercury
   <!-- id: ot-harvest-mercury-composable | created: 2026-07-15 | last_used: 2026-07-15 | uses: 2 | tier: working | origin: 2026-07-15-215538.md -->
-
-- [x] **Profile selection renamed `APP_PROFILES_ACTIVE` / `app.profiles.active` — no alias
-  (increment 37).** Maintainer decision 2026-07-19 (supersedes the 2026-07-15 alias plan; its
-  "foundation robust" gate is met): Spring is irrelevant to the Rust port, so the generic names
-  replace `SPRING_PROFILES_ACTIVE`/`spring.profiles.active` outright — the **one deliberate
-  exception to D9's verbatim-config rule** (a `spring.profiles.active` line in a ported config
-  file does NOT carry over). Mechanism/precedence unchanged (env → override registry →
-  consolidated key; `application-{profile}.yml` overlays). Code + manifest + tests + design doc
-  (§3, §8 Q1 DECIDED) + ledger updated; workspace 202 tests / clippy 0 / fmt clean.
-  **Follow-up DONE same day (maintainer-directed): `spring.application.name` retired too** —
-  `Platform::name()` reads `application.name` alone (Java's own primary key) and the default
-  aligns to Java's `"application"` (was an unnoted `"untitled"` divergence). No Spring-named
-  config key remains live anywhere in the port. → serves: vision-mercury
-  <!-- id: profiles-renamed-app-active | created: 2026-07-19 | last_used: 2026-07-19 | uses: 1 | tier: archive-candidate | supersedes: ot-profiles-alias-backlog | origin: 2026-07-19-215701.md -->
 
 ## User Preferences
 

--- a/memory/sessions/2026-07-20-185216.md
+++ b/memory/sessions/2026-07-20-185216.md
@@ -1,0 +1,44 @@
+# Session (2026-07-20T18:52:16.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Post-graduation wrap-up: the Rust port adopts the canonical version line — 0.1.0 →
+4.9.0** (branch `release/v4.9.0`; the maintainer merges via the PR process). Batched
+records from the graduation aftermath:
+
+- **Rust CI merged** — PR [#148](https://github.com/Accenture/mercury/pull/148) (fmt +
+  clippy `-D warnings` + workspace tests; ready as a required branch-protection check).
+  The docs site went live at accenture.github.io/mercury on the #147 merge.
+- **Cross-links merged** — mercury-composable PR
+  [#204](https://github.com/Accenture/mercury-composable/pull/204): README + docs home +
+  llms.txt point here; the two `llms.txt` maps now reference each other.
+- **Java 4.9.0 RELEASED** — PR
+  [#205](https://github.com/Accenture/mercury-composable/pull/205) merged + tagged:
+  version sweep per the #185 recipe (32 poms + steering files + OtelForwarderContext +
+  Dockerfile), CHANGELOG release notes covering #187–#204, GitHub release published.
+  Full reactor verified green (950 tests). **Ops lesson recorded in the release notes:**
+  `rest-spring-3`'s test context binds port 8085 — a leftover Playground app there fails
+  4 tests spuriously (diagnosed live: baseline red → port freed → baseline green).
+- **Version decision (recommendation implemented, PR = veto gate): track the canonical
+  line.** The engines are behavior-synced (byte-identical companion contract, shared
+  grammar, every fix in both), so `mercury` 4.9.0 = "the Rust implementation of the
+  4.9.0 behavior" — one version, two languages. Footprint: the one workspace
+  `Cargo.toml` line (crates inherit; `/info` reports via `CARGO_PKG_VERSION`) +
+  `cargo update -w` lockfile sync + the CHANGELOG 4.9.0 entry (graduation-release
+  narrative, increments 30–49 summarized).
+- **LOC analysis for the maintainer (CI-speed question):** Rust engine 36,327 lines
+  (27,610 src + 8,717 tests, 96 files) vs Java's 59,860 for the three in-scope modules
+  (~0.6×) and 97,655 for the whole reactor; the 1-min-vs-5-min CI gap decomposes into
+  scope (fewer modules) + cargo per-crate caching + suite size (206 vs 950 tests) — NOT
+  raw compiler speed.
+
+## Memory References
+
+- bp-graduate-to-accenture — referenced (aftermath items all closed)
+- ot-java-ai-docs-backport — referenced (#203 shipped in the Java 4.9.0 release)
+- conventions-rust-baseline — applied (gates + ledger discipline for the release PR)
+- port-bottom-up-faithful — applied (version alignment = the parity story, made visible)
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

Bumps the workspace version 0.1.0 → **4.9.0** (one line in `Cargo.toml`; all crates
inherit it and `/info` reports it via `CARGO_PKG_VERSION`), syncs the lockfile, and adds
the CHANGELOG 4.9.0 entry — the graduation release, summarizing increments 30–49. Also
batches the post-graduation memory-layer records (#148, mercury-composable #204/#205).

## Why

The Rust engine is behavior-synced with mercury-composable 4.9.0 (released today): the
companion REST contract is byte-identical, the graph/flow DSLs are shared, and every
engine fix since the port began landed in both implementations (upstream PRs #187–#204).
Tracking the canonical version line makes that visible at a glance — **one version, two
languages** — instead of forcing every parity conversation through a version-mapping
table. An independent 0.x line would understate an engine that is behavior-complete for
its scope; this is the honest number.

Verified: 206 workspace tests, clippy 0 warnings, fmt clean.

Co-Authored-By: Claude Code <noreply@anthropic.com>