### PR TITLE
fix(event-script): enforce the max.model.array.size cap and the flow-launch body precondition (increment 52)

### DIFF
--- a/crates/event-script/src/executor.rs
+++ b/crates/event-script/src/executor.rs
@@ -1534,6 +1534,20 @@ fn set_input_rhs(
 /// list indices (`[model.n]` → the resolved integer; a numeric RHS index must
 /// not be negative), and finally the reserved-key re-check on a dynamically
 /// resolved RHS (the compiler cannot see runtime-substituted targets).
+/// Java `TaskExecutor.maxModelArraySize`: the configured ceiling for a
+/// dynamically resolved RHS model index (`max.model.array.size`, default
+/// 1000) — read once, like Java's constructor. Guards only the dynamic
+/// `[model.x]` path; literal numeric indices are uncapped in both engines.
+fn max_model_array_size() -> i32 {
+    static CACHE: OnceLock<i32> = OnceLock::new();
+    *CACHE.get_or_init(|| {
+        str2int(
+            &platform_core::AppConfigReader::get_instance()
+                .get_property_or("max.model.array.size", "1000"),
+        )
+    })
+}
+
 fn substitute_dynamic_index(
     statement: &str,
     source: &MultiLevelMap,
@@ -1560,6 +1574,15 @@ fn substitute_dynamic_index(
                     .map(|v| display(&v))
                     .unwrap_or_else(|| "null".to_string());
                 let n = str2int(&resolved);
+                // Java resolveModelIndex: the configured cap first, then the
+                // negative check (F4 parity fix, 2026-07-21 — unbounded
+                // growth was possible before)
+                if is_rhs && n > max_model_array_size() {
+                    return Err(format!(
+                        "Cannot set RHS to index > {n} that exceeds max {} - {statement}",
+                        max_model_array_size()
+                    ));
+                }
                 if is_rhs && n < 0 {
                     return Err(format!("Cannot set RHS to negative index - {statement}"));
                 }
@@ -1654,6 +1677,7 @@ impl FlowExecutor {
         business_correlation_id: &str,
         trace: Option<(&str, &str)>,
     ) -> Result<(), AppError> {
+        Self::require_body(&dataset)?;
         let po = PostOffice::new(platform);
         po.send(Self::launch_event(
             flow_id,
@@ -1673,12 +1697,26 @@ impl FlowExecutor {
         timeout: Duration,
         trace: Option<(&str, &str)>,
     ) -> Result<EventEnvelope, AppError> {
+        Self::require_body(&dataset)?;
         let po = PostOffice::new(platform);
         po.request(
             Self::launch_event(flow_id, dataset, business_correlation_id, trace),
             timeout,
         )
         .await
+    }
+
+    /// Java `FlowExecutor` precondition (both `launch` and `request`): the
+    /// dataset must carry a top-level `body` key, or the flow never starts —
+    /// a malformed dataset must not execute side effects (F18 parity fix).
+    fn require_body(dataset: &Value) -> Result<(), AppError> {
+        let has_body = matches!(dataset, Value::Map(entries)
+            if entries.iter().any(|(key, _)| key.as_str() == Some("body")));
+        if has_body {
+            Ok(())
+        } else {
+            Err(AppError::new(400, "Missing body in dataset"))
+        }
     }
 
     fn launch_event(

--- a/crates/event-script/tests/compiler.rs
+++ b/crates/event-script/tests/compiler.rs
@@ -111,6 +111,8 @@ fn loaded_flow_set_matches_the_java_engine() {
         // from more-flows.yaml: the parser fixtures that compile.
         // dynamic-reserved-key: the reserved-key RHS is dynamic, checked at runtime
         "dynamic-reserved-key",
+        // dynamic-index-cap: the max.model.array.size cap is dynamic, checked at runtime
+        "dynamic-index-cap",
         // 23/25/26/27: an invalid mapping drops the TASK, the flow still loads
         "parser-test-23",
         "parser-test-25",

--- a/crates/event-script/tests/flow_runtime.rs
+++ b/crates/event-script/tests/flow_runtime.rs
@@ -602,6 +602,35 @@ async fn flows_run_end_to_end_like_java() {
         "the error should name the key: {body}"
     );
 
+    // --- dynamic RHS index above max.model.array.size is rejected at runtime
+    // (increment 52, parity F4 — Java resolveModelIndex; default cap 1000)
+    let reply = run_flow(
+        &platform,
+        "dynamic-index-cap",
+        from_json(&serde_json::json!({"body": {"n": 5000}, "header": {}})),
+        "biz-cid-cap",
+    )
+    .await;
+    let body = json_body(&reply);
+    let message = body["message"].as_str().unwrap_or("");
+    assert!(
+        message.contains("exceeds max 1000"),
+        "unexpected error: {body}"
+    );
+    // ...while an in-range dynamic index still works
+    let reply = run_flow(
+        &platform,
+        "dynamic-index-cap",
+        from_json(&serde_json::json!({"body": {"n": 3}, "header": {}})),
+        "biz-cid-cap-ok",
+    )
+    .await;
+    assert!(
+        !reply.has_error(),
+        "in-range dynamic index must pass: {:?}",
+        json_body(&reply)
+    );
+
     // --- fire-and-forget launch works (no reply expected)
     FlowExecutor::launch(
         &platform,
@@ -1267,4 +1296,42 @@ async fn flows_run_end_to_end_like_java() {
         .await
         .expect("direct rpc");
     assert_eq!(ping.body_as::<String>().unwrap(), "ping");
+}
+
+/// Increment 52 (parity F18): the Java FlowExecutor precondition — a launch
+/// dataset must carry a top-level `body` key, or the flow never starts (a
+/// malformed dataset must not execute side effects). Java throws
+/// "Missing body in dataset" from both launch() and request().
+#[tokio::test]
+async fn flow_launch_requires_a_body_in_the_dataset() {
+    let platform = Platform::new();
+    let no_body = from_json(&serde_json::json!({"header": {}}));
+    let err = FlowExecutor::request(
+        &platform,
+        "greetings",
+        no_body.clone(),
+        "cid-nobody-1",
+        Duration::from_secs(2),
+        None,
+    )
+    .await
+    .expect_err("request without body must be rejected");
+    assert_eq!(err.status(), 400);
+    assert_eq!(err.message(), "Missing body in dataset");
+    let err = FlowExecutor::launch(&platform, "greetings", no_body, "cid-nobody-2", None)
+        .await
+        .expect_err("launch without body must be rejected");
+    assert_eq!(err.status(), 400);
+    assert_eq!(err.message(), "Missing body in dataset");
+    // a non-map dataset cannot carry a body key either
+    let err = FlowExecutor::launch(
+        &platform,
+        "greetings",
+        Value::from("not-a-map"),
+        "cid-nobody-3",
+        None,
+    )
+    .await
+    .expect_err("non-map dataset must be rejected");
+    assert_eq!(err.status(), 400);
 }

--- a/crates/event-script/tests/resources/more-flows.yaml
+++ b/crates/event-script/tests/resources/more-flows.yaml
@@ -34,6 +34,7 @@ flows:
   - 'parser-test-30.yml'
   - 'parser-test-31.yml'
   - 'dynamic-reserved-key.yml'
+  - 'dynamic-index-cap.yml'
   # duplicated filename is intentional for unit test
   - 'parser-test-17.yml'
 

--- a/crates/event-script/tests/resources/parser-flows/dynamic-index-cap.yml
+++ b/crates/event-script/tests/resources/parser-flows/dynamic-index-cap.yml
@@ -1,0 +1,31 @@
+flow:
+  id: 'dynamic-index-cap'
+  description: 'a dynamic RHS array index above max.model.array.size must be rejected at runtime'
+  ttl: 10s
+  exception: 'v1.hello.exception'
+
+first.task: 'greeting.test'
+
+tasks:
+  - input:
+      - 'text(cap-tester) -> user'
+      - 'text(hello world) -> greeting'
+      # the dynamic RHS index resolves only at runtime; the executor caps it at
+      # max.model.array.size (default 1000) exactly like Java resolveModelIndex
+      - 'input.body.n -> model.n'
+      - 'text(x) -> model.list[model.n]'
+    process: 'greeting.test'
+    output:
+      - 'result -> output.body'
+    description: 'Hello World'
+    execution: end
+
+  - input:
+      - 'error.code -> status'
+      - 'error.message -> message'
+    process: 'v1.hello.exception'
+    output:
+      - 'result.status -> output.status'
+      - 'result -> output.body'
+    description: 'Exception handler'
+    execution: end

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -68,6 +68,7 @@
 | 49 | `/sync` contract gaps (findings #62–#63): dedup bypass for direct RPC + `Syntax:` usage classified as failure; both ports | 2026-07-20 | — | 206 |
 | 50 | parity remediation 1 — REST boundary preserves function response-envelope headers (redirects/cookies/content-type) + envelope header model (case-insensitive get, CR/LF filter) | 2026-07-21 | — | 213 |
 | 51 | parity remediation 2 — trace continuity: zero-traced routes keep the trace flowing (telemetry-only suppression), send_later captures context at schedule time, explicit trace identity wins over the ambient bracket | 2026-07-21 | — | 216 |
+| 52 | parity remediation 3 — Event Script safety: `max.model.array.size` cap enforced on dynamic RHS indices (+ docs contradiction fixed), flow-launch `body` precondition | 2026-07-21 | — | 217 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1396,6 +1397,30 @@ against the Java source (`WorkerHandler` + `PostOffice.touch()`):
   `explicit_trace_identity_survives_ambient_bracket` — **red/green-verified** (all three
   fail on the pre-fix source). `annotations.rs` updated to the corrected contract (the
   bracket exists but is telemetry-suppressed). Workspace 216 tests / clippy 0 / fmt.
+
+---
+
+## Increment 52 — parity remediation 3: Event Script safety (2026-07-21)
+
+Third increment of the parity-remediation program — the two Event Script safety findings:
+
+- **F4 (High) — the `max.model.array.size` cap is enforced.** A dynamically resolved RHS
+  array index (`[model.x]`) above the configured ceiling (default 1000, read once like
+  Java's `TaskExecutor` constructor) now fails the mapping with Java's exact message
+  ("Cannot set RHS to index > N that exceeds max 1000 - ...") instead of allocating an
+  arbitrarily large state-machine array; cap check before the negative check, as in
+  `resolveModelIndex`. Literal numeric indices stay uncapped in both engines. **The
+  repo's own docs contradicted each other** (syntax.md claimed the limit existed;
+  configuration-reference.md listed the key as not read) — configuration-reference.md now
+  documents the key as read, with a port note.
+- **F18 (Medium) — flow launches require a `body`.** `FlowExecutor::launch`/`request`
+  enforce Java's precondition: a dataset without a top-level `body` key is rejected with
+  "Missing body in dataset" (400) before any dispatch, so a malformed dataset never
+  starts a flow or executes side effects (non-map datasets included).
+- **Tests:** the `dynamic-index-cap` fixture (over-cap rejected via the exception handler,
+  in-range index passes) in the e2e scenario suite + `flow_launch_requires_a_body_in_the_dataset`
+  (request/launch/non-map) — **red/green-verified** (both fail on the pre-fix source);
+  the compiler's loaded-flow-set assertion extended. Workspace 217 tests / clippy 0 / fmt.
 
 ---
 

--- a/docs/design/event-script-port.md
+++ b/docs/design/event-script-port.md
@@ -226,7 +226,14 @@ mutexes, not worker serialization, are the thread-safety story, matching Java.)*
   output/decision/error — stripped afterwards), so `model.*` writes persist exactly
   like Java's shared-reference map with zero model copies. The dynamic-index
   substitution re-checks runtime-resolved RHS targets against the reserved-key guard
-  (Java `substituteDynamicIndex`), proven by the dynamic-reserved-key fixture.
+  (Java `substituteDynamicIndex`), proven by the dynamic-reserved-key fixture, and —
+  increment 52 (parity F4) — enforces the `max.model.array.size` cap (default 1000,
+  read once like Java's `TaskExecutor` constructor) on a dynamically resolved RHS
+  index before the negative check, exactly as Java `resolveModelIndex`; literal
+  numeric indices stay uncapped in both engines (dynamic-index-cap fixture).
+  `FlowExecutor::launch`/`request` enforce Java's precondition (increment 52, parity
+  F18): the dataset must carry a top-level `body` key — "Missing body in dataset"
+  (400) — so a malformed dataset never starts a flow or executes side effects.
 - **E2E tests** (canonical fixtures + Java-parity task functions, all registered
   through the annotation inventory exactly as a user app would): greetings (type
   conversions, business-cid exposure, result-header copying, status mapping),

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -24,7 +24,7 @@ files themselves merge in the manifest order described below.
     sync-over-async/Redis, the OpenTelemetry forwarder (`otel.*`), classpath scanning
     (`web.component.scan`, `yaml.preload.override`, `modules.autostart`), threading
     (`kernel.thread.pool`, `deferred.commit.log`), event-script extras
-    (`max.model.array.size`, `yaml.event.over.http`, `yaml.journal`, `yaml.multicast`),
+    (`yaml.event.over.http`, `yaml.journal`, `yaml.multicast`),
     HTTP extras (`async.http.temp`, `stack.trace.transport.size`,
     `protect.info.endpoints`), and serialization extras (`snake.case.serialization`,
     `custom.content.types`, `mime.types`). If a key is not on this page, the Rust port
@@ -376,6 +376,22 @@ location: 'classpath:/flows/'
 
 `location` inside the manifest defaults to `classpath:/flows/`. Read by
 `crates/event-script` (compiler).
+
+#### `max.model.array.size`
+
+| Type | Default |
+|---|---|
+| int | `1000` |
+
+Ceiling for a **dynamically resolved** array index on the right-hand side of a data
+mapping (a `[model.x]` index) — a mapping whose resolved index exceeds it fails instead of
+allocating an arbitrarily large state-machine array. Literal numeric indices are not
+capped (same as the Java engine). Read once by `crates/event-script` (task executor).
+
+!!! note "Port note"
+    Added in increment 52 (parity remediation): the key existed in the Java engine from
+    the start, and the syntax guide already described it — the Rust executor now enforces
+    it.
 
 ## Knowledge graph and Playground
 

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-044626)
+- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-050117)
 - **last_review:** 2026-07-21 | through 2026-07-21-021231
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -68,7 +68,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Rust layer by layer, foundation → UI (platform-core, then event-script, then active
   knowledge graph), preserving the Java project's behavior. The Java repo is the canonical
   spec (map, don't mirror).
-  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 62 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 63 | tier: active | origin: 2026-07-15-215538.md -->
 ## Conventions
 
 > Established with the first code (increment 1, 2026-07-15); enforced from the first commit.
@@ -92,7 +92,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   2026-07-16): annotated functions + `platform_core::auto_start_main!();` with the app's
   `resources/` beside its `Cargo.toml` — never cargo examples inside a library crate.
   Event-script and knowledge-graph demos land as sibling `examples/<name>/` crates.
-  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 61 | tier: active | origin: 2026-07-15-224707.md -->
+  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 62 | tier: active | origin: 2026-07-15-224707.md -->
 
 ## Open Threads
 
@@ -241,7 +241,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   `docs/llms.txt` maps them, so companion briefs for extension/task tutorials can stay
   "llms.txt + follow the map".
   → serves: vision-mercury (faithful delivery; a fresh agent orients + operates from the docs alone)
-  <!-- id: ot-companion-validation-sweep | created: 2026-07-18 | last_used: 2026-07-20 | uses: 37 | tier: active | origin: 2026-07-18-061457.md -->
+  <!-- id: ot-companion-validation-sweep | created: 2026-07-18 | last_used: 2026-07-20 | uses: 37 | tier: archive-candidate | origin: 2026-07-18-061457.md -->
 
 - [x] **HTTP-boundary content-type dispatch mirrors Java exactly (parity fix, maintainer-directed
   2026-07-19).** The maintainer's manual `/sync` test surfaced that the Rust boundary was laxer than
@@ -515,9 +515,11 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   `touch()` pre-timer), `apply_current_trace` = exact `touch()` mirror (trace id/path
   fill-if-absent, span unconditional; F8 false parity comment fixed); 3 red/green tests in
   telemetry.rs + annotations.rs contract update; workspace 216/clippy 0/fmt; (3)
-  Event Script safety: dynamic-index array cap `max.model.array.size` missing (own docs
-  contradict: syntax.md claims it, configuration-reference.md says not read), flow-launch
-  `body` precondition missing; (4) date/time plugins: full Java pattern support + the
+  Event Script safety — DONE 2026-07-21 (increment 52): `max.model.array.size` cap
+  enforced on dynamic RHS indices (Java resolveModelIndex order + message; docs
+  contradiction fixed — configuration-reference.md now documents the key), flow-launch
+  `body` precondition ("Missing body in dataset", 400, both launch+request); red/green
+  fixture dynamic-index-cap + body-precondition test; workspace 217/clippy 0/fmt; (4) date/time plugins: full Java pattern support + the
   silently-dropped zone arg of `f:dateTime`; (5) fetcher cache key = dictionary-declared
   inputs only (Rust keys the whole staged fetch map → re-fires POSTs Java reuses;
   single-request path only); (6) registration semantics (Java replaces on re-register,
@@ -532,7 +534,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   **F2 (null-on-spill) needs a maintainer decision**, not a fix: documented design, but the
   consequence (Nil visibility varies with load) is stated nowhere — document or normalize.
   Full verdict table in the session log. → serves: vision-mercury (faithful port)
-  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 3 | tier: working | origin: 2026-07-21-030938.md -->
+  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 4 | tier: working | origin: 2026-07-21-030938.md -->
 
 - [ ] **(backlog) Port `ManagedCache` (+ sibling `SimpleCache`).** Java platform-core ships
   `org.platformlambda.core.util.ManagedCache` — a named, self-managing TTL+size-bounded

--- a/memory/sessions/2026-07-21-050117.md
+++ b/memory/sessions/2026-07-21-050117.md
@@ -1,0 +1,33 @@
+# Session (2026-07-21T05:01:17.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Increment 52 — parity remediation 3: Event Script safety** (findings F4/F18):
+
+- **F4:** `substitute_dynamic_index` now enforces `max.model.array.size` (default 1000,
+  read once via a OnceLock — Java `TaskExecutor` constructor parity) on a dynamically
+  resolved RHS index, cap-before-negative-check with Java's exact message
+  (`resolveModelIndex`). Literal numeric indices stay uncapped in both engines. The docs
+  contradiction is fixed: `configuration-reference.md` now documents the key as read
+  (it previously listed it under "not read" while `syntax.md` claimed the limit existed).
+- **F18:** `FlowExecutor::launch`/`request` enforce Java's precondition — a dataset
+  without a top-level `body` key is rejected with "Missing body in dataset" (400) before
+  any dispatch; non-map datasets too. A malformed dataset can no longer start a flow and
+  execute side effects.
+
+Tests, **red/green-verified via `git stash push -- src`** (both fail on pre-fix source):
+the `dynamic-index-cap` fixture (over-cap → exception handler with "exceeds max 1000";
+in-range index passes) + `flow_launch_requires_a_body_in_the_dataset` (request, launch,
+non-map). Compiler's loaded-flow-set assertion extended for the new fixture. Workspace
+217 tests / clippy 0 / fmt. Docs: INCREMENTS.md increment-52 section; event-script design
+doc §5d state-machine passage extended; configuration-reference.md gains the
+`max.model.array.size` entry with a port note.
+
+## Memory References
+
+- referenced: ot-parity-remediation (item 3 → DONE), port-bottom-up-faithful,
+  conventions-rust-baseline
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

Increment 52 — parity remediation item 3, the two Event Script safety findings:

- **`max.model.array.size` enforced (F4, High):** a dynamically resolved RHS array index
  (`[model.x]`) above the configured ceiling (default 1000, read once like Java's
  `TaskExecutor` constructor) now fails the mapping with Java's exact message, cap check
  before the negative check as in `resolveModelIndex`. Previously the state-machine array
  grew unbounded (`set_in` resized to any index). Literal numeric indices stay uncapped in
  both engines. This also resolves the repo's own docs contradiction — `syntax.md` claimed
  the limit existed while `configuration-reference.md` listed the key as not read; the
  reference now documents the key with a port note.
- **Flow-launch `body` precondition (F18, Medium):** `FlowExecutor::launch`/`request`
  enforce Java's check — a dataset without a top-level `body` key is rejected with
  "Missing body in dataset" (400) before any dispatch (non-map datasets included), so a
  malformed dataset can no longer start a flow and execute side effects.

## Why

Both are verified findings from the maintainer-approved parity remediation
(`ot-parity-remediation`): the missing cap allowed hostile or accidental huge allocations
from a single mapping line, and the missing precondition let malformed programmatic
launches run flows Java would reject up front.

Verified red/green (both tests fail on the pre-fix source): the new `dynamic-index-cap`
fixture drives an over-cap index into the exception handler ("exceeds max 1000") and an
in-range index through cleanly; `flow_launch_requires_a_body_in_the_dataset` covers
request, launch, and non-map datasets. Workspace 217 tests green, clippy clean, fmt
applied. `INCREMENTS.md`, the event-script design doc, and the configuration reference
updated; the remediation thread marks item 3 done.

Co-Authored-By: Claude Code <noreply@anthropic.com>