### PR TITLE
fix(knowledge-graph): harden describe-graph tokenizer against unbalanced trailing brackets

### DIFF
--- a/crates/knowledge-graph/src/commands.rs
+++ b/crates/knowledge-graph/src/commands.rs
@@ -992,9 +992,17 @@ fn collect_path_tokens(text: &str, prefix: &str, found: &mut std::collections::B
                 break;
             }
         }
-        let token = text[begin..end]
+        let mut token = text[begin..end]
             .trim_end_matches(['.', '-', '['])
             .to_string();
+        // a trailing `]` with no matching `[` is the enclosing list's closing
+        // bracket (e.g. Java-style `{mapping=[... -> output.body]}` text),
+        // not an array index — trim until the brackets balance
+        while token.ends_with(']') && token.matches('[').count() < token.matches(']').count() {
+            token.pop();
+            let trimmed = token.trim_end_matches(['.', '-', '[']).len();
+            token.truncate(trimmed);
+        }
         if token.len() > prefix.len() {
             found.insert(token);
         }
@@ -2277,9 +2285,47 @@ pub fn download_graph(id: &str) -> Option<Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::convert_mapping_properties;
+    use super::{collect_path_tokens, convert_mapping_properties};
     use event_script::mlm::MultiLevelMap;
     use rmpv::Value;
+
+    fn tokens(text: &str, prefix: &str) -> Vec<String> {
+        let mut found = std::collections::BTreeSet::new();
+        collect_path_tokens(text, prefix, &mut found);
+        found.into_iter().collect()
+    }
+
+    #[test]
+    fn path_tokens_terminate_at_json_string_quotes() {
+        // the describe-graph surface scan runs over JSON-serialized properties
+        let text =
+            r#"{"mapping":["text(hello world) -> output.body"],"skill":"graph.data.mapper"}"#;
+        assert_eq!(tokens(text, "output."), vec!["output.body"]);
+    }
+
+    #[test]
+    fn path_tokens_drop_an_unbalanced_trailing_bracket() {
+        // hardening: Java-style Map.toString() text has no quotes, so a path
+        // ending a mapping list would otherwise absorb the list's closing `]`
+        // (the Java engine's describe-graph bug, found 2026-07-20)
+        let text = "{mapping=[text(hello world) -> output.body], skill=graph.data.mapper}";
+        assert_eq!(tokens(text, "output."), vec!["output.body"]);
+    }
+
+    #[test]
+    fn path_tokens_keep_genuine_array_indices() {
+        // balanced brackets are an array index, not an enclosing list
+        assert_eq!(
+            tokens("input.profile[0] -> model.name", "input."),
+            vec!["input.profile[0]"]
+        );
+        // an index at the end of an unquoted list keeps the index and drops
+        // only the enclosing bracket
+        assert_eq!(
+            tokens("{mapping=[a -> output.body[0]]}", "output."),
+            vec!["output.body[0]"]
+        );
+    }
 
     fn map_with(property: &str, entries: &[&str]) -> MultiLevelMap {
         let mut m = MultiLevelMap::new();

--- a/crates/knowledge-graph/tests/playground.rs
+++ b/crates/knowledge-graph/tests/playground.rs
@@ -202,12 +202,14 @@ async fn playground_command_grammar_and_companion() {
         console_has(&lines, "Deployed graph model 'tutorial-3'"),
         "deployed-model header expected"
     );
+    // exact indented lines: a stray trailing character (e.g. the Java
+    // engine's `output.body]` toString leak, 2026-07-20) must fail here
     assert!(
-        console_has(&lines, "input.body.person_id"),
+        console_has(&lines, "  input.body.person_id\n"),
         "derived input surface expected"
     );
     assert!(
-        console_has(&lines, "output.body.name"),
+        console_has(&lines, "  output.body.name\n"),
         "derived output surface expected"
     );
     command(&po, in_route, out_route, "describe graph no-such-model-xyz").await;

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-20 | agent: Claude Code (2026-07-20-185216)
+- **last_session:** 2026-07-20 | agent: Claude Code (2026-07-20-213830)
 - **last_review:** 2026-07-20 | through 2026-07-20-040852
 - **last_invariant_check:** 2026-07-18 | through 2026-07-18-061457 (confirmed — inv-never-couple-functions + Vision both hold)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -522,6 +522,21 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   back-ported docs alone. Java human-doc bugs also parked: flow-schema `error.status` →
   engine's `error.code`. → serves: vision-mercury
   <!-- id: ot-java-ai-docs-backport | created: 2026-07-20 | last_used: 2026-07-20 | uses: 4 | tier: active | origin: 2026-07-20-163856.md -->
+
+- [ ] **`describe graph` trailing-`]` in the derived surface — JAVA-only bug; Rust hardened
+  preventively (2026-07-20).** The maintainer's screenshot (:8085 = Java playground) showed
+  `output.body]`; the Rust engine prints clean (probe-verified — its scan runs over
+  JSON-quoted text, while Java's `describeDeployedGraph` scans `Map.toString()` text whose
+  unquoted list form leaks the closing `]` into a path token ending a mapping list; both
+  ports' tokenizers accept `[`/`]` for array indices and trimmed only `.`/`-`/`[`). Rust
+  hardening landed (maintainer-directed): `collect_path_tokens` drops an unbalanced trailing
+  `]` + 3 unit tests + playground assertions tightened to exact indented lines (substring
+  `contains` is how both suites missed it); workspace 38 binaries green/clippy 0/fmt.
+  **Pending: the Java fix** — handed off to the mercury-composable agent session via
+  `/tmp/describe-graph-trailing-bracket-finding.md` (recommended: JSON-serialize properties
+  before scanning for byte-identical contract output + same tokenizer guard + exact-line
+  test). Close when the Java PR merges. → serves: vision-mercury
+  <!-- id: ot-describe-surface-trailing-bracket | created: 2026-07-20 | last_used: 2026-07-20 | uses: 1 | tier: working | origin: 2026-07-20-213830.md -->
 
 - [ ] **(knowledge-harvest) Harvest the canonical vision/specs from mercury-composable (Java).**
   **Gate satisfied 2026-07-15** — the maintainer added `~/sandbox/mercury-composable` and

--- a/memory/sessions/2026-07-20-213830.md
+++ b/memory/sessions/2026-07-20-213830.md
@@ -1,0 +1,50 @@
+# Session (2026-07-20T21:38:30.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+The maintainer's screenshot of `describe graph tutorial-1/-2` on the playground at :8085
+showed the derived output surface as `output.body]` — a stray trailing bracket. Investigated
+whether the Rust port has the bug.
+
+**Finding: the bug is in the JAVA engine only** (the :8085 app is the Java
+`minigraph-playground` example; the Rust playground binds 8100). Root cause — same
+tokenizer, different scanned text: both engines scan node `properties` as free text for
+`input.*`/`output.*` path tokens, and both accept `[`/`]` as token chars (array indices)
+while trimming only trailing `.`, `-`, `[`. The Rust `describe_deployed_graph` scans the
+**JSON serialization** (quoted strings — the token stops at the closing `"`), so it prints
+`output.body` clean — verified empirically with a temporary probe test (booted the
+playground, drove the command service, captured the exact console block; probe deleted
+after). The Java `describeDeployedGraph` (PR #200) scans
+`String.valueOf(node.get("properties"))` — Java `Map`/`List.toString()`, no quotes — so a
+path ending a mapping list absorbs the list's closing `]`. Both engines' tests missed it
+because they assert substring `contains("output.body.name")`, which matches the broken
+token too.
+
+**Handoff:** full finding + recommended Java fix (JSON-serialize the properties before
+scanning, restoring byte-identical contract output; optional unbalanced-`]` tokenizer guard;
+exact-line test tightening; red/green validation plan) written to
+`/tmp/describe-graph-trailing-bracket-finding.md` for the mercury-composable session to
+execute. The maintainer re-tested the Rust engine live and confirmed it displays correctly.
+
+## Changed in this repo (maintainer-directed preventive hardening)
+
+- `crates/knowledge-graph/src/commands.rs` — `collect_path_tokens` now drops a trailing `]`
+  that has no matching `[` (the enclosing list's bracket, never an array index), so the
+  tokenizer is robust regardless of the serialization feeding it and stays identical to the
+  hardened Java version once that lands. Three new unit tests: JSON-quoted text, Java-style
+  `Map.toString()` text, and genuine array indices (`input.profile[0]`, index-at-end-of-list).
+- `crates/knowledge-graph/tests/playground.rs` — the describe-graph assertions tightened to
+  the exact indented lines (`"  output.body.name\n"`), so a stray trailing character can
+  never pass substring matching again.
+- Workspace: all 38 test binaries green, `cargo clippy --all-targets` clean, `cargo fmt`
+  applied.
+
+## Memory References
+
+- referenced: port-bottom-up-faithful, conventions-rust-baseline, ot-companion-validation-sweep
+  (the `describe graph` contract view is increment 47 / findings #53–#54)
+- created: ot-describe-surface-trailing-bracket (born tier: working)
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

Hardens `collect_path_tokens` — the scanner that derives the input/output surface for
`describe graph {graph-id}` — against an unbalanced trailing `]`. The tokenizer accepts
`[`/`]` as token characters so genuine array indices (`output.body[0]`) survive, but it
previously trimmed only trailing `.`, `-`, `[`. It now also drops a trailing `]` that has
no matching `[`: a balanced pair is an array index; an unbalanced one can only be an
enclosing list's closing bracket, never part of a path.

Three new unit tests cover the JSON-quoted form the Rust engine actually scans, the
unquoted Java-style `Map.toString()` form that triggers the defect, and genuine indices
(mid-text and at the end of an unquoted list). The playground integration assertions for
the describe-graph contract view are tightened from substring `contains` to the exact
indented lines (`"  output.body.name\n"`), so a stray trailing character now fails the
suite.

## Why

The maintainer's live test of `describe graph tutorial-1/-2` on the Java playground (:8085)
rendered the derived surface as `output.body]`. Investigation showed the Rust engine is
**not** affected — its scan runs over JSON-serialized properties, where the token stops at
the closing quote (probe-verified: the Rust output is clean) — while the Java
`describeDeployedGraph` (PR #200) scans `String.valueOf(properties)`, whose unquoted list
form leaks the closing `]` into any path token that ends a mapping list. Both engines'
tests missed it because they asserted with substring matching.

This change is the preventive half of the shared fix (maintainer-directed): the tokenizer
becomes robust regardless of the serialization feeding it and stays identical to the Java
tokenizer once the matching fix lands there (handed off to the mercury-composable session
with a full finding doc and red/green validation plan). The exact-line test assertions close
the blind spot that let this class of defect pass both suites, keeping the `describe graph`
contract output byte-identical across engines.

Workspace: all 38 test binaries green, `cargo clippy --all-targets` clean, `cargo fmt`
applied. Session log: `memory/sessions/2026-07-20-213830.md`; open thread
`ot-describe-surface-trailing-bracket` tracks the pending Java-side fix.

Co-Authored-By: Claude Code <noreply@anthropic.com>