### PR TITLE
test(platform-core): fix the event_bus config-singleton init race (CI flake)

### DIFF
--- a/crates/platform-core/tests/event_bus.rs
+++ b/crates/platform-core/tests/event_bus.rs
@@ -31,10 +31,14 @@ use platform_core::{
 use serde::{Deserialize, Serialize};
 use std::sync::Once;
 
-/// Every test calls this first: `Platform::register` reads configuration (the
-/// dispatch mailbox size, the elastic queue's segment size and holding area),
-/// so the resource root, spill-dir override, and singleton init must be fixed
-/// before the first registration in this process.
+/// Every test that can reach the process-wide config singleton calls this
+/// first — and the reach is wider than it looks: `Platform::register` reads
+/// configuration (dispatch mailbox size, the elastic queue's segment size and
+/// holding area), and `EventEnvelope::to_bytes()` reads
+/// `serializer.null.transport` through the same singleton. Tests run in
+/// parallel threads, so a test that touches the singleton without this setup
+/// races the `Once` block and can freeze the config WITHOUT the
+/// `tests/resources` root (the `demo.instances` CI flake, fixed 2026-07-21).
 fn setup_config() {
     static INIT: Once = Once::new();
     INIT.call_once(|| {
@@ -143,6 +147,9 @@ struct Pojo {
 
 #[test]
 fn envelope_round_trips_through_msgpack() {
+    // to_bytes() reaches the config singleton (serializer.null.transport) —
+    // without this call it races the other tests' Once init (see setup_config)
+    setup_config();
     let pojo = Pojo {
         name: "mercury".to_string(),
         count: 42,

--- a/memory/sessions/2026-07-21-041845.md
+++ b/memory/sessions/2026-07-21-041845.md
@@ -1,0 +1,22 @@
+# Session (2026-07-21T04:18:45.000Z)
+
+**Agent:** Claude Code
+
+*Lightweight session.* Fixed the maintainer-reported CI flake in
+`crates/platform-core/tests/event_bus.rs` (`worker_count_can_come_from_configuration`
+panicking on `demo.instances`): an init-order race on the process-wide config singleton —
+`envelope_round_trips_through_msgpack` skipped `setup_config()` but reaches
+`AppConfigReader::get_instance()` transitively (`to_bytes()` → `strip_nulls` →
+`null_transport()`), so on slow 2-core CI runners it could freeze the singleton WITHOUT the
+`tests/resources` root before any `setup_config()` test ran. Fix: that test now calls
+`setup_config()` too; the helper's doc comment states the widened constraint (any test that
+can transitively reach the singleton). **Red/green proven deterministically** with
+`--test-threads=1` (declaration order forces the race): old code fails with the exact CI
+panic, fixed code passes 14/14. Stress: 60 fresh-process runs green. Workspace green,
+clippy 0, fmt clean.
+
+## Memory References
+
+(none)
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

`envelope_round_trips_through_msgpack` now calls `setup_config()` like every other test in
`event_bus.rs`, and the helper's doc comment states the widened constraint: any test that
can **transitively** reach the process-wide config singleton must call it first — the reach
includes envelope serialization (`to_bytes()` → `strip_nulls` → `null_transport()` reads
`serializer.null.transport`), not just `Platform::register`.

## Why

`worker_count_can_come_from_configuration` failed intermittently in CI with
`panicked at event_bus.rs:463: demo.instances in application.yml`. The envelope round-trip
test looked config-free but initializes `AppConfigReader` through the serializer's
null-transport flag; tests run in parallel threads, so on a slow 2-core CI runner it could
win the `OnceLock` init race and freeze the config **without** the `tests/resources` root —
leaving the fixture `application.yml` (`demo.instances: 3`) unloaded for every test after it.
Fast local machines rarely hit the window, which is why the flake lived in CI only.

Red/green proven deterministically: `--test-threads=1` forces declaration order (the
envelope test always initializes first), where the old code reproduces the exact CI panic
on every run and the fixed code passes 14/14. Stress-validated with 60 fresh-process runs
(2-thread and default parallelism), all green. Workspace green, clippy clean, fmt applied.

Co-Authored-By: Claude Code <noreply@anthropic.com>