### PR TITLE
fix(platform-core): trace continuity through zero-traced routes, scheduled sends, and explicit identities (increment 51)

### DIFF
--- a/crates/platform-core/src/platform.rs
+++ b/crates/platform-core/src/platform.rs
@@ -483,20 +483,27 @@ async fn worker_loop(
         let event_from = event.from().map(str::to_string);
         // trace bracket (Java WorkerHandler): a traced request carries trace id
         // + path; this execution gets its own span, parented to the sender's
-        // span carried on the envelope
-        let trace_state = if !zero_traced {
-            match (event.trace_id(), event.trace_path()) {
-                (Some(trace_id), Some(trace_path)) => Some(TraceState::new(
+        // span carried on the envelope. A ZERO-TRACED route still keeps the
+        // bracket when the incoming event is traced — Java gates only
+        // startTracing + sendTracingInfo on the flag, while the reply and any
+        // nested calls carry the trace onward unconditionally (F3 parity fix,
+        // 2026-07-21) — but the hop emits no telemetry and contributes no span.
+        // Deliberate minor divergence: the hop's own JSON log lines still
+        // resolve trace tokens (Java registers no log context here); log-only,
+        // nothing changes on the wire.
+        let trace_state = match (event.trace_id(), event.trace_path()) {
+            (Some(trace_id), Some(trace_path)) => {
+                let mut state = TraceState::new(
                     &route,
                     trace_id,
                     trace_path,
                     event.span_id(),
                     event.correlation_id(),
-                )),
-                _ => None,
+                );
+                state.zero_traced = zero_traced;
+                Some(state)
             }
-        } else {
-            None
+            _ => None,
         };
         let (result, finished_state) =
             trace::run_scoped(trace_state, function.handle_event(headers, event, instance)).await;
@@ -507,12 +514,18 @@ async fn worker_loop(
         // reports the same value rather than a raw full-precision float.
         let elapsed_ms = started.elapsed().as_secs_f32() * 1000.0;
         let elapsed_ms = (elapsed_ms.max(0.0) * 1000.0).round() / 1000.0;
-        // propagate the trace to the response so the next hop chains correctly
-        let trace_triple = finished_state
-            .as_ref()
-            .map(|s| (s.trace_id.clone(), s.trace_path.clone(), s.span_id.clone()));
-        // send the performance-metrics dataset to the telemetry sink
-        if let Some(state) = finished_state {
+        // propagate the trace to the response so the next hop chains correctly;
+        // a zero-traced hop contributes no span of its own (Java parity)
+        let trace_triple = finished_state.as_ref().map(|s| {
+            (
+                s.trace_id.clone(),
+                s.trace_path.clone(),
+                (!s.zero_traced).then(|| s.span_id.clone()),
+            )
+        });
+        // send the performance-metrics dataset to the telemetry sink — never
+        // for a zero-traced route (Java: sendTracingInfo is gated on tracing)
+        if let Some(state) = finished_state.filter(|s| !s.zero_traced) {
             emit_telemetry(&registry, &route, event_from, &state, &result, elapsed_ms).await;
         }
         match (reply_to, result) {
@@ -534,7 +547,9 @@ async fn worker_loop(
                 response.set_exec_time_internal(elapsed_ms);
                 if let Some((trace_id, trace_path, span_id)) = trace_triple {
                     response.set_trace_internal(&trace_id, &trace_path);
-                    response.set_span_id_internal(&span_id);
+                    if let Some(span_id) = span_id {
+                        response.set_span_id_internal(&span_id);
+                    }
                 }
                 // a lightweight RPC inbox (Java AsyncInbox parity) bypasses the
                 // route machinery entirely — complete the caller's oneshot

--- a/crates/platform-core/src/post_office.rs
+++ b/crates/platform-core/src/post_office.rs
@@ -32,10 +32,13 @@ use crate::function::AppError;
 use crate::platform::Platform;
 use crate::trace;
 
-/// Stamp the current trace context onto an outbound event (Java parity:
-/// the sender's PostOffice propagates its trace and carries its span id so
-/// the receiver knows its parent span; the business correlation-id follows
-/// the request to the next touch point when the event has none of its own).
+/// Stamp the current trace context onto an outbound event — the mirror of
+/// Java `PostOffice.touch()`: trace id and path are filled **only when the
+/// event has none of its own** (an explicitly supplied trace identity always
+/// wins — F8 parity fix, 2026-07-21); the span id is stamped unconditionally
+/// so the receiver knows its parent span — except inside a zero-traced hop,
+/// which owns no span (Java: no live TraceInfo there); `from` and the
+/// business correlation-id follow the request when absent.
 /// No-op outside a trace bracket.
 fn apply_current_trace(mut event: EventEnvelope) -> EventEnvelope {
     let snapshot = trace::with_current(|state| {
@@ -45,12 +48,17 @@ fn apply_current_trace(mut event: EventEnvelope) -> EventEnvelope {
             state.trace_path.clone(),
             state.span_id.clone(),
             state.cid.clone(),
+            state.zero_traced,
         )
     });
-    if let Some((route, trace_id, trace_path, span_id, cid)) = snapshot {
-        event = event
-            .set_trace(&trace_id, &trace_path)
-            .set_span_id(&span_id);
+    if let Some((route, trace_id, trace_path, span_id, cid, zero_traced)) = snapshot {
+        // Java touch(): each trace field fills independently, if-absent
+        let effective_id = event.trace_id().unwrap_or(&trace_id).to_string();
+        let effective_path = event.trace_path().unwrap_or(&trace_path).to_string();
+        event = event.set_trace(&effective_id, &effective_path);
+        if !zero_traced {
+            event = event.set_span_id(&span_id);
+        }
         if event.from().is_none() {
             event = event.set_from(&route);
         }
@@ -109,6 +117,10 @@ impl PostOffice {
     /// abortable tokio task (map-don't-mirror; increment E-3 — built for the
     /// event-script flow TTL watcher).
     pub fn send_later(&self, event: EventEnvelope, delay: std::time::Duration) -> String {
+        // capture the sender/trace/correlation context NOW (Java sendLater
+        // wraps the event in touch() before the timer) — the spawned timer
+        // task does not inherit the task-local trace bracket (F7 parity fix)
+        let event = apply_current_trace(event);
         let timer_id = uuid::Uuid::new_v4().simple().to_string();
         let platform = self.platform.clone();
         let id_for_task = timer_id.clone();

--- a/crates/platform-core/src/trace.rs
+++ b/crates/platform-core/src/trace.rs
@@ -72,6 +72,12 @@ pub struct TraceState {
     /// Developer-supplied log-context key-values
     /// (`PostOffice::update_context`) — flows to the application log only.
     pub custom_log_keys: HashMap<String, serde_json::Value>,
+    /// True on a zero-traced route: the trace CONTEXT still flows (replies and
+    /// nested calls keep the trace id/path — Java propagates them from the
+    /// incoming event unconditionally), but this hop emits no telemetry and
+    /// mints no span into the chain (Java never calls `startTracing`, so
+    /// `touch()` finds no TraceInfo and stamps no span id).
+    pub zero_traced: bool,
 }
 
 impl TraceState {
@@ -92,6 +98,7 @@ impl TraceState {
             start_time: iso8601_utc_now(),
             annotations: HashMap::new(),
             custom_log_keys: HashMap::new(),
+            zero_traced: false,
         }
     }
 

--- a/crates/platform-core/tests/annotations.rs
+++ b/crates/platform-core/tests/annotations.rs
@@ -111,8 +111,10 @@ impl ComposableFunction for ZeroTracedFn {
         _instance: usize,
     ) -> Result<EventEnvelope, AppError> {
         ZERO_TRACED_RAN.store(true, Ordering::SeqCst);
+        // the bracket exists for CONTINUITY (increment 51, Java parity: the
+        // function still sees the trace context) but is telemetry-suppressed
         ZERO_TRACED_HAD_TRACE.store(
-            trace::with_current(|_| true).unwrap_or(false),
+            trace::with_current(|state| !state.zero_traced).unwrap_or(false),
             Ordering::SeqCst,
         );
         EventEnvelope::new().set_body("ok")
@@ -327,8 +329,10 @@ async fn annotation_macros_end_to_end() {
         .expect("untyped rpc");
     assert_eq!(reply.body_as::<String>().expect("untyped reply"), "hello");
 
-    // the stacked #[zero_tracing] marker suppresses the trace bracket even
-    // for a traced request
+    // the stacked #[zero_tracing] marker suppresses the hop's TELEMETRY
+    // (increment 51, Java parity): the trace context still flows through for
+    // continuity, marked zero_traced so no dataset is emitted and no span
+    // joins the chain
     let reply = po
         .request(
             EventEnvelope::new()
@@ -344,7 +348,7 @@ async fn annotation_macros_end_to_end() {
     assert!(ZERO_TRACED_RAN.load(Ordering::SeqCst));
     assert!(
         !ZERO_TRACED_HAD_TRACE.load(Ordering::SeqCst),
-        "zero-traced route must not execute inside a trace bracket"
+        "zero-traced route must run with a telemetry-suppressed trace bracket"
     );
 
     // the stacked #[event_interceptor] marker: the manual reply arrives and

--- a/crates/platform-core/tests/telemetry.rs
+++ b/crates/platform-core/tests/telemetry.rs
@@ -329,3 +329,253 @@ context:
     assert!(!rendered.contains_key("bogus"));
     std::fs::remove_dir_all(&dir).ok();
 }
+
+// ---- increment 51: trace continuity (parity findings F3 / F7 / F8) ----
+
+/// (trace id, trace path, span id) as observed on one delivered event.
+type SeenTraces = Arc<Mutex<Vec<(Option<String>, Option<String>, Option<String>)>>>;
+
+/// Records the trace identity each delivered event carries.
+struct TraceRecorder {
+    seen: SeenTraces,
+}
+
+#[async_trait]
+impl ComposableFunction for TraceRecorder {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        self.seen.lock().expect("recorder mutex").push((
+            input.trace_id().map(str::to_string),
+            input.trace_path().map(str::to_string),
+            input.span_id().map(str::to_string),
+        ));
+        EventEnvelope::new().set_body("ok")
+    }
+}
+
+/// A zero-traced middle hop: calls the next route and returns its reply.
+struct ZeroTracedRelay {
+    platform: Platform,
+    next: &'static str,
+}
+
+#[async_trait]
+impl ComposableFunction for ZeroTracedRelay {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        _input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let po = PostOffice::new(&self.platform);
+        let request = EventEnvelope::new().set_to(self.next).set_body("relay")?;
+        po.request(request, Duration::from_secs(2)).await
+    }
+}
+
+/// F3: a zero-traced route suppresses only its own telemetry — the trace
+/// context still flows to nested calls and back on the reply (Java gates
+/// startTracing/sendTracingInfo on the flag, never the propagation).
+#[tokio::test]
+async fn zero_traced_route_preserves_trace_continuity() {
+    setup_config();
+    let (platform, datasets) = capture_platform();
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    platform
+        .register(
+            "v1.trace.recorder",
+            Arc::new(TraceRecorder { seen: seen.clone() }),
+            1,
+        )
+        .unwrap();
+    platform
+        .register_with_options(
+            "v1.zero.relay",
+            Arc::new(ZeroTracedRelay {
+                platform: platform.clone(),
+                next: "v1.trace.recorder",
+            }),
+            1,
+            platform_core::FunctionOptions {
+                zero_traced: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let po = PostOffice::new(&platform);
+    let response = po
+        .request(
+            EventEnvelope::new()
+                .set_to("v1.zero.relay")
+                .set_trace("trace-through-zero", "GET /zero")
+                .set_body("go")
+                .unwrap(),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+    // the reply from the zero-traced hop still carries the trace identity
+    assert_eq!(response.trace_id(), Some("trace-through-zero"));
+    assert_eq!(response.trace_path(), Some("GET /zero"));
+    // the nested call saw the same trace id/path — with NO span from the
+    // zero-traced hop (it owns no span, Java parity)
+    let recorded = seen.lock().expect("recorder mutex").clone();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].0.as_deref(), Some("trace-through-zero"));
+    assert_eq!(recorded[0].1.as_deref(), Some("GET /zero"));
+    assert_eq!(recorded[0].2, None, "zero-traced hop must not mint a span");
+    // exactly ONE telemetry dataset: the recorder's own execution — the
+    // zero-traced relay emitted none
+    let all = wait_for_datasets(&datasets, 1).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let all_after = datasets.lock().expect("capture mutex").clone();
+    assert_eq!(all_after.len(), all.len(), "no late datasets expected");
+    assert!(all_after
+        .iter()
+        .all(|d| trace_of(d)["service"] == "v1.trace.recorder"));
+}
+
+/// A function that schedules a delayed send and returns immediately — the
+/// timer fires long after the trace bracket is gone.
+struct Scheduler {
+    platform: Platform,
+}
+
+#[async_trait]
+impl ComposableFunction for Scheduler {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        _input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let po = PostOffice::new(&self.platform);
+        let event = EventEnvelope::new()
+            .set_to("v1.trace.recorder.later")
+            .set_body("later")?;
+        po.send_later(event, Duration::from_millis(50));
+        EventEnvelope::new().set_body("scheduled")
+    }
+}
+
+/// F7: send_later captures the sender's trace context AT SCHEDULING TIME
+/// (Java sendLater wraps the event in touch() before the timer).
+#[tokio::test]
+async fn scheduled_send_captures_context_at_schedule_time() {
+    setup_config();
+    let (platform, _datasets) = capture_platform();
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    platform
+        .register(
+            "v1.trace.recorder.later",
+            Arc::new(TraceRecorder { seen: seen.clone() }),
+            1,
+        )
+        .unwrap();
+    platform
+        .register(
+            "v1.scheduler",
+            Arc::new(Scheduler {
+                platform: platform.clone(),
+            }),
+            1,
+        )
+        .unwrap();
+    let po = PostOffice::new(&platform);
+    let _ = po
+        .request(
+            EventEnvelope::new()
+                .set_to("v1.scheduler")
+                .set_trace("trace-scheduled", "GET /later")
+                .set_body("go")
+                .unwrap(),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+    // wait for the timer to fire and the recorder to run
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    while seen.lock().expect("recorder mutex").is_empty() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "scheduled event never arrived"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let recorded = seen.lock().expect("recorder mutex").clone();
+    assert_eq!(recorded[0].0.as_deref(), Some("trace-scheduled"));
+    assert_eq!(recorded[0].1.as_deref(), Some("GET /later"));
+    assert!(recorded[0].2.is_some(), "scheduler's span rides the event");
+}
+
+/// Sends one event carrying an EXPLICIT trace identity from inside a bracket.
+struct ExplicitSender {
+    platform: Platform,
+}
+
+#[async_trait]
+impl ComposableFunction for ExplicitSender {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        _input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let po = PostOffice::new(&self.platform);
+        let request = EventEnvelope::new()
+            .set_to("v1.trace.recorder.explicit")
+            .set_trace("explicit-id", "EXPLICIT /path")
+            .set_body("x")?;
+        let _ = po.request(request, Duration::from_secs(2)).await?;
+        EventEnvelope::new().set_body("sent")
+    }
+}
+
+/// F8: an explicitly supplied trace identity survives the ambient bracket
+/// (Java touch() fills trace id/path only when absent).
+#[tokio::test]
+async fn explicit_trace_identity_survives_ambient_bracket() {
+    setup_config();
+    let (platform, _datasets) = capture_platform();
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    platform
+        .register(
+            "v1.trace.recorder.explicit",
+            Arc::new(TraceRecorder { seen: seen.clone() }),
+            1,
+        )
+        .unwrap();
+    platform
+        .register(
+            "v1.explicit.sender",
+            Arc::new(ExplicitSender {
+                platform: platform.clone(),
+            }),
+            1,
+        )
+        .unwrap();
+    let po = PostOffice::new(&platform);
+    let _ = po
+        .request(
+            EventEnvelope::new()
+                .set_to("v1.explicit.sender")
+                .set_trace("ambient-id", "GET /ambient")
+                .set_body("go")
+                .unwrap(),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+    let recorded = seen.lock().expect("recorder mutex").clone();
+    assert_eq!(recorded.len(), 1);
+    // the explicit identity won; the ambient bracket did not overwrite it
+    assert_eq!(recorded[0].0.as_deref(), Some("explicit-id"));
+    assert_eq!(recorded[0].1.as_deref(), Some("EXPLICIT /path"));
+    // the sender's span still rides the event (Java: span is stamped
+    // unconditionally so the receiver knows its parent)
+    assert!(recorded[0].2.is_some());
+}

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -67,6 +67,7 @@
 | 48 | outbound HTTPS for the async HTTP client (rustls + OS trust store, `trust_all_cert` parity) — Rust-only parity work | 2026-07-20 | — | 206 |
 | 49 | `/sync` contract gaps (findings #62–#63): dedup bypass for direct RPC + `Syntax:` usage classified as failure; both ports | 2026-07-20 | — | 206 |
 | 50 | parity remediation 1 — REST boundary preserves function response-envelope headers (redirects/cookies/content-type) + envelope header model (case-insensitive get, CR/LF filter) | 2026-07-21 | — | 213 |
+| 51 | parity remediation 2 — trace continuity: zero-traced routes keep the trace flowing (telemetry-only suppression), send_later captures context at schedule time, explicit trace identity wins over the ambient bracket | 2026-07-21 | — | 216 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1364,6 +1365,37 @@ reached the HTTP client — Java's `AsyncHttpResponse.updateHeaders` copies them
 - Remaining header-model item (tracked in the thread): Java derives a fallback response
   content type from the request `Accept` header (`updateContentType`) and renders the body
   per that negotiation — the Rust port still derives from the body shape alone.
+
+---
+
+## Increment 51 — parity remediation 2: trace continuity (2026-07-21)
+
+Second increment of the parity-remediation program — the telemetry half of the
+maintainer's functional-integrity concern. Three verified findings fixed, each mirrored
+against the Java source (`WorkerHandler` + `PostOffice.touch()`):
+
+- **F3 (High) — zero-traced routes no longer break the trace chain.** Java gates only
+  `startTracing` + `sendTracingInfo` on the tracing flag; the reply and nested calls carry
+  the incoming trace unconditionally. The Rust worker now keeps the trace bracket on a
+  zero-traced hop (marked `TraceState.zero_traced`): the trace id/path flow to the reply
+  and to nested calls, while the hop emits **no telemetry** and mints **no span** into the
+  chain (Java: no `TraceInfo` exists, so `touch()` stamps no span). Deliberate log-only
+  divergence documented in the design doc: the hop's own JSON log lines resolve trace
+  tokens.
+- **F7 (Medium) — `send_later` captures context at scheduling time.** Java `sendLater`
+  wraps the event in `touch()` before the timer; the Rust spawned timer task inherits no
+  task-local bracket, so the capture now happens before the spawn.
+- **F8 (Medium) — an explicit trace identity survives the ambient bracket.**
+  `apply_current_trace` is now the exact mirror of Java `touch()`: trace id and path fill
+  independently, only-if-absent; the span id stays unconditional (both ports overwrite it).
+  The doc comment that wrongly claimed "Java parity" for overwrite semantics is corrected
+  (no-silent-divergence meta-fix).
+- **Tests:** 3 new in `telemetry.rs` — `zero_traced_route_preserves_trace_continuity`
+  (reply + nested trace, no span from the hop, exactly one dataset),
+  `scheduled_send_captures_context_at_schedule_time`,
+  `explicit_trace_identity_survives_ambient_bracket` — **red/green-verified** (all three
+  fail on the pre-fix source). `annotations.rs` updated to the corrected contract (the
+  bracket exists but is telemetry-suppressed). Workspace 216 tests / clippy 0 / fmt.
 
 ---
 

--- a/docs/design/platform-core-port.md
+++ b/docs/design/platform-core-port.md
@@ -344,10 +344,19 @@ automation.)* Port of the `Telemetry` service, the trace bracket in `WorkerHandl
   around the invocation — torn down when the function returns, same spawn/`Mono`-completion
   boundary as Java. Zero-traced routes: the telemetry plumbing, `inbox.*` (Java's AsyncInbox
   bypasses ServiceQueue), and `skip.rpc.tracing` (default `async.http.request`, verbatim).
-- **Automatic propagation**: `PostOffice::send`/`request` inside a trace stamp the outbound
-  event with trace id/path, this span (→ receiver's parent), sender route, and the
-  **business correlation-id** when the event carries none — cid is a separate concern from
-  the trace id, readable via `my_correlation_id()`. Responses carry the trace back
+  **A zero-traced hop keeps the bracket for CONTINUITY** (increment 51, parity F3): Java
+  gates only `startTracing`/`sendTracingInfo` on the flag — the trace context still flows
+  to replies and nested calls; the hop emits no telemetry and mints no span into the chain
+  (`TraceState.zero_traced`). Deliberate log-only divergence: the hop's own JSON log lines
+  resolve trace tokens (Java registers no log context there); nothing changes on the wire.
+- **Automatic propagation** (Java `PostOffice.touch()`, exact since increment 51 —
+  parity F7/F8): `PostOffice::send`/`request` inside a trace **fill** the outbound event's
+  trace id/path **only when absent** (an explicit trace identity always wins), stamp this
+  span unconditionally (→ receiver's parent; withheld inside a zero-traced hop), sender
+  route, and the **business correlation-id** when the event carries none — cid is a
+  separate concern from the trace id, readable via `my_correlation_id()`. `send_later`
+  captures the whole context **at scheduling time** (Java wraps in `touch()` before the
+  timer; the spawned timer task inherits no task-local bracket). Responses carry the trace back
   (applyTraceContext parity).
 - **`Telemetry` service** (`distributed.tracing`, registered by the essential-services
   phase): logs each span dataset `{trace:{id, span_id, parent_span_id, service, path, from,

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-032558)
+- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-044626)
 - **last_review:** 2026-07-21 | through 2026-07-21-021231
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -68,7 +68,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Rust layer by layer, foundation → UI (platform-core, then event-script, then active
   knowledge graph), preserving the Java project's behavior. The Java repo is the canonical
   spec (map, don't mirror).
-  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-20 | uses: 59 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 62 | tier: active | origin: 2026-07-15-215538.md -->
 ## Conventions
 
 > Established with the first code (increment 1, 2026-07-15); enforced from the first commit.
@@ -92,7 +92,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   2026-07-16): annotated functions + `platform_core::auto_start_main!();` with the app's
   `resources/` beside its `Cargo.toml` — never cargo examples inside a library crate.
   Event-script and knowledge-graph demos land as sibling `examples/<name>/` crates.
-  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-20 | uses: 58 | tier: active | origin: 2026-07-15-224707.md -->
+  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 61 | tier: active | origin: 2026-07-15-224707.md -->
 
 ## Open Threads
 
@@ -334,7 +334,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   history intact).
   Thereafter the regular PR process applies (no more direct pushes to main). The private
   R&D repo (acn-ericlaw/mercury) freezes as the prototyping archive. → serves: vision-mercury
-  <!-- id: bp-graduate-to-accenture | created: 2026-07-15 | last_used: 2026-07-20 | uses: 5 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: bp-graduate-to-accenture | created: 2026-07-15 | last_used: 2026-07-20 | uses: 5 | tier: archive-candidate | origin: 2026-07-15-215538.md -->
 - [ ] **(blueprint)** **Synchronous AI-companion feedback** — make the companion a real AI *tool*, not
   a write-then-poll bus. The current `POST /api/companion/{id}` is fire-and-forget (`{status:accepted}`);
   command outcome + errors stream WS-only, so an AI caller is blind (Tut-4: HTTP 200 while the run had
@@ -396,7 +396,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   bridge over async transports). This is also why HTTP config keys keep their `http.` prefix
   (connector counterparts arrive later). Vision non-goals + instructions + the public
   `docs/background/port-scope.md` all updated to the refined wording. → serves: vision-mercury
-  <!-- id: bp-kafka-connectors-backlog | created: 2026-07-20 | last_used: 2026-07-20 | uses: 1 | tier: working | origin: 2026-07-20-030615.md -->
+  <!-- id: bp-kafka-connectors-backlog | created: 2026-07-20 | last_used: 2026-07-21 | uses: 2 | tier: working | origin: 2026-07-20-030615.md -->
 
 - [x] **`/sync` contract gaps (findings #62–#63) — FIXED 2026-07-20 (increment 49, BOTH
   ports).** `/sync` marks its dispatch `direct` → the 1s dedup guard does not apply
@@ -458,7 +458,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   port notes. Validation: a fresh-agent drive against the JAVA Playground from the
   back-ported docs alone. Java human-doc bugs also parked: flow-schema `error.status` →
   engine's `error.code`. → serves: vision-mercury
-  <!-- id: ot-java-ai-docs-backport | created: 2026-07-20 | last_used: 2026-07-20 | uses: 4 | tier: active | origin: 2026-07-20-163856.md -->
+  <!-- id: ot-java-ai-docs-backport | created: 2026-07-20 | last_used: 2026-07-20 | uses: 4 | tier: archive-candidate | origin: 2026-07-20-163856.md -->
 
 - [x] **`describe graph` trailing-`]` in the derived surface — CLOSED 2026-07-21: Java fix
   MERGED (PR [#206](https://github.com/Accenture/mercury-composable/pull/206), 2026-07-20 —
@@ -508,9 +508,13 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   (raw-socket multi-Set-Cookie assertions); workspace 213/clippy 0/fmt. NEW sub-item
   discovered while porting: Java's `Accept`-based fallback content negotiation
   (`updateContentType` + `handleContent` body rendering) remains unported — Rust derives
-  the fallback content type from body shape only (queued with item 7); (2) trace continuity: zero-traced routes drop trace state
-  (Java suppresses telemetry only), scheduled sends capture no context (Java `touch()` at
-  schedule time), ambient trace overwrites explicit id/path (Java fills-if-absent); (3)
+  the fallback content type from body shape only (queued with item 7); (2) trace continuity — DONE
+  2026-07-21 (increment 51): zero-traced hops keep a telemetry-suppressed bracket (trace
+  flows to replies + nested calls, no dataset, no span — Java gates only
+  startTracing/sendTracingInfo), `send_later` captures context at schedule time (Java
+  `touch()` pre-timer), `apply_current_trace` = exact `touch()` mirror (trace id/path
+  fill-if-absent, span unconditional; F8 false parity comment fixed); 3 red/green tests in
+  telemetry.rs + annotations.rs contract update; workspace 216/clippy 0/fmt; (3)
   Event Script safety: dynamic-index array cap `max.model.array.size` missing (own docs
   contradict: syntax.md claims it, configuration-reference.md says not read), flow-launch
   `body` precondition missing; (4) date/time plugins: full Java pattern support + the
@@ -528,7 +532,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   **F2 (null-on-spill) needs a maintainer decision**, not a fix: documented design, but the
   consequence (Nil visibility varies with load) is stated nowhere — document or normalize.
   Full verdict table in the session log. → serves: vision-mercury (faithful port)
-  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 1 | tier: working | origin: 2026-07-21-030938.md -->
+  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 3 | tier: working | origin: 2026-07-21-030938.md -->
 
 - [ ] **(backlog) Port `ManagedCache` (+ sibling `SimpleCache`).** Java platform-core ships
   `org.platformlambda.core.util.ManagedCache` — a named, self-managing TTL+size-bounded

--- a/memory/sessions/2026-07-21-041845.md
+++ b/memory/sessions/2026-07-21-041845.md
@@ -15,6 +15,9 @@ can transitively reach the singleton). **Red/green proven deterministically** wi
 panic, fixed code passes 14/14. Stress: 60 fresh-process runs green. Workspace green,
 clippy 0, fmt clean.
 
+Also: shipped as PR [#154](https://github.com/Accenture/mercury/pull/154), MERGED 2026-07-21
+(true merge `5c4380f3`, CI green).
+
 ## Memory References
 
 (none)

--- a/memory/sessions/2026-07-21-044626.md
+++ b/memory/sessions/2026-07-21-044626.md
@@ -1,0 +1,35 @@
+# Session (2026-07-21T04:46:26.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Increment 51 — parity remediation 2: trace continuity** (findings F3/F7/F8, the
+telemetry half of the maintainer's functional-integrity concern). All three fixed as exact
+mirrors of Java `WorkerHandler` + `PostOffice.touch()`:
+
+- **F3:** the worker keeps the trace bracket on a ZERO-TRACED hop (new
+  `TraceState.zero_traced` flag) — trace id/path flow to the reply and nested calls (Java
+  propagates from the incoming event unconditionally; the flag gates only
+  startTracing/sendTracingInfo), while the hop emits no telemetry and mints no span into
+  the chain (reply/nested span withheld). Deliberate log-only divergence documented (the
+  hop's own JSON log lines resolve trace tokens; Java registers no log context there).
+- **F7:** `send_later` runs `apply_current_trace` at SCHEDULING time (Java `touch()`
+  pre-timer) — the spawned timer task inherits no task-local bracket.
+- **F8:** `apply_current_trace` fills trace id/path independently, only-if-absent (an
+  explicit trace identity wins); span stays unconditional like Java (withheld only inside
+  a zero-traced hop). The false "Java parity" doc comment corrected (meta-fix).
+
+Tests: 3 new in `telemetry.rs`, **red/green-verified via `git stash push -- src`** (all
+three FAIL on pre-fix source, pass after). `annotations.rs` updated to the corrected
+contract — its old assertion ("zero-traced route must not execute inside a trace bracket")
+encoded the pre-parity semantics; now asserts a telemetry-suppressed bracket. Workspace
+216 tests / clippy 0 / fmt. Docs: INCREMENTS.md increment-51 section; design-doc tracing
+section rewritten (zero-traced continuity + touch() fill-if-absent + send_later capture).
+
+## Memory References
+
+- referenced: ot-parity-remediation (item 2 → DONE), port-bottom-up-faithful,
+  conventions-rust-baseline
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

Increment 51 — parity remediation item 2, fixing three verified trace-continuity
divergences as exact mirrors of Java `WorkerHandler` + `PostOffice.touch()`:

- **Zero-traced routes (F3, High):** the worker now keeps the trace bracket on a
  zero-traced hop, marked `TraceState.zero_traced` — the trace id/path flow to the reply
  and to nested calls, while the hop emits **no telemetry** and mints **no span** into the
  chain. Previously the whole trace state was dropped, severing the chain at every
  plumbing hop (e.g. `async.http.request`).
- **Scheduled sends (F7, Medium):** `send_later` captures the sender/trace/correlation
  context **at scheduling time**, since the spawned timer task inherits no task-local
  bracket — Java wraps the event in `touch()` before the timer.
- **Explicit trace identity (F8, Medium):** `apply_current_trace` now fills trace id and
  path independently, **only when absent** — an explicitly supplied identity always wins;
  the span id stays unconditional as in Java, withheld only inside a zero-traced hop. The
  doc comment that wrongly claimed "Java parity" is corrected (no-silent-divergence).

## Why

These are the telemetry-integrity findings from the verified correctness assessment,
called out by the maintainer when approving the remediation ("serious side effects...
affect functional integrity such as telemetry and response headers"). In Java, the
zero-tracing flag gates only `startTracing`/`sendTracingInfo` — never the propagation —
so a Rust deployment lost trace lineage precisely at the hops meant to be invisible.

Verified: 3 new regression tests in `telemetry.rs`, **red/green-proven** (all three fail
on the pre-fix source); `annotations.rs` updated to the corrected contract (its old
assertion encoded the pre-parity semantics). One deliberate log-only divergence documented
in the design doc: a zero-traced hop's own JSON log lines resolve trace tokens. Workspace
216 tests green, clippy clean, fmt applied. `INCREMENTS.md` + design doc D5 tracing
section updated; the remediation thread marks item 2 done.

Co-Authored-By: Claude Code <noreply@anthropic.com>