### PR TITLE
fix(platform-core): preserve function response-envelope headers at the REST boundary (increment 50)

### DIFF
--- a/crates/platform-core/src/automation/server.rs
+++ b/crates/platform-core/src/automation/server.rs
@@ -336,15 +336,46 @@ async fn process(
         &parent_span,
     )?;
     let result = po.request(event, info.timeout).await?;
-    // map the response envelope back to HTTP
+    // map the response envelope back to HTTP (Java AsyncHttpResponse:
+    // updateHeadersAndContentType + updateHeaders)
     let status = status_of(result.status());
-    let (content_type, payload) = envelope_payload(&result);
+    let is_head = method == "HEAD";
+    let (derived_type, payload) = envelope_payload(&result);
+    let mut content_type = derived_type.map(str::to_string);
+    let mut set_cookies: Vec<String> = Vec::new();
     let mut response_headers: HashMap<String, String> = HashMap::new();
-    if let Some(content_type) = content_type {
-        response_headers.insert("content-type".to_string(), content_type.to_string());
+    for (name, value) in result.headers() {
+        let key = name.to_lowercase();
+        match key.as_str() {
+            // the response-streaming contract (x-stream-id + x-ttl) is a
+            // documented deferral in this port (D10) — recognized like Java
+            // and withheld from the wire, never leaked as literal headers
+            "x-stream-id" if value.starts_with("stream.") && value.contains(".in") => {}
+            "x-ttl" => {}
+            // a function-set content type overrides the body-derived one
+            // (Java: response.putHeader directly, lowercased; skipped for HEAD)
+            "content-type" => {
+                if !is_head {
+                    content_type = Some(value.to_lowercase());
+                }
+            }
+            // repeated cookies ride one envelope header, "|"-separated
+            // (Java SimpleHttpUtility.setCookies -> one header line each)
+            "set-cookie" => {
+                set_cookies.extend(value.split('|').map(|c| c.trim().to_string()));
+            }
+            _ => {
+                response_headers.insert(key, value.clone());
+            }
+        }
     }
+    // the rest.yaml response transform filters the merged header map (Java
+    // filterHeaders); content-type and cookies bypass it, as in Java
     if let Some(header_info) = &info.headers {
         header_info.response.apply(&mut response_headers);
+    }
+    if let Some(content_type) = content_type {
+        response_headers.insert("content-type".to_string(), content_type);
     }
     if let Some(cors) = &info.cors {
         for (name, value) in &cors.headers {
@@ -355,6 +386,13 @@ async fn process(
     for (name, value) in response_headers {
         response = response.header(name, value);
     }
+    for cookie in set_cookies {
+        if !cookie.is_empty() {
+            response = response.header("set-cookie", cookie);
+        }
+    }
+    // a HEAD response never carries a body (Java: isHeadMethod skips content)
+    let payload = if is_head { Bytes::new() } else { payload };
     response
         .body(Full::new(payload))
         .map_err(|e| AppError::new(500, e.to_string()))

--- a/crates/platform-core/src/envelope.rs
+++ b/crates/platform-core/src/envelope.rs
@@ -120,7 +120,10 @@ impl EventEnvelope {
     }
 
     pub fn set_header(mut self, key: &str, value: &str) -> Self {
-        self.headers.insert(key.to_string(), value.to_string());
+        // Java setHeader guarantees CR/LF never enter a header value
+        // (header-injection guard); same filter here
+        let value: String = value.chars().filter(|c| *c != '\r' && *c != '\n').collect();
+        self.headers.insert(key.to_string(), value);
         self
     }
 
@@ -188,7 +191,15 @@ impl EventEnvelope {
     }
 
     pub fn header(&self, key: &str) -> Option<&str> {
-        self.headers.get(key).map(String::as_str)
+        // Java getHeader falls back to a case-insensitive scan when the
+        // exact key is absent
+        if let Some(value) = self.headers.get(key) {
+            return Some(value.as_str());
+        }
+        self.headers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case(key))
+            .map(|(_, value)| value.as_str())
     }
 
     pub fn body(&self) -> &rmpv::Value {

--- a/crates/platform-core/tests/event_bus.rs
+++ b/crates/platform-core/tests/event_bus.rs
@@ -540,3 +540,21 @@ async fn manual_reply_reaches_the_rpc_inbox() {
     // the MANUAL reply won the oneshot (it was sent before the function returned)
     assert_eq!(response.body_as::<String>().unwrap(), "manual reply");
 }
+
+/// Increment 50: envelope header-model parity with Java `EventEnvelope` —
+/// `getHeader` is case-insensitive and `setHeader` filters CR/LF
+/// (header-injection guard).
+#[test]
+fn envelope_header_lookup_is_case_insensitive() {
+    let event = EventEnvelope::new().set_header("Content-Type", "text/plain");
+    assert_eq!(event.header("content-type"), Some("text/plain"));
+    assert_eq!(event.header("CONTENT-TYPE"), Some("text/plain"));
+    assert_eq!(event.header("Content-Type"), Some("text/plain"));
+    assert_eq!(event.header("no-such-header"), None);
+}
+
+#[test]
+fn envelope_header_values_are_sanitized_for_crlf() {
+    let event = EventEnvelope::new().set_header("x-answer", "one\r\ntwo\rthree\nfour");
+    assert_eq!(event.header("x-answer"), Some("onetwothreefour"));
+}

--- a/crates/platform-core/tests/rest_automation.rs
+++ b/crates/platform-core/tests/rest_automation.rs
@@ -184,6 +184,32 @@ impl ComposableFunction for ApiKeyCheck {
     }
 }
 
+/// Increment 50: a function that decorates its response envelope — the
+/// headers must survive the REST boundary exactly as in Java
+/// `AsyncHttpResponse.updateHeaders` (redirect Location, repeated
+/// Set-Cookie, content-type override; stream metadata withheld).
+struct HeaderProbe;
+
+#[async_trait]
+impl ComposableFunction for HeaderProbe {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        _input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        EventEnvelope::new()
+            .set_status(302)
+            .set_header("Location", "/somewhere/else")
+            .set_header("Content-Type", "application/vnd.demo+json")
+            .set_header("Set-Cookie", "first=1; Path=/|second=2; HttpOnly")
+            .set_header("X-Custom", "custom-value")
+            .set_header("x-stream-id", "stream.100.in")
+            .set_header("x-ttl", "10")
+            .set_body(serde_json::json!({"moved": true}))
+    }
+}
+
 const REST_YAML: &str = r#"
 rest:
   - service: "http.echo"
@@ -191,6 +217,11 @@ rest:
     url: "/api/echo/{user}"
     timeout: 5s
     cors: cors_1
+    headers: header_1
+  - service: "header.probe"
+    methods: ['GET', 'HEAD']
+    url: "/api/headers"
+    timeout: 5s
     headers: header_1
   - service: "trace.probe"
     methods: ['GET']
@@ -286,6 +317,9 @@ async fn server() -> TestServer {
     platform
         .register("api.key.check", Arc::new(ApiKeyCheck), 1)
         .unwrap();
+    platform
+        .register("header.probe", Arc::new(HeaderProbe), 1)
+        .unwrap();
     let addr = automation::start_http_server(&platform).await.unwrap();
     TestServer {
         port: addr.port(),
@@ -333,7 +367,69 @@ async fn http(
     (status, headers, payload.to_string())
 }
 
+/// Raw HTTP exchange keeping the header block verbatim — repeated headers
+/// (Set-Cookie) stay visible as separate lines, unlike the map in `http`.
+async fn http_raw(port: u16, method: &str, path: &str) -> (u16, String, String) {
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("connect");
+    let request =
+        format!("{method} {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    stream.write_all(request.as_bytes()).await.expect("write");
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).await.expect("read");
+    let text = String::from_utf8_lossy(&raw).to_string();
+    let (head, payload) = text.split_once("\r\n\r\n").unwrap_or((text.as_str(), ""));
+    let status: u16 = head
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse().ok())
+        .expect("status code");
+    (status, head.to_lowercase(), payload.to_string())
+}
+
 // ---- tests ----
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn function_response_headers_survive_the_rest_boundary() {
+    let server = server().await;
+    let (status, head, body) = http_raw(server.port, "GET", "/api/headers").await;
+    // envelope status + Location = a working redirect (Java parity)
+    assert_eq!(status, 302);
+    assert!(head.contains("location: /somewhere/else"), "{head}");
+    // function-set content type overrides the body-derived one
+    assert!(
+        head.contains("content-type: application/vnd.demo+json"),
+        "{head}"
+    );
+    // custom header preserved
+    assert!(head.contains("x-custom: custom-value"), "{head}");
+    // "|"-separated cookies become one Set-Cookie line each
+    assert!(head.contains("set-cookie: first=1; path=/"), "{head}");
+    assert!(head.contains("set-cookie: second=2; httponly"), "{head}");
+    // the rest.yaml response transform still applies alongside
+    assert!(head.contains("x-served-by: mercury"), "{head}");
+    // stream metadata is recognized and withheld from the wire (deferral)
+    assert!(!head.contains("x-stream-id"), "{head}");
+    assert!(!head.contains("x-ttl"), "{head}");
+    // the body still rides normally on GET
+    assert!(body.contains("moved"), "{body}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn head_response_carries_headers_but_no_body() {
+    let server = server().await;
+    let (status, head, body) = http_raw(server.port, "HEAD", "/api/headers").await;
+    assert_eq!(status, 302);
+    assert!(head.contains("location: /somewhere/else"), "{head}");
+    // HEAD: the function's content-type override is skipped (Java isHead)
+    assert!(
+        !head.contains("content-type: application/vnd.demo+json"),
+        "{head}"
+    );
+    assert!(body.is_empty(), "HEAD must not carry a body: {body:?}");
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_with_path_query_and_generated_cid() {

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -66,6 +66,7 @@
 | 47 | `describe graph {graph-id}` — a deployed model's contract view (finding #53) + differentiated tutorial purposes (#54); both ports | 2026-07-20 | — | 202 |
 | 48 | outbound HTTPS for the async HTTP client (rustls + OS trust store, `trust_all_cert` parity) — Rust-only parity work | 2026-07-20 | — | 206 |
 | 49 | `/sync` contract gaps (findings #62–#63): dedup bypass for direct RPC + `Syntax:` usage classified as failure; both ports | 2026-07-20 | — | 206 |
+| 50 | parity remediation 1 — REST boundary preserves function response-envelope headers (redirects/cookies/content-type) + envelope header model (case-insensitive get, CR/LF filter) | 2026-07-21 | — | 213 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1334,6 +1335,35 @@ the identical design in both ports (like #40).
   tests** green; branch **`fix/companion-sync-contract-gaps`** pushed for the upstream PR.
 - **Docs:** the sync-envelope contract now states both rules (agent guide bullets +
   `sync_envelope` notes in the catalog); rollups #62/#63 → DONE.
+
+---
+
+## Increment 50 — parity remediation 1: REST response headers (2026-07-21)
+
+First increment of the maintainer-approved parity-remediation program (the verified
+third-party correctness assessment; thread `ot-parity-remediation`). The **Critical**
+finding: the REST boundary dropped every header a function set on its response
+`EventEnvelope`, so redirects (`Location`), cookies, and custom content types never
+reached the HTTP client — Java's `AsyncHttpResponse.updateHeaders` copies them all.
+
+- **REST boundary** (`automation/server.rs`): response-envelope headers now map to HTTP
+  exactly as in Java — `content-type` overrides the body-derived type (lowercased,
+  skipped for HEAD); `set-cookie` splits on the `|` separator into one header line per
+  cookie (`SimpleHttpUtility.setCookies`); `x-stream-id` (with the `stream.*.in` shape) +
+  `x-ttl` are recognized as the response-streaming contract and withheld from the wire
+  (streaming is a documented D10 deferral); everything else joins the response header map,
+  which the rest.yaml response transform then filters (Java `filterHeaders` — content-type
+  and cookies bypass it, as in Java). HEAD responses carry headers but no body.
+- **Envelope header model** (`envelope.rs`, Java `EventEnvelope` parity): `header()` falls
+  back to a case-insensitive scan; `set_header()` filters CR/LF from values (the
+  header-injection guard).
+- **Tests:** `function_response_headers_survive_the_rest_boundary` +
+  `head_response_carries_headers_but_no_body` (raw-socket reads so repeated `Set-Cookie`
+  lines stay visible) in `rest_automation.rs`; envelope unit tests in `event_bus.rs`.
+  Workspace 213 tests / clippy 0 / fmt clean.
+- Remaining header-model item (tracked in the thread): Java derives a fallback response
+  content type from the request `Accept` header (`updateContentType`) and renders the body
+  per that negotiation — the Rust port still derives from the body shape alone.
 
 ---
 

--- a/docs/design/platform-core-port.md
+++ b/docs/design/platform-core-port.md
@@ -413,9 +413,19 @@ authoritative schema is the Java project's own `docs/guides/rest-automation/rest
   declare `application/json` to get a parsed map, which is why the canonical POST-provider
   fixtures map `text(application/json) -> header.content-type`
   → `po.request(service, timeout)` → envelope mapped back (status; body: map/list→JSON,
-  text→text/plain, bytes→octet-stream; response header transforms + CORS headers). Errors are
-  the Java JSON shape `{status, message, type:"error"}`; timeout → 408; OPTIONS preflight →
-  CORS options headers.
+  text→text/plain, bytes→octet-stream; response header transforms + CORS headers).
+  **Function response-envelope headers are preserved** (increment 50, Java
+  `AsyncHttpResponse.updateHeaders` parity): `content-type` overrides the body-derived type
+  (lowercased; skipped for HEAD), `set-cookie` splits on `|` into one header line per cookie,
+  `x-stream-id` (`stream.*.in` shape) + `x-ttl` are recognized as the response-streaming
+  contract and **withheld** (streaming stays deferred), all other headers join the response
+  map that the rest.yaml response transform filters (content-type/cookies bypass the filter,
+  as in Java). HEAD responses carry headers, never a body. Envelope header model matches Java
+  `EventEnvelope`: case-insensitive `header()` lookup, CR/LF filtered on `set_header()`.
+  Still open (tracked in `ot-parity-remediation`): Java's `Accept`-based fallback content
+  negotiation (`updateContentType`) — the Rust port derives the fallback from body shape only.
+  Errors are the Java JSON shape `{status, message, type:"error"}`; timeout → 408; OPTIONS
+  preflight → CORS options headers.
 - **The edge starts traces** (the piece increments 5 was built for): a **business
   correlation-id is always ensured** (per-entry/global header, else generated) — independent
   of tracing — set on the envelope and exposed via the reserved `my_correlation_id` request

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-030938)
+- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-032558)
 - **last_review:** 2026-07-21 | through 2026-07-21-021231
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -500,10 +500,15 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   ports identical; wildcard grammar)**. Maintainer reviewed and directed remediation —
   "serious side effects... affect functional integrity such as telemetry and response
   headers." Fix order (amended from the report): **(1) CRITICAL: REST boundary drops
-  function response-envelope headers** (`server.rs:342-353` never reads `result.headers()`;
-  Java `AsyncHttpResponse.updateHeaders` copies all + content-type override + Set-Cookie —
-  design together with the header-model questions of case-insensitive lookup/CR-LF
-  sanitize/multi-Set-Cookie); (2) trace continuity: zero-traced routes drop trace state
+  function response-envelope headers — DONE 2026-07-21 (increment 50):** the boundary now
+  mirrors Java `AsyncHttpResponse.updateHeaders` (content-type override, `|`-separated
+  multi-Set-Cookie, `x-stream-id`/`x-ttl` withheld as the deferred streaming contract,
+  rest.yaml response filter on the merged map, HEAD = headers-no-body) + the F9 envelope
+  header model (case-insensitive `header()`, CR/LF-filtered `set_header()`); 4 new tests
+  (raw-socket multi-Set-Cookie assertions); workspace 213/clippy 0/fmt. NEW sub-item
+  discovered while porting: Java's `Accept`-based fallback content negotiation
+  (`updateContentType` + `handleContent` body rendering) remains unported — Rust derives
+  the fallback content type from body shape only (queued with item 7); (2) trace continuity: zero-traced routes drop trace state
   (Java suppresses telemetry only), scheduled sends capture no context (Java `touch()` at
   schedule time), ambient trace overwrites explicit id/path (Java fills-if-absent); (3)
   Event Script safety: dynamic-index array cap `max.model.array.size` missing (own docs

--- a/memory/sessions/2026-07-21-032558.md
+++ b/memory/sessions/2026-07-21-032558.md
@@ -1,0 +1,43 @@
+# Session (2026-07-21T03:25:58.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Increment 50 — parity remediation 1 (the CRITICAL finding): the REST boundary now
+preserves function response-envelope headers**, mirroring Java
+`AsyncHttpResponse.updateHeaders`:
+
+- `automation/server.rs`: envelope headers map to HTTP — `content-type` overrides the
+  body-derived type (lowercased, skipped for HEAD); `set-cookie` splits on the `|`
+  separator into one header line per cookie (Java `SimpleHttpUtility.setCookies`);
+  `x-stream-id` (`stream.*.in` shape) + `x-ttl` recognized as the response-streaming
+  contract and withheld from the wire (streaming is a documented D10 deferral); all other
+  headers join the response map, filtered by the rest.yaml response transform
+  (content-type/cookies bypass the filter, as in Java). HEAD responses carry headers,
+  never a body.
+- `envelope.rs` (F9 header model): `header()` falls back to a case-insensitive scan;
+  `set_header()` filters CR/LF (header-injection guard) — both Java `EventEnvelope`
+  parity.
+- Tests: `function_response_headers_survive_the_rest_boundary` +
+  `head_response_carries_headers_but_no_body` (raw-socket reads keep repeated
+  `Set-Cookie` lines visible) in `rest_automation.rs`; 2 envelope unit tests in
+  `event_bus.rs`. Workspace 213 tests green / clippy 0 / fmt clean.
+- Docs: `INCREMENTS.md` increment-50 row + section; `platform-core-port.md` D10 response
+  mapping updated (and the open `Accept`-negotiation gap noted).
+
+**New sub-item discovered:** Java's `Accept`-based fallback content negotiation
+(`updateContentType` + `handleContent` rendering) is unported — Rust derives the fallback
+content type from body shape only. Queued in [[ot-parity-remediation]] with item 7.
+
+Java references verified during design: `AsyncHttpResponse.updateHeaders` /
+`updateHeadersAndContentType` (constants `x-stream-id`/`x-ttl`/`stream.`/`.in`),
+`SimpleHttpUtility.setCookies` (`|` separator) / `getHeaderCase` / `filterHeaders`,
+`EventEnvelope.getHeader` (case-insensitive) / `setHeader` (CR/LF filter).
+
+## Memory References
+
+- referenced: ot-parity-remediation (item 1 → DONE; new Accept-negotiation sub-item),
+  port-bottom-up-faithful, conventions-rust-baseline
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

Increment 50 — the REST boundary now maps a function's response-envelope headers onto the
HTTP response, mirroring Java `AsyncHttpResponse.updateHeaders`: `content-type` override
(lowercased, skipped for HEAD), `|`-separated `Set-Cookie` values as one header line each
(`SimpleHttpUtility.setCookies`), `x-stream-id`/`x-ttl` recognized as the response-streaming
contract and withheld (streaming is a documented D10 deferral), all other headers filtered
through the rest.yaml response transform (content-type/cookies bypass it, as in Java), and
HEAD responses carrying headers but no body. The envelope header model gains Java parity
too (finding F9): case-insensitive `header()` lookup and CR/LF-filtered `set_header()`.

## Why

This is the first increment of the maintainer-approved parity remediation
(`ot-parity-remediation`), fixing the verified assessment's one CRITICAL finding: the
boundary never read `result.headers()`, so redirects (`Location`), cookies, and custom
content types set by functions were silently dropped — breaking functional integrity for
any HTTP-facing composable function. Java copies every envelope header with dedicated
handling; the two ports now agree. A follow-up discovered while porting — Java's
`Accept`-based fallback content negotiation — is recorded in the thread, not absorbed here.

Verified: 4 new tests (raw-socket reads keep repeated `Set-Cookie` lines visible; HEAD
semantics; envelope unit tests), workspace 213 tests green, clippy clean, fmt applied.
`INCREMENTS.md` and design doc D10 updated.

Co-Authored-By: Claude Code <noreply@anthropic.com>