### PR TITLE
fix(event-script): full Java date/time pattern support and the f:dateTime zone argument (increment 53)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,7 +260,9 @@ dependencies = [
  "async-trait",
  "base64",
  "chrono",
+ "chrono-tz",
  "event-script-macros",
+ "iana-time-zone",
  "log",
  "platform-core",
  "rmpv",
@@ -640,6 +652,24 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -1084,6 +1114,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/crates/event-script/Cargo.toml
+++ b/crates/event-script/Cargo.toml
@@ -20,6 +20,11 @@ serde_json = "1"
 serde_json_path = "0.7"
 base64 = "0.22"
 chrono = "0.4"
+# increment 53 (parity F5): f:dateTime zone argument — chrono-tz is the
+# ZoneId.of() analog (IANA database), iana-time-zone names the system zone
+# (the ZoneId.systemDefault() analog, same crate chrono uses internally)
+chrono-tz = "0.10"
+iana-time-zone = "0.1"
 event-script-macros = { path = "../event-script-macros" }
 uuid = { version = "1", features = ["v4"] }
 

--- a/crates/event-script/src/plugins.rs
+++ b/crates/event-script/src/plugins.rs
@@ -603,4 +603,86 @@ mod tests {
         );
         assert!(calculate("noSuchPlugin", &[]).is_err());
     }
+
+    /// Increment 53 (parity F5): full Java DateTimeFormatter pattern support
+    /// and the f:dateTime zone argument (previously silently dropped).
+    #[test]
+    fn date_time_patterns_and_zone_match_java_semantics() {
+        // the converter tokenizes properly: names, 12-hour clock, AM/PM,
+        // millis, quoted literals, escaped quotes, offsets
+        assert_eq!(
+            java_pattern_to_chrono("MM/dd/yyyy HH:mm:ss"),
+            Ok("%m/%d/%Y %H:%M:%S".to_string())
+        );
+        assert_eq!(
+            java_pattern_to_chrono("yyyy-MM-dd'T'HH:mm:ss.SSS"),
+            Ok("%Y-%m-%dT%H:%M:%S.%3f".to_string())
+        );
+        assert_eq!(
+            java_pattern_to_chrono("EEE, dd MMM yyyy hh:mm a"),
+            Ok("%a, %d %b %Y %I:%M %p".to_string())
+        );
+        assert_eq!(java_pattern_to_chrono("yyyy''MM"), Ok("%Y'%m".to_string()));
+        // unsupported letters fail loudly instead of emitting garbage
+        let err = java_pattern_to_chrono("yyyy VV").expect_err("V unsupported");
+        assert!(err.contains("'V'"), "{err}");
+
+        // f:dateTime honors the zone argument (Java ZoneId.of analog) —
+        // deterministic via the offset pattern
+        assert_eq!(
+            calculate("dateTime", &[Value::from("XXX"), Value::from("UTC")]),
+            Ok(Value::from("+00:00"))
+        );
+        assert_eq!(
+            calculate(
+                "dateTime",
+                &[Value::from("XXX"), Value::from("Asia/Kolkata")]
+            ),
+            Ok(Value::from("+05:30"))
+        );
+        let err = calculate("dateTime", &[Value::from("HH"), Value::from("Not/AZone")])
+            .expect_err("invalid zone");
+        assert!(err.contains("Unknown time zone"), "{err}");
+        // no-arg form: ISO_DATE_TIME with the [zone-id] suffix (Java
+        // ZonedDateTime + DateTimeFormatter.ISO_DATE_TIME)
+        let stamp = get_text_value(&calculate("dateTime", &[]).expect("no-arg dateTime"));
+        assert!(
+            stamp.contains('T') && stamp.ends_with(']') && stamp.contains('['),
+            "{stamp}"
+        );
+
+        // parseDateTime with AM/PM + 12-hour clock (previously garbage)
+        let ms = calculate(
+            "parseDateTime",
+            &[
+                Value::from("07/04/2026 09:30:00 PM"),
+                Value::from("MM/dd/yyyy hh:mm:ss a; ms"),
+            ],
+        )
+        .expect("parse AM/PM");
+        // the same instant computed directly (local zone, like Java
+        // LocalDateTime.parse().atZone(systemDefault()))
+        use chrono::TimeZone;
+        let expected = chrono::Local
+            .from_local_datetime(
+                &chrono::NaiveDate::from_ymd_opt(2026, 7, 4)
+                    .unwrap()
+                    .and_hms_opt(21, 30, 0)
+                    .unwrap(),
+            )
+            .earliest()
+            .unwrap()
+            .timestamp_millis();
+        assert_eq!(ms, Value::from(expected));
+        // milliseconds in the pattern round-trip too
+        let ms = calculate(
+            "parseDateTime",
+            &[
+                Value::from("2026-07-04 21:30:00.250"),
+                Value::from("yyyy-MM-dd HH:mm:ss.SSS; ms"),
+            ],
+        )
+        .expect("parse millis");
+        assert_eq!(ms, Value::from(expected + 250));
+    }
 }

--- a/crates/event-script/src/plugins_e8.rs
+++ b/crates/event-script/src/plugins_e8.rs
@@ -243,26 +243,126 @@ fn plugin_now(args: &[Value]) -> Result<Value, String> {
     }
 }
 
-/// Convert the common Java DateTimeFormatter pattern letters to a chrono
-/// format string (yyyy/MM/dd/HH/mm/ss — the tokens flow files use).
-fn java_pattern_to_chrono(pattern: &str) -> String {
-    pattern
-        .replace("yyyy", "%Y")
-        .replace("MM", "%m")
-        .replace("dd", "%d")
-        .replace("HH", "%H")
-        .replace("mm", "%M")
-        .replace("ss", "%S")
+/// Convert a Java `DateTimeFormatter` pattern to a chrono format string
+/// (increment 53, parity F5 — was a naive six-token replace that passed
+/// everything else through as garbage). A real tokenizer: repeated pattern
+/// letters, `'quoted literals'` (with `''` as an escaped quote), literal
+/// separators (`%` escaped). Coverage is the practical Java letter set;
+/// an unsupported letter fails LOUDLY instead of producing wrong output.
+/// Known micro-divergences (closest chrono forms, documented): `X`/`XX`
+/// render as `+0530` (no minute-less form), `XXX` renders UTC as `+00:00`
+/// where Java prints `Z`; `z` is format-only (chrono cannot parse zone
+/// abbreviations).
+fn java_pattern_to_chrono(pattern: &str) -> Result<String, String> {
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut out = String::new();
+    let push_literal = |out: &mut String, c: char| {
+        if c == '%' {
+            out.push_str("%%");
+        } else {
+            out.push(c);
+        }
+    };
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        if c == '\'' {
+            // '' outside a quoted section is a literal quote
+            if chars.get(i + 1) == Some(&'\'') {
+                out.push('\'');
+                i += 2;
+                continue;
+            }
+            // quoted literal text, '' inside = one quote
+            i += 1;
+            while i < chars.len() {
+                if chars[i] == '\'' {
+                    if chars.get(i + 1) == Some(&'\'') {
+                        out.push('\'');
+                        i += 2;
+                        continue;
+                    }
+                    i += 1;
+                    break;
+                }
+                push_literal(&mut out, chars[i]);
+                i += 1;
+            }
+            continue;
+        }
+        if c.is_ascii_alphabetic() {
+            let mut n = 1;
+            while chars.get(i + n) == Some(&c) {
+                n += 1;
+            }
+            let token = match (c, n) {
+                ('y' | 'u', 2) => "%y",
+                ('y' | 'u', _) => "%Y",
+                ('M', 4..) => "%B",
+                ('M', 3) => "%b",
+                ('M', 2) => "%m",
+                ('M', 1) => "%-m",
+                ('d', 2..) => "%d",
+                ('d', 1) => "%-d",
+                ('E', 4..) => "%A",
+                ('E', _) => "%a",
+                ('H', 2..) => "%H",
+                ('H', 1) => "%-H",
+                ('h', 2..) => "%I",
+                ('h', 1) => "%-I",
+                ('m', 2..) => "%M",
+                ('m', 1) => "%-M",
+                ('s', 2..) => "%S",
+                ('s', 1) => "%-S",
+                ('S', 3) => "%3f",
+                ('S', _) => {
+                    return Err(format!(
+                        "Unsupported fractional-second width in '{pattern}' - use SSS (milliseconds)"
+                    ))
+                }
+                ('a', _) => "%p",
+                ('X', 3) => "%:z",
+                ('X', 1..=2) => "%z",
+                ('Z', _) => "%z",
+                ('z', _) => "%Z",
+                _ => {
+                    return Err(format!(
+                        "Unsupported date-time pattern letter '{c}' in '{pattern}'"
+                    ))
+                }
+            };
+            out.push_str(token);
+            i += n;
+            continue;
+        }
+        push_literal(&mut out, c);
+        i += 1;
+    }
+    Ok(out)
 }
 
 fn plugin_date_time(args: &[Value]) -> Result<Value, String> {
-    let now = chrono::Local::now();
+    // Java DateGenerator: ZonedDateTime.now(zone).format(pattern) — the
+    // optional 2nd argument is the zone (ZoneId.of), previously silently
+    // dropped (parity F5); no pattern → ISO_DATE_TIME with the [zone-id]
+    // suffix; no zone → the system default
+    let zone_name = match args.get(1) {
+        Some(zone) => get_text_value(zone),
+        None => iana_time_zone::get_timezone()
+            .map_err(|e| format!("unable to detect the system time zone - {e}"))?,
+    };
+    let tz: chrono_tz::Tz = zone_name
+        .parse()
+        .map_err(|_| format!("Unknown time zone '{zone_name}'"))?;
+    let now = chrono::Utc::now().with_timezone(&tz);
     match args.first() {
-        None => Ok(Value::from(
-            now.to_rfc3339_opts(chrono::SecondsFormat::Millis, false),
-        )),
+        None => Ok(Value::from(format!(
+            "{}[{}]",
+            now.format("%Y-%m-%dT%H:%M:%S%.f%:z"),
+            zone_name
+        ))),
         Some(pattern) => {
-            let format = java_pattern_to_chrono(&get_text_value(pattern));
+            let format = java_pattern_to_chrono(&get_text_value(pattern))?;
             Ok(Value::from(now.format(&format).to_string()))
         }
     }
@@ -388,7 +488,7 @@ fn plugin_parse_date(args: &[Value]) -> Result<Value, String> {
                     "Invalid validation rule. Syntax: text(pattern, iso | local | ms)".to_string(),
                 );
             };
-            let format = java_pattern_to_chrono(pattern);
+            let format = java_pattern_to_chrono(pattern)?;
             let date = chrono::NaiveDate::parse_from_str(&get_text_value(value), &format)
                 .map_err(|e| format!("unable to parse date - {e}"))?;
             let midnight = date.and_hms_opt(0, 0, 0).ok_or("invalid date")?;
@@ -407,7 +507,7 @@ fn plugin_parse_date_time(args: &[Value]) -> Result<Value, String> {
                     "Invalid validation rule. Syntax: text(pattern, iso | local | ms)".to_string(),
                 );
             };
-            let format = java_pattern_to_chrono(pattern);
+            let format = java_pattern_to_chrono(pattern)?;
             let datetime = chrono::NaiveDateTime::parse_from_str(&get_text_value(value), &format)
                 .map_err(|e| format!("unable to parse datetime - {e}"))?;
             parsed_date_output(datetime, &rules)

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -69,6 +69,7 @@
 | 50 | parity remediation 1 — REST boundary preserves function response-envelope headers (redirects/cookies/content-type) + envelope header model (case-insensitive get, CR/LF filter) | 2026-07-21 | — | 213 |
 | 51 | parity remediation 2 — trace continuity: zero-traced routes keep the trace flowing (telemetry-only suppression), send_later captures context at schedule time, explicit trace identity wins over the ambient bracket | 2026-07-21 | — | 216 |
 | 52 | parity remediation 3 — Event Script safety: `max.model.array.size` cap enforced on dynamic RHS indices (+ docs contradiction fixed), flow-launch `body` precondition | 2026-07-21 | — | 217 |
+| 53 | parity remediation 4 — date/time plugins: full Java-pattern tokenizer (names, 12h/AM-PM, SSS, quoted literals, offsets; loud failure on unsupported letters), `f:dateTime` zone argument + ISO_DATE_TIME no-arg form | 2026-07-21 | — | 218 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1421,6 +1422,35 @@ Third increment of the parity-remediation program — the two Event Script safet
   in-range index passes) in the e2e scenario suite + `flow_launch_requires_a_body_in_the_dataset`
   (request/launch/non-map) — **red/green-verified** (both fail on the pre-fix source);
   the compiler's loaded-flow-set assertion extended. Workspace 217 tests / clippy 0 / fmt.
+
+---
+
+## Increment 53 — parity remediation 4: date/time plugins (2026-07-21)
+
+Fourth increment of the parity-remediation program (finding F5, High). The Java-pattern →
+chrono converter was a six-token literal replace — everything beyond
+`yyyy/MM/dd/HH/mm/ss` passed through as garbage chrono directives — and `f:dateTime`
+silently discarded its zone argument.
+
+- **A real pattern tokenizer** (`java_pattern_to_chrono`, now `Result`): repeated pattern
+  letters mapped to their chrono equivalents — years (`yy`/`yyyy`/`u`), months incl.
+  names (`M`–`MMMM`), weekdays (`E`–`EEEE`), 12/24-hour clocks (`h`/`H`), AM/PM (`a`),
+  `SSS` milliseconds, `'quoted literals'` with `''` escapes, `X`/`XXX`/`Z` offsets,
+  format-only `z` zone names — and an **explicit error** for unsupported letters instead
+  of silently wrong output. Micro-divergences documented at the converter (minute-less
+  `X` renders `+0530`; `XXX` at UTC renders `+00:00`, not `Z`).
+- **`f:dateTime` zone argument** (Java `DateGenerator`: `ZonedDateTime.now(zone)`): the
+  optional second argument now selects the zone via chrono-tz (`ZoneId.of` analog;
+  unknown zone → error, as Java throws). The no-arg form emits Java's `ISO_DATE_TIME`
+  shape incl. the `[zone-id]` suffix (system zone via iana-time-zone — the
+  `ZoneId.systemDefault()` analog). New deps: `chrono-tz 0.10`, `iana-time-zone 0.1`.
+- **`parseDate`/`parseDateTime`** ride the same converter — AM/PM, millis, and quoted
+  literals in parse patterns now work.
+- **Tests:** `date_time_patterns_and_zone_match_java_semantics` — converter mappings +
+  loud unsupported-letter failure, deterministic zone assertions (`XXX` @ UTC/Kolkata),
+  invalid-zone error, no-arg shape, AM/PM + millis parse round-trips against
+  locally-computed epochs. Workspace 218 tests / clippy 0 / fmt. syntax.md documents the
+  pattern/zone forms (upstream doc candidate: Java's page is equally terse).
 
 ---
 

--- a/docs/design/event-script-port.md
+++ b/docs/design/event-script-port.md
@@ -356,8 +356,15 @@ reactive back-pressure.*
   `promoteNumber` semantics incl. divide-by-zero guards), generators (`now` with
   iso/local/ms, `dateTime` with Java-pattern formatting), comparisons (`gt`/`lt`,
   `ternary`, case-insensitive `startsWith`/`endsWith`/`includes` with list
-  membership), date parsing (`parseDate`/`parseDateTime` — a small Java-pattern →
-  chrono format converter covers the yyyy/MM/dd/HH/mm/ss tokens flow files use),
+  membership), date parsing (`parseDate`/`parseDateTime` — the Java-pattern → chrono
+  converter is a real tokenizer since increment 53 (parity F5): the practical
+  `DateTimeFormatter` letter set — years/months incl. names, weekdays, 12/24-hour
+  clocks, AM/PM, SSS millis, quoted literals, X/Z offsets — with unsupported letters
+  failing loudly; `f:dateTime` honors its optional zone argument via chrono-tz
+  (`ZoneId.of` analog) and its no-arg form emits Java's ISO_DATE_TIME shape with the
+  `[zone-id]` suffix. Known micro-divergences documented at the converter: minute-less
+  `X` offsets render as `+0530`, `XXX` at UTC renders `+00:00` not `Z`, `z` is
+  format-only),
   list-of-map operations (`listOfMap` normalization + column merge,
   `updateListOfMap`, `removeKey`, `uniqueSet`, `defaultValue`), and the full
   `validate` rule engine (type checks, `required`/`evaluate` modes, string/integer/

--- a/docs/guides/event-script/syntax.md
+++ b/docs/guides/event-script/syntax.md
@@ -1446,6 +1446,10 @@ For example:
 *DateTime plugins*
 
 - f:dateTime() will yield a timestamp with local timezone.
+- f:dateTime(text(pattern)) formats the current time with a Java `DateTimeFormatter`
+  pattern (e.g. `yyyy-MM-dd'T'HH:mm:ss.SSS a`); an optional second argument selects the
+  time zone by ID, e.g. f:dateTime(text(HH:mm), text(Asia/Tokyo)) — default is the
+  system zone.
 
 ```
 2026-03-15T14:48:21.735153-07:00[America/Los_Angeles]

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-050117)
+- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-051629)
 - **last_review:** 2026-07-21 | through 2026-07-21-021231
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -33,7 +33,9 @@ swap for a maintained fork only if it ever blocks), thiserror 1, log 0.4 (std fe
 tokio 1 (rt-multi-thread/sync/time/macros/net/signal/io-util), async-trait 0.1,
 async-channel 2 (per-route MPMC queue), rmp-serde 1 + rmpv 1 (with-serde), uuid 1 (v4),
 **hyper 1 (http1/server) + hyper-util 0.1 + http-body-util 0.1** (D10 — REST automation;
-deliberately not a web framework: rest.yaml IS the router), **tokio-rustls 0.26 (ring) +
+deliberately not a web framework: rest.yaml IS the router), **chrono 0.4 + chrono-tz 0.10 +
+iana-time-zone 0.1** (event-script date/time plugins; chrono-tz = the ZoneId.of analog,
+increment 53), **tokio-rustls 0.26 (ring) +
 rustls-native-certs 0.8** (increment 48 — outbound HTTPS with OS-trust-store verification +
 `trust_all_cert`; rcgen dev-dep for the self-signed TLS test). Stack rationale:
 `platform-core-stack` + design doc D1–D10. `.gitignore` is stack-aware (Rust section:
@@ -68,7 +70,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Rust layer by layer, foundation → UI (platform-core, then event-script, then active
   knowledge graph), preserving the Java project's behavior. The Java repo is the canonical
   spec (map, don't mirror).
-  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 63 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 64 | tier: active | origin: 2026-07-15-215538.md -->
 ## Conventions
 
 > Established with the first code (increment 1, 2026-07-15); enforced from the first commit.
@@ -92,7 +94,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   2026-07-16): annotated functions + `platform_core::auto_start_main!();` with the app's
   `resources/` beside its `Cargo.toml` — never cargo examples inside a library crate.
   Event-script and knowledge-graph demos land as sibling `examples/<name>/` crates.
-  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 62 | tier: active | origin: 2026-07-15-224707.md -->
+  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 63 | tier: active | origin: 2026-07-15-224707.md -->
 
 ## Open Threads
 
@@ -519,8 +521,11 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   enforced on dynamic RHS indices (Java resolveModelIndex order + message; docs
   contradiction fixed — configuration-reference.md now documents the key), flow-launch
   `body` precondition ("Missing body in dataset", 400, both launch+request); red/green
-  fixture dynamic-index-cap + body-precondition test; workspace 217/clippy 0/fmt; (4) date/time plugins: full Java pattern support + the
-  silently-dropped zone arg of `f:dateTime`; (5) fetcher cache key = dictionary-declared
+  fixture dynamic-index-cap + body-precondition test; workspace 217/clippy 0/fmt; (4) date/time plugins — DONE 2026-07-21
+  (increment 53): real pattern tokenizer (names/12h/AM-PM/SSS/quoted literals/offsets;
+  unsupported letters fail loudly), `f:dateTime` zone arg via chrono-tz + ISO_DATE_TIME
+  no-arg form with [zone-id] suffix; parse plugins ride the same converter; deterministic
+  zone tests; workspace 218/clippy 0/fmt; deps + micro-divergences documented; (5) fetcher cache key = dictionary-declared
   inputs only (Rust keys the whole staged fetch map → re-fires POSTs Java reuses;
   single-request path only); (6) registration semantics (Java replaces on re-register,
   clamps instances 1..=1000), config resolver false-cycle on repeated `${a} ${a}`,
@@ -534,7 +539,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   **F2 (null-on-spill) needs a maintainer decision**, not a fix: documented design, but the
   consequence (Nil visibility varies with load) is stated nowhere — document or normalize.
   Full verdict table in the session log. → serves: vision-mercury (faithful port)
-  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 4 | tier: working | origin: 2026-07-21-030938.md -->
+  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 5 | tier: working | origin: 2026-07-21-030938.md -->
 
 - [ ] **(backlog) Port `ManagedCache` (+ sibling `SimpleCache`).** Java platform-core ships
   `org.platformlambda.core.util.ManagedCache` — a named, self-managing TTL+size-bounded

--- a/memory/sessions/2026-07-21-051629.md
+++ b/memory/sessions/2026-07-21-051629.md
@@ -1,0 +1,36 @@
+# Session (2026-07-21T05:16:29.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Increment 53 — parity remediation 4: date/time plugins** (finding F5, High). The
+Java-pattern → chrono converter was a naive six-token replace (everything else passed
+through as garbage), and `f:dateTime` silently discarded its zone argument.
+
+- `java_pattern_to_chrono` rewritten as a real tokenizer returning `Result`: the
+  practical DateTimeFormatter letter set (yy/yyyy/u, M–MMMM incl. names, E–EEEE
+  weekdays, h/H 12/24-hour, a AM/PM, SSS millis, 'quoted literals' + '' escapes,
+  X/XXX/Z offsets, format-only z) — unsupported letters fail LOUDLY. Micro-divergences
+  documented at the converter (X → +0530 form; XXX at UTC → +00:00 not Z).
+- `f:dateTime`: optional zone argument honored via **chrono-tz** (ZoneId.of analog;
+  unknown zone errors like Java) — NEW DEPS chrono-tz 0.10 + iana-time-zone 0.1
+  (system-zone name, the ZoneId.systemDefault analog) recorded in Stack & Tools. The
+  no-arg form now emits Java's ISO_DATE_TIME shape incl. the `[zone-id]` suffix
+  (matches the canonical doc example).
+- `parseDate`/`parseDateTime` ride the converter — AM/PM + millis patterns now parse.
+- Test `date_time_patterns_and_zone_match_java_semantics`: converter mappings,
+  loud-failure assertion, deterministic zone checks (XXX @ UTC = +00:00, Asia/Kolkata =
+  +05:30), invalid zone, no-arg shape, AM/PM + SSS parse round-trips vs locally-computed
+  epochs. Workspace 218 / clippy 0 / fmt.
+- Docs: INCREMENTS.md §53; design doc converter passage rewritten; syntax.md now
+  documents the pattern/zone forms (upstream doc candidate — Java's page is equally
+  terse about them).
+
+## Memory References
+
+- referenced: ot-parity-remediation (item 4 → DONE), port-bottom-up-faithful,
+  conventions-rust-baseline
+  (new deps recorded directly in continuity's Stack & Tools section)
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

Increment 53 — parity remediation item 4 (finding F5, High):

- **`java_pattern_to_chrono` is now a real tokenizer** (returning `Result`): years
  (`yy`/`yyyy`/`u`), months incl. names (`M`–`MMMM`), weekdays (`E`–`EEEE`), 12/24-hour
  clocks (`h`/`H`), AM/PM (`a`), `SSS` milliseconds, `'quoted literals'` with `''`
  escapes, `X`/`XXX`/`Z` offsets, and format-only `z` zone names. An unsupported pattern
  letter fails loudly with a clear message instead of producing silently wrong output.
- **`f:dateTime` honors its zone argument** via chrono-tz (the `ZoneId.of` analog; an
  unknown zone errors, as Java throws), and the no-arg form emits Java's `ISO_DATE_TIME`
  shape including the `[zone-id]` suffix — matching the canonical doc example. New deps:
  `chrono-tz 0.10`, `iana-time-zone 0.1` (the `ZoneId.systemDefault` analog).
- **`parseDate`/`parseDateTime` ride the same converter** — AM/PM, millis, and quoted
  literals in parse patterns now work.

## Why

The converter was a six-token literal replace, so valid Java formats involving
milliseconds, offsets, weekdays, AM/PM, or quoting produced garbage chrono directives —
and the zone argument was silently dropped. Both halves are verified findings from the
maintainer-approved parity remediation. Where chrono has no exact Java form, the
divergence is documented at the converter instead of hidden (minute-less `X` renders
`+0530`; `XXX` at UTC renders `+00:00`, not `Z`; `z` is format-only).

Tests: converter mappings, the loud unsupported-letter failure, deterministic zone
assertions (`XXX` @ UTC → `+00:00`, Asia/Kolkata → `+05:30`), invalid-zone error, no-arg
shape, and AM/PM + `SSS` parse round-trips against locally computed epochs. Workspace 218
tests green, clippy clean, fmt applied. `INCREMENTS.md`, the design doc, and `syntax.md`
updated (the pattern/zone prose is an upstream doc candidate — Java's page is equally
terse about them).

Co-Authored-By: Claude Code <noreply@anthropic.com>