### PR TITLE
fix(docs): disable pymdownx.emoji — ":mm:" in HH:mm:ss rendered as a flag emoji

### DIFF
--- a/memory/sessions/2026-07-21-013706.md
+++ b/memory/sessions/2026-07-21-013706.md
@@ -1,0 +1,19 @@
+# Session (2026-07-21T01:37:06.000Z)
+
+**Agent:** Claude Code
+
+*Lightweight session.* Removed `pymdownx.emoji` from `mkdocs.yml` — the maintainer spotted
+the live site rendering `HH:mm:ss` as `HH🇲🇲ss` on the Event Script Syntax page (the twemoji
+alias set includes two-letter country codes, and `:mm:` in plain prose gets substituted;
+confirmed with a local strict build: the parseDateTime bullet was the site's only emoji
+substitution). The Java repo's `mkdocs.yml` already deliberately omits the extension with a
+NOTE naming this exact case — this Rust config had diverged via the Material boilerplate;
+the same NOTE comment is now carried here, so the decision is recorded in both ports.
+Verified: `mkdocs build --strict` green, zero twemoji in the built site, the line renders
+literally. Nothing in the docs used emoji/icon shortcodes intentionally.
+
+## Memory References
+
+(none)
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,9 +73,9 @@ markdown_extensions:
   - pymdownx.snippets:
       base_path: ["."]
       check_paths: true
-  - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  # NOTE: pymdownx.emoji is deliberately NOT enabled. These docs are full of
+  # colon-delimited technical patterns (e.g. HH:mm:ss), and the emoji extension
+  # turns ":mm:" into a flag emoji in plain text.
 
 plugins:
   - search


### PR DESCRIPTION
## What

Removes the `pymdownx.emoji` extension from `mkdocs.yml` and replaces it with the same
NOTE comment the Java repo carries at that spot, recording the decision in-place: these
docs are full of colon-delimited technical patterns, and the emoji extension turns `:mm:`
into a flag emoji in plain text.

## Why

The published site rendered the Event Script Syntax page's parseDateTime example as
`MM/dd/yyyy HH🇲🇲ss; iso` — the twemoji alias set includes two-letter country codes, so the
`:mm:` inside a plain-prose `HH:mm:ss` became the Myanmar flag. A local strict build
confirmed it was the only emoji substitution in the entire site — but only because the
other colon-heavy patterns happen to sit inside code spans today; every new prose page
re-rolls the dice. Nothing in the docs uses emoji or icon shortcodes intentionally (the
extension arrived with the Material boilerplate), so removing it costs nothing.

The canonical Java repo (`mercury-composable`) already made this exact call — its
`mkdocs.yml` deliberately omits the extension, with a NOTE naming the `HH:mm:ss` case.
This config had diverged from that shared publishing decision; carrying the NOTE over
keeps both ports' doc toolchains aligned.

Verified: `mkdocs build --strict` green, zero twemoji artifacts in the built site, the
line renders literally. Merging to main triggers the docs workflow's `gh-deploy`, which
republishes the site and fixes the live page automatically.

Co-Authored-By: Claude Code <noreply@anthropic.com>