### PR TITLE
fix(knowledge-graph): fetcher cache key uses dictionary-declared inputs only (increment 54)

### DIFF
--- a/crates/knowledge-graph/src/fetcher.rs
+++ b/crates/knowledge-graph/src/fetcher.rs
@@ -298,7 +298,14 @@ async fn execute_providers(
                 )
                 .map_err(invalid)?;
             let request = build_http_request(&md, &mut state)?;
-            let params_value = pairs_to_value(&params_map);
+            // the cache key is the DICTIONARY-scoped parameter map
+            // ({node}.dd.{alias}.* — declared inputs only), never the whole
+            // staged fetch map: equivalent dictionary requests must share a
+            // cache entry regardless of extra fetcher-level staging (Java
+            // makeRegularHttpCall; parity F6 fix, 2026-07-21)
+            let params_value = state
+                .get_element(&format!("{node_name}.dd.{}", dd.get_alias()))
+                .unwrap_or(Value::Map(vec![]));
             let cached = get_cached_result(&md.provider_name, &state, &params_value);
             (request.to_value(), params_value, cached)
         };
@@ -718,15 +725,6 @@ fn value_to_pairs(value: &Value) -> Vec<(String, Value)> {
             .collect(),
         _ => Vec::new(),
     }
-}
-
-fn pairs_to_value(pairs: &[(String, Value)]) -> Value {
-    Value::Map(
-        pairs
-            .iter()
-            .map(|(k, v)| (Value::from(k.as_str()), v.clone()))
-            .collect(),
-    )
 }
 
 fn params_keys(params: &Value) -> Vec<String> {

--- a/crates/knowledge-graph/tests/graph_runtime.rs
+++ b/crates/knowledge-graph/tests/graph_runtime.rs
@@ -126,6 +126,27 @@ impl knowledge_graph::features::FeatureRunner for DemoAuth {
     }
 }
 
+/// Counts every provider call it receives — the cache-key regression probe
+/// (increment 54, parity F6): two fetches whose DICTIONARY-declared inputs
+/// match must produce exactly one call, regardless of fetcher-level staging.
+static CACHE_PROBE_CALLS: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(0);
+
+#[preload(route = "mock.cache.counter", instances = 10)]
+struct MockCacheCounter;
+
+#[async_trait]
+impl ComposableFunction for MockCacheCounter {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        _input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let n = CACHE_PROBE_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+        EventEnvelope::new().set_body(serde_json::json!({"count": n}))
+    }
+}
+
 /// Echoes the Authorization header it received on the wire.
 #[preload(route = "mock.echo.auth", instances = 10)]
 struct MockEchoAuth;
@@ -218,6 +239,7 @@ async fn graph_runtime_end_to_end() {
     graph_task_matches_java_semantics(&platform).await;
     join_loop_retirement_and_health(&platform).await;
     api_fetcher_matches_java_semantics(&platform).await;
+    fetcher_cache_key_uses_dictionary_declared_inputs_only(&platform).await;
     graph_extension_matches_java_semantics(&platform).await;
     activated_hello_graphs_match_java_semantics(&platform).await;
     // Run in this single test so the whole file shares one runtime + one booted
@@ -719,6 +741,45 @@ async fn graph_extension_matches_java_semantics(platform: &Platform) {
     assert_eq!(
         Some("world"),
         reply.headers().get("x-hello").map(String::as_str)
+    );
+}
+
+/// Increment 54 (parity F6): the provider cache key is built EXCLUSIVELY from
+/// dictionary-declared inputs (Java `makeRegularHttpCall` reads the
+/// `{node}.dd.{alias}.*` namespace). Two sequential fetchers stage a
+/// DIFFERENT undeclared fetcher-level parameter (`extra` = alpha/beta) while
+/// their dictionaries declare the same `person_id` — Java reuses the cached
+/// response; the pre-fix Rust keyed on the whole staged map and re-fired the
+/// provider call.
+async fn fetcher_cache_key_uses_dictionary_declared_inputs_only(platform: &Platform) {
+    let before = CACHE_PROBE_CALLS.load(std::sync::atomic::Ordering::SeqCst);
+    let reply = run_graph(
+        platform,
+        "rust-cache-key",
+        serde_json::json!({"person_id": 100}),
+        serde_json::json!({}),
+    )
+    .await;
+    assert_eq!(
+        200,
+        reply.status(),
+        "rust-cache-key failed: {:?}",
+        reply.body()
+    );
+    let after = CACHE_PROBE_CALLS.load(std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(
+        1,
+        after - before,
+        "equivalent dictionary requests must share ONE provider call (Java parity)"
+    );
+    // both fetches surfaced the SAME cached response
+    let mm = body_map(&reply);
+    let count1 = mm.get_element("count1");
+    let count2 = mm.get_element("count2");
+    assert!(count1.is_some(), "count1 missing: {:?}", reply.body());
+    assert_eq!(
+        count1, count2,
+        "the second fetch must reuse the first fetch's cached response"
     );
 }
 

--- a/crates/knowledge-graph/tests/resources/graph/rust-cache-key.json
+++ b/crates/knowledge-graph/tests/resources/graph/rust-cache-key.json
@@ -1,0 +1,127 @@
+{
+  "nodes": [
+    {
+      "types": ["Root"],
+      "alias": "root",
+      "properties": {
+        "skill": "graph.data.mapper",
+        "mapping": ["input.body.person_id -> model.person_id"],
+        "purpose": "Regression probe: the provider cache key is built from dictionary-declared inputs only (parity F6)",
+        "name": "rust-cache-key"
+      }
+    },
+    {
+      "types": ["Fetcher"],
+      "alias": "fetcher-1",
+      "properties": {
+        "skill": "graph.api.fetcher",
+        "input": [
+          "input.body.person_id -> person_id",
+          "text(alpha) -> extra"
+        ],
+        "dictionary": ["cache-name"],
+        "output": ["result.count -> output.body.count1"]
+      }
+    },
+    {
+      "types": ["Fetcher"],
+      "alias": "fetcher-2",
+      "properties": {
+        "skill": "graph.api.fetcher",
+        "input": [
+          "input.body.person_id -> person_id",
+          "text(beta) -> extra"
+        ],
+        "dictionary": ["cache-echo"],
+        "output": ["result.count -> output.body.count2"]
+      }
+    },
+    {
+      "types": ["Dictionary"],
+      "alias": "cache-name",
+      "properties": {
+        "input": ["person_id"],
+        "output": ["response.count -> result.count"],
+        "provider": "counter-api",
+        "purpose": "call count as seen by the first fetch"
+      }
+    },
+    {
+      "types": ["Dictionary"],
+      "alias": "cache-echo",
+      "properties": {
+        "input": ["person_id"],
+        "output": ["response.count -> result.count"],
+        "provider": "counter-api",
+        "purpose": "call count as seen by the second fetch"
+      }
+    },
+    {
+      "types": ["Provider"],
+      "alias": "counter-api",
+      "properties": {
+        "method": "GET",
+        "url": "http://127.0.0.1:${rest.server.port:8080}/api/cache/counter/{id}",
+        "input": [
+          "text(application/json) -> header.accept",
+          "person_id -> path_parameter.id"
+        ],
+        "purpose": "call-counting mock endpoint"
+      }
+    },
+    {
+      "types": ["Island"],
+      "alias": "dictionary",
+      "properties": {
+        "skill": "graph.island"
+      }
+    },
+    {
+      "types": ["End"],
+      "alias": "end",
+      "properties": {}
+    }
+  ],
+  "connections": [
+    {
+      "source": "root",
+      "relations": [{"type": "fetch", "properties": {}}],
+      "target": "fetcher-1"
+    },
+    {
+      "source": "fetcher-1",
+      "relations": [{"type": "then", "properties": {}}],
+      "target": "fetcher-2"
+    },
+    {
+      "source": "fetcher-2",
+      "relations": [{"type": "complete", "properties": {}}],
+      "target": "end"
+    },
+    {
+      "source": "root",
+      "relations": [{"type": "contains", "properties": {}}],
+      "target": "dictionary"
+    },
+    {
+      "source": "dictionary",
+      "relations": [{"type": "data", "properties": {}}],
+      "target": "cache-name"
+    },
+    {
+      "source": "dictionary",
+      "relations": [{"type": "data", "properties": {}}],
+      "target": "cache-echo"
+    },
+    {
+      "source": "cache-name",
+      "relations": [{"type": "provider", "properties": {}}],
+      "target": "counter-api"
+    },
+    {
+      "source": "cache-echo",
+      "relations": [{"type": "provider", "properties": {}}],
+      "target": "counter-api"
+    }
+  ]
+}

--- a/crates/knowledge-graph/tests/resources/rest.yaml
+++ b/crates/knowledge-graph/tests/resources/rest.yaml
@@ -26,6 +26,12 @@ rest:
     timeout: 10s
     tracing: true
 
+  - service: 'mock.cache.counter'
+    methods: ['GET']
+    url: '/api/cache/counter/{id}'
+    timeout: 10s
+    tracing: true
+
   - service: 'post.companion.command'
     methods: ['POST']
     url: '/api/companion/{id}'

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -70,6 +70,7 @@
 | 51 | parity remediation 2 — trace continuity: zero-traced routes keep the trace flowing (telemetry-only suppression), send_later captures context at schedule time, explicit trace identity wins over the ambient bracket | 2026-07-21 | — | 216 |
 | 52 | parity remediation 3 — Event Script safety: `max.model.array.size` cap enforced on dynamic RHS indices (+ docs contradiction fixed), flow-launch `body` precondition | 2026-07-21 | — | 217 |
 | 53 | parity remediation 4 — date/time plugins: full Java-pattern tokenizer (names, 12h/AM-PM, SSS, quoted literals, offsets; loud failure on unsupported letters), `f:dateTime` zone argument + ISO_DATE_TIME no-arg form | 2026-07-21 | — | 218 |
+| 54 | parity remediation 5 — fetcher cache key = dictionary-declared inputs only (`{node}.dd.{alias}.*`, Java makeRegularHttpCall parity); call-counting red/green regression | 2026-07-21 | — | 218 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1451,6 +1452,34 @@ silently discarded its zone argument.
   invalid-zone error, no-arg shape, AM/PM + millis parse round-trips against
   locally-computed epochs. Workspace 218 tests / clippy 0 / fmt. syntax.md documents the
   pattern/zone forms (upstream doc candidate: Java's page is equally terse).
+
+---
+
+## Increment 54 — parity remediation 5: the fetcher cache key (2026-07-21)
+
+Fifth increment of the parity-remediation program — the last High (finding F6). The
+knowledge-graph fetcher cached provider responses keyed on the WHOLE staged fetch map
+(everything the fetcher's own `input` mapping staged), while Java keys on the
+dictionary-scoped namespace `{node}.dd.{alias}.*` — dictionary-declared inputs only.
+Since the Rust key was a strict superset, Rust could only miss where Java hits: two
+fetches with identical declared inputs but different fetcher-level staging re-fired the
+provider call Java reuses — including side-effecting POSTs.
+
+- **Fix** (`fetcher.rs`, single-request path — `for_each` has no cache in either
+  engine): the cache lookup/store key is now the dd-namespace map read back from the
+  state machine after `fill_dictionary_api_parameters`, mirroring Java
+  `makeRegularHttpCall` exactly (a no-input dictionary keys on the empty map, as in
+  Java). The provider-call log line and the `parameters` trace annotation now report
+  the dictionary-scoped keys, matching Java's output. The now-unused whole-map
+  conversion helper was removed.
+- **Test:** `fetcher_cache_key_uses_dictionary_declared_inputs_only` — a
+  call-counting mock provider (`mock.cache.counter`) behind the new `rust-cache-key`
+  fixture: two sequential fetchers stage different undeclared `extra` parameters while
+  their dictionaries declare the same `person_id`. **Red/green-verified**: pre-fix code
+  makes 2 provider calls, fixed code makes 1 and both fetches surface the same cached
+  response. (The assessment recommended exactly this call-counting regression in each
+  repository — the Java repo can adopt the same fixture.) Workspace 218 tests /
+  clippy 0 / fmt.
 
 ---
 

--- a/docs/design/knowledge-graph-port.md
+++ b/docs/design/knowledge-graph-port.md
@@ -119,7 +119,10 @@ changes).
    > text, https rejected explicitly) + the `AsyncHttpRequest` builder/parser.
    > event-script: E-9 http-client fixtures activated E2E incl. the full-shape W3C
    > trace-propagation test through the real HTTP edge. knowledge-graph:
-   > `fetcher.rs` (dictionary/provider, `key:default` fallbacks, instance cache,
+   > `fetcher.rs` (dictionary/provider, `key:default` fallbacks, instance cache —
+   > keyed on the DICTIONARY-scoped parameter map `{node}.dd.{alias}.*`, declared
+   > inputs only, exactly like Java `makeRegularHttpCall` (increment 54, parity F6:
+   > the whole-staged-map key re-fired provider calls Java reuses, POSTs included) —
    > for-each fork-join) + `features.rs` (`FeatureRunner` registry — explicit
    > registration replaces the Java annotation scan; built-in log-request/
    > response-headers). Tutorials 3/5/6/12/114 + unit-test-1 pass over real HTTP

--- a/memory/archive/2026-Q3.md
+++ b/memory/archive/2026-Q3.md
@@ -307,3 +307,44 @@
   the full join-barrier arc (increments 40+41) is live in BOTH engines.
   → serves: vision-mercury
   <!-- id: join-barrier-valid-completions | created: 2026-07-19 | last_used: 2026-07-19 | uses: 1 | tier: archive-candidate | origin: 2026-07-19-233602.md -->
+
+## 2026-07-21 — archived via archive-fact (faded)
+
+### Faded facts
+
+- [x] **Prepare `docs/guides` for the human reader — COMPLETE 2026-07-20 (increments 43–46,
+  all four phases).** MkDocs+Material site, 20 nav pages strict-green: Home + Getting Started
+  (43); Foundations + Layer 1/2 guides with the layer-organized "AI-enabled" nav (44); Layer 3
+  human set incl. composing-the-layers (sweep finding #9 closed) + rest-automation +
+  flow-schema + six D-H2 source-enumerated references (45); port-scope + polish + final pass
+  (46). ~4,600 lines, all source-verified, ~40 port-note boxes. **This was the stated gate
+  before graduation to github.com/Accenture/mercury.** Upstream doc-fix candidates parked:
+  Java flow-schema documents `error.status` but the engine key is `error.code` (both
+  implementations); `error.stack` null in Rust. Original backlog text:** **Design approved (Q1–Q4
+  answered: guides/ tree for both audiences; identity = github.com/Accenture/mercury —
+  graduation after the docs; deep-purple palette; help pages unchanged) + PHASES 1–2 SHIPPED
+  2026-07-20 (increments 43–44)**: scaffold + Home + Getting Started + strict CI; then
+  Foundations trio + Layer 1/2 guides (7 source-verified pages, 17 port-note boxes,
+  observability records verbatim from a live run) with the Java site's LAYER-ORGANIZED nav
+  (each layer's AI agent guide inside its section — "the repo is AI-enabled"). PHASE 3
+  SHIPPED same day (increment 45: 12 pages — KG human set incl. composing-the-layers closing
+  sweep finding #9, rest-automation, flow-schema, the six D-H2 reference conversions with
+  source-enumerated keys; 19 nav pages, strict build green; Java-doc bugs surfaced:
+  `error.status`→`error.code`, `error.stack` null — upstream doc-fix candidates). Remaining:
+  phase 4 (background/port-scope page + Home polish + final link pass). Design
+  (`docs/design/human-docs.md` v1): MkDocs+Material per the agent-memory
+  recipe; core rule D-H2 = no wide reference tables (entry-per-heading, the maintainer's
+  presentation critique); human pages under `docs/guides-human/` (AI-doc paths untouched);
+  AI set surfaced under Reference (link, never restate); 18 Java pages mapped, 8 skipped
+  (out of port scope); 4 increments; 4 open questions. Maintainer decision 2026-07-19:
+  the guides tree currently serves AI agents (the knowledge-graph AI set + event-script +
+  event-driven AI guides, hardened by the validation sweep); the **human developer documentation
+  was deferred** and is now backlog. Source map: the Java upstream's human guides
+  (`~/sandbox/mercury-composable/docs/guides/` — getting-started, architecture, methodology,
+  event-driven walkthroughs like write-your-first-function / function-execution, rest-automation
+  human pages, api-overview, annotations/configuration/event-envelope references, observability,
+  index/home) — adapted to the Rust port the way the help pages were (2026-07-19): map don't
+  mirror, all code in the Rust API, port truths (tokio not virtual threads, `#[preload]` not
+  `@PreLoad`, no Kafka/Spring), verified against source. The AI docs stay agent-optimized and
+  separate; the in-app help pages are already done. → serves: vision-mercury
+  <!-- id: ot-human-guides-backlog | created: 2026-07-19 | last_used: 2026-07-20 | uses: 7 | tier: archive-candidate | origin: 2026-07-19-181641.md -->

--- a/memory/archive/INDEX.md
+++ b/memory/archive/INDEX.md
@@ -26,3 +26,4 @@
 - ot-sync-ok-heuristic-fix — Bug FIXED (Rust; Java prepared): `/sync` ok-heuristic false-negative on import's benign — faded — 2026-Q3.md
 - plugin-numeric-promotion — Numeric promotion for the simple-plugin arithmetic family (increment 39, BOTH ports). — faded — 2026-Q3.md
 - join-barrier-valid-completions — LATENT BUG fixed (both ports): join barrier counted failed/reset branches (increment 40). — faded — 2026-Q3.md
+- ot-human-guides-backlog — Prepare `docs/guides` for the human reader — COMPLETE 2026-07-20 (increments 43–46, — faded — 2026-Q3.md

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-051629)
+- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-212346)
 - **last_review:** 2026-07-21 | through 2026-07-21-021231
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -70,7 +70,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Rust layer by layer, foundation → UI (platform-core, then event-script, then active
   knowledge graph), preserving the Java project's behavior. The Java repo is the canonical
   spec (map, don't mirror).
-  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 64 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 65 | tier: active | origin: 2026-07-15-215538.md -->
 ## Conventions
 
 > Established with the first code (increment 1, 2026-07-15); enforced from the first commit.
@@ -94,7 +94,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   2026-07-16): annotated functions + `platform_core::auto_start_main!();` with the app's
   `resources/` beside its `Cargo.toml` — never cargo examples inside a library crate.
   Event-script and knowledge-graph demos land as sibling `examples/<name>/` crates.
-  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 63 | tier: active | origin: 2026-07-15-224707.md -->
+  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 64 | tier: active | origin: 2026-07-15-224707.md -->
 
 ## Open Threads
 
@@ -263,43 +263,6 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   workspace 202 tests / clippy 0 / fmt clean. `/sync` unaffected (commands still arrive as strings in
   both engines, even mislabeled as JSON). → serves: vision-mercury
   <!-- id: http-boundary-content-type-parity | created: 2026-07-19 | last_used: 2026-07-19 | uses: 1 | tier: working | origin: 2026-07-19-213516.md -->
-
-- [x] **Prepare `docs/guides` for the human reader — COMPLETE 2026-07-20 (increments 43–46,
-  all four phases).** MkDocs+Material site, 20 nav pages strict-green: Home + Getting Started
-  (43); Foundations + Layer 1/2 guides with the layer-organized "AI-enabled" nav (44); Layer 3
-  human set incl. composing-the-layers (sweep finding #9 closed) + rest-automation +
-  flow-schema + six D-H2 source-enumerated references (45); port-scope + polish + final pass
-  (46). ~4,600 lines, all source-verified, ~40 port-note boxes. **This was the stated gate
-  before graduation to github.com/Accenture/mercury.** Upstream doc-fix candidates parked:
-  Java flow-schema documents `error.status` but the engine key is `error.code` (both
-  implementations); `error.stack` null in Rust. Original backlog text:** **Design approved (Q1–Q4
-  answered: guides/ tree for both audiences; identity = github.com/Accenture/mercury —
-  graduation after the docs; deep-purple palette; help pages unchanged) + PHASES 1–2 SHIPPED
-  2026-07-20 (increments 43–44)**: scaffold + Home + Getting Started + strict CI; then
-  Foundations trio + Layer 1/2 guides (7 source-verified pages, 17 port-note boxes,
-  observability records verbatim from a live run) with the Java site's LAYER-ORGANIZED nav
-  (each layer's AI agent guide inside its section — "the repo is AI-enabled"). PHASE 3
-  SHIPPED same day (increment 45: 12 pages — KG human set incl. composing-the-layers closing
-  sweep finding #9, rest-automation, flow-schema, the six D-H2 reference conversions with
-  source-enumerated keys; 19 nav pages, strict build green; Java-doc bugs surfaced:
-  `error.status`→`error.code`, `error.stack` null — upstream doc-fix candidates). Remaining:
-  phase 4 (background/port-scope page + Home polish + final link pass). Design
-  (`docs/design/human-docs.md` v1): MkDocs+Material per the agent-memory
-  recipe; core rule D-H2 = no wide reference tables (entry-per-heading, the maintainer's
-  presentation critique); human pages under `docs/guides-human/` (AI-doc paths untouched);
-  AI set surfaced under Reference (link, never restate); 18 Java pages mapped, 8 skipped
-  (out of port scope); 4 increments; 4 open questions. Maintainer decision 2026-07-19:
-  the guides tree currently serves AI agents (the knowledge-graph AI set + event-script +
-  event-driven AI guides, hardened by the validation sweep); the **human developer documentation
-  was deferred** and is now backlog. Source map: the Java upstream's human guides
-  (`~/sandbox/mercury-composable/docs/guides/` — getting-started, architecture, methodology,
-  event-driven walkthroughs like write-your-first-function / function-execution, rest-automation
-  human pages, api-overview, annotations/configuration/event-envelope references, observability,
-  index/home) — adapted to the Rust port the way the help pages were (2026-07-19): map don't
-  mirror, all code in the Rust API, port truths (tokio not virtual threads, `#[preload]` not
-  `@PreLoad`, no Kafka/Spring), verified against source. The AI docs stay agent-optimized and
-  separate; the in-app help pages are already done. → serves: vision-mercury
-  <!-- id: ot-human-guides-backlog | created: 2026-07-19 | last_used: 2026-07-20 | uses: 7 | tier: archive-candidate | origin: 2026-07-19-181641.md -->
 
 - [x] **Discovery commands for deployed flows and graph models — DONE 2026-07-20 (increment 42,
   BOTH ports).** From tut-11 finding #38: the `list` command grows two read-only forms —
@@ -483,7 +446,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Rust's counts brackets — differs only for an array-index path ending an unquoted list
   (`output.body[0]]`), unreachable except via Java's exception fallback.
   → serves: vision-mercury
-  <!-- id: ot-describe-surface-trailing-bracket | created: 2026-07-20 | last_used: 2026-07-21 | uses: 2 | tier: active | origin: 2026-07-20-213830.md -->
+  <!-- id: ot-describe-surface-trailing-bracket | created: 2026-07-20 | last_used: 2026-07-21 | uses: 2 | tier: archive-candidate | origin: 2026-07-20-213830.md -->
 
 - [x] **Re-verify invariants — CONFIRMED 2026-07-21 (maintainer ceremony):**
   `inv-never-couple-functions` holds (code evidence: zero direct inter-function calls across
@@ -525,9 +488,12 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   (increment 53): real pattern tokenizer (names/12h/AM-PM/SSS/quoted literals/offsets;
   unsupported letters fail loudly), `f:dateTime` zone arg via chrono-tz + ISO_DATE_TIME
   no-arg form with [zone-id] suffix; parse plugins ride the same converter; deterministic
-  zone tests; workspace 218/clippy 0/fmt; deps + micro-divergences documented; (5) fetcher cache key = dictionary-declared
-  inputs only (Rust keys the whole staged fetch map → re-fires POSTs Java reuses;
-  single-request path only); (6) registration semantics (Java replaces on re-register,
+  zone tests; workspace 218/clippy 0/fmt; deps + micro-divergences documented; (5) fetcher cache key — DONE 2026-07-21
+  (increment 54, the last High): key = the dd-namespace map `{node}.dd.{alias}.*`
+  (declared inputs only, Java makeRegularHttpCall parity; log + trace annotation now
+  report dd-scoped keys); call-counting red/green regression (rust-cache-key fixture +
+  mock.cache.counter — pre-fix 2 calls, fixed 1; Java repo can adopt the same fixture);
+  workspace 218/clippy 0/fmt; (6) registration semantics (Java replaces on re-register,
   clamps instances 1..=1000), config resolver false-cycle on repeated `${a} ${a}`,
   .properties full syntax; (7) REST routing parity (multi-value query params, 405-vs-404 +
   OPTIONS, cookies map/raw query/https flag — https is hardcoded false; wildcard deltas both
@@ -539,7 +505,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   **F2 (null-on-spill) needs a maintainer decision**, not a fix: documented design, but the
   consequence (Nil visibility varies with load) is stated nowhere — document or normalize.
   Full verdict table in the session log. → serves: vision-mercury (faithful port)
-  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 5 | tier: working | origin: 2026-07-21-030938.md -->
+  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 6 | tier: working | origin: 2026-07-21-030938.md -->
 
 - [ ] **(backlog) Port `ManagedCache` (+ sibling `SimpleCache`).** Java platform-core ships
   `org.platformlambda.core.util.ManagedCache` — a named, self-managing TTL+size-bounded

--- a/memory/sessions/2026-07-21-212346.md
+++ b/memory/sessions/2026-07-21-212346.md
@@ -1,0 +1,33 @@
+# Session (2026-07-21T21:23:46.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Increment 54 — parity remediation 5: the fetcher cache key** (finding F6, the last
+High). The Rust fetcher keyed its per-instance provider cache on the WHOLE staged fetch
+map; Java keys on the dictionary-scoped namespace `{node}.dd.{alias}.*` (declared inputs
+only). Rust's superset key could only miss where Java hits — re-firing provider calls
+Java reuses, side-effecting POSTs included.
+
+- **Fix** (`fetcher.rs`, single-request path; `for_each` has no cache in either engine):
+  the lookup/store key is now the dd-namespace map read back after
+  `fill_dictionary_api_parameters` — the exact Java `makeRegularHttpCall` read (no-input
+  dictionary ⇒ empty-map key, as in Java). The provider log line + `parameters` trace
+  annotation now report dd-scoped keys like Java. Removed the now-unused `pairs_to_value`.
+- **Test** (the assessment's recommended call-counting regression):
+  `fetcher_cache_key_uses_dictionary_declared_inputs_only` — new `rust-cache-key`
+  fixture (two sequential fetchers staging different undeclared `extra` params, two
+  dictionaries declaring the same `person_id`, one shared provider) against a new
+  counting mock (`mock.cache.counter` + rest.yaml route). **Red/green: pre-fix = 2
+  provider calls (observed), fixed = 1**, both fetches surface the same cached response.
+- Workspace 218 tests / clippy 0 / fmt. Docs: INCREMENTS.md §54; knowledge-graph design
+  doc K-5 fetcher passage updated. The Java repo can adopt the same fixture as its
+  call-counting guard (assessment recommendation — both repos).
+
+## Memory References
+
+- referenced: ot-parity-remediation (item 5 → DONE; all CRITICAL+High findings now
+  remediated), port-bottom-up-faithful, conventions-rust-baseline
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

Increment 54 — parity remediation item 5 (finding F6, the last High). The fetcher's
per-instance provider cache is now keyed on the **dictionary-scoped parameter map**
(`{node}.dd.{alias}.*` — declared inputs only), read back after
`fill_dictionary_api_parameters` exactly as Java's `GraphApiFetcher.makeRegularHttpCall`
does (a no-input dictionary keys on the empty map). The provider-call log line and the
`parameters` trace annotation now report the dictionary-scoped keys, matching Java's
output.

## Why

The old key was the whole staged fetch map — a strict superset of Java's — so Rust could
only miss where Java hits: two fetches with identical dictionary-declared inputs but
different fetcher-level staging re-fired the provider call Java reuses, **including
side-effecting POSTs**. The divergence was confined to the single-request path (`for_each`
has no cache in either engine).

Verified with the assessment's recommended call-counting regression:
`fetcher_cache_key_uses_dictionary_declared_inputs_only` drives the new `rust-cache-key`
fixture — two sequential fetchers staging different undeclared `extra` parameters, two
dictionaries declaring the same `person_id`, one shared provider — against a counting mock.
**Red/green: the pre-fix code makes 2 provider calls (observed), the fixed code makes 1**,
and both fetches surface the same cached response. The Java repo can adopt the same fixture
as its own guard. Workspace 218 tests green, clippy clean, fmt applied; `INCREMENTS.md` and
the knowledge-graph design doc updated.

This completes the Critical + all five High findings; items 6–8 (config/registration
semantics, REST routing parity, remaining mappings) remain in `ot-parity-remediation`.

Co-Authored-By: Claude Code <noreply@anthropic.com>