### PR TITLE
fix(platform-core): registration replace/clamp semantics, config false-cycle fix, full .properties syntax (increment 55)

### DIFF
--- a/crates/platform-core/src/platform.rs
+++ b/crates/platform-core/src/platform.rs
@@ -100,6 +100,10 @@ pub struct Platform {
 
 /// Registration options (Java annotation analogs): `zero_traced` is
 /// `@ZeroTracing` (this route's executions are excluded from trace recording);
+/// Java `ServiceDef.MAX_INSTANCES`: the worker-count ceiling — registration
+/// clamps to `1..=1000` exactly like `setConcurrency`.
+const MAX_INSTANCES: usize = 1000;
+
 /// `interceptor` is `@EventInterceptor` (the function receives the raw
 /// envelope — `reply_to`/`cid` intact — and replies manually; the worker sends
 /// no auto-reply on success, though a failure still routes to `reply_to`).
@@ -162,15 +166,21 @@ impl Platform {
         options: FunctionOptions,
     ) -> Result<(), AppError> {
         validate_route(route)?;
-        if instances == 0 {
-            return Err(AppError::new(400, "instances must be at least 1"));
-        }
+        // Java ServiceDef.setConcurrency: Math.max(1, Math.min(n, 1000)) —
+        // zero is accepted (→ 1) and the worker count is capped, silently
+        // (F10 parity fix, 2026-07-21; previously 0 was rejected and there
+        // was no ceiling)
+        let instances = instances.clamp(1, MAX_INSTANCES);
         let (mailbox_tx, mailbox_rx) = mpsc::channel::<MailboxMessage>(dispatch_mailbox_size());
         let stop = Arc::new(Notify::new());
         {
             let mut routes = self.routes.write().expect("route registry poisoned");
-            if routes.contains_key(route) {
-                return Err(AppError::new(400, format!("Route {route} already exists")));
+            // Java Platform.register: an existing route is RELOADED — the old
+            // service is released and the new one takes its place (F10 parity
+            // fix; previously rejected with "already exists")
+            if let Some(previous) = routes.remove(route) {
+                log::warn!("Reloading LambdaFunction {route}");
+                previous.stop.notify_one();
             }
             routes.insert(
                 route.to_string(),

--- a/crates/platform-core/src/util/config_reader.rs
+++ b/crates/platform-core/src/util/config_reader.rs
@@ -273,9 +273,17 @@ impl ConfigReader {
             log::warn!("Config loop for '{key}' detected");
             Some(String::new())
         } else {
+            // `visited` is the CURRENT resolution chain, not an ever-seen
+            // set: pop after the segment resolves so a repeated reference
+            // (`${a} ${a}`, or a diamond) is not a false cycle — the Java
+            // resolver keeps a fresh per-segment chain (F11 parity fix,
+            // 2026-07-21); a genuine a→b→a cycle is still on the chain
             visited.push(name.to_string());
-            self.base_get(name, default, visited)
-                .map(|v| v.to_display_string())
+            let resolved = self
+                .base_get(name, default, visited)
+                .map(|v| v.to_display_string());
+            visited.pop();
+            resolved
         };
         from_base.or_else(|| middle_default.map(str::to_string))
     }
@@ -386,22 +394,35 @@ impl ConfigReader {
         Ok(())
     }
 
-    /// Minimal `.properties` support: `key=value` lines, `#`/`!` comments.
-    /// Values are strings (Java `Properties` semantics); composite keys expand
-    /// into the nested tree via `set_element`, sorted first (Java behavior).
+    /// `.properties` with `java.util.Properties.load` semantics (increment 55,
+    /// parity F13 — previously only trimmed `key=value` lines parsed):
+    /// `=`/`:`/whitespace separators, backslash line continuations, `\uXXXX`
+    /// and single-character escapes, and the value's trailing whitespace
+    /// PRESERVED. Values are strings; composite keys expand into the nested
+    /// tree via `set_element`, sorted first (Java behavior).
     fn load_properties_text(&mut self, data: &str) -> Result<(), ConfigError> {
         let mut pairs: Vec<(String, String)> = Vec::new();
-        for line in data.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with('!') {
+        let mut lines = data.lines();
+        while let Some(line) = lines.next() {
+            // leading whitespace never counts; blank + comment lines skipped
+            let stripped = line.trim_start();
+            if stripped.is_empty() || stripped.starts_with('#') || stripped.starts_with('!') {
                 continue;
             }
-            if let Some(eq) = trimmed.find('=') {
-                let key = trimmed[..eq].trim();
-                let value = trimmed[eq + 1..].trim();
-                if !key.is_empty() {
-                    pairs.push((key.to_string(), value.to_string()));
+            // fold backslash continuations into one logical line (a line
+            // ending with an ODD number of backslashes continues; the next
+            // line's leading whitespace is stripped)
+            let mut logical = stripped.to_string();
+            while ends_with_odd_backslashes(&logical) {
+                logical.pop();
+                match lines.next() {
+                    Some(next) => logical.push_str(next.trim_start()),
+                    None => break,
                 }
+            }
+            let (key, value) = split_properties_line(&logical).map_err(ConfigError::Invalid)?;
+            if !key.is_empty() {
+                pairs.push((key, value));
             }
         }
         pairs.sort_by(|a, b| a.0.cmp(&b.0));
@@ -411,6 +432,89 @@ impl ConfigReader {
                 .map_err(ConfigError::Invalid)?;
         }
         Ok(())
+    }
+}
+
+/// True when the line ends with an odd number of backslashes — the
+/// `java.util.Properties` line-continuation rule (an even count is pairs of
+/// escaped backslashes, not a continuation).
+fn ends_with_odd_backslashes(line: &str) -> bool {
+    line.bytes().rev().take_while(|b| *b == b'\\').count() % 2 == 1
+}
+
+/// Split one logical `.properties` line into (key, value) with
+/// `java.util.Properties` rules: the key ends at the first unescaped `=`,
+/// `:` or whitespace (whitespace may be followed by one optional `=`/`:`);
+/// escapes decode in both key and value; the value keeps trailing whitespace.
+fn split_properties_line(line: &str) -> Result<(String, String), String> {
+    let chars: Vec<char> = line.chars().collect();
+    let mut key = String::new();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        if c == '\\' {
+            let (decoded, used) = decode_properties_escape(&chars[i..])?;
+            key.push(decoded);
+            i += used;
+            continue;
+        }
+        if c == '=' || c == ':' {
+            i += 1;
+            break;
+        }
+        if c.is_whitespace() {
+            while i < chars.len() && chars[i].is_whitespace() {
+                i += 1;
+            }
+            if i < chars.len() && (chars[i] == '=' || chars[i] == ':') {
+                i += 1;
+            }
+            break;
+        }
+        key.push(c);
+        i += 1;
+    }
+    while i < chars.len() && chars[i].is_whitespace() {
+        i += 1;
+    }
+    let mut value = String::new();
+    while i < chars.len() {
+        let c = chars[i];
+        if c == '\\' {
+            let (decoded, used) = decode_properties_escape(&chars[i..])?;
+            value.push(decoded);
+            i += used;
+            continue;
+        }
+        value.push(c);
+        i += 1;
+    }
+    Ok((key, value))
+}
+
+/// Decode one backslash escape (`chars[0]` is the backslash):
+/// `\t` `\n` `\r` `\f`, `\uXXXX`, and `\x` → `x` for any other character —
+/// exactly `java.util.Properties.loadConvert` (malformed `\u` is an error,
+/// as in Java).
+fn decode_properties_escape(chars: &[char]) -> Result<(char, usize), String> {
+    match chars.get(1) {
+        Some('t') => Ok(('\t', 2)),
+        Some('n') => Ok(('\n', 2)),
+        Some('r') => Ok(('\r', 2)),
+        Some('f') => Ok(('\u{000C}', 2)),
+        Some('u') => {
+            let hex: String = chars.iter().skip(2).take(4).collect();
+            if hex.len() == 4 {
+                if let Ok(code) = u32::from_str_radix(&hex, 16) {
+                    if let Some(c) = char::from_u32(code) {
+                        return Ok((c, 6));
+                    }
+                }
+            }
+            Err("Malformed \\uxxxx encoding in .properties".to_string())
+        }
+        Some(&other) => Ok((other, 2)),
+        None => Ok(('\\', 1)),
     }
 }
 

--- a/crates/platform-core/tests/config.rs
+++ b/crates/platform-core/tests/config.rs
@@ -260,3 +260,56 @@ fn composite_key_values_view_is_substituted_and_cached() {
     let again = app.get_composite_key_values();
     assert_eq!(view as *const _, again as *const _);
 }
+
+// ---- increment 55: config parity (findings F11 / F13) ----
+
+/// F11: a repeated `${ref}` in one value — or a diamond through a nested
+/// reference — is NOT a cycle (Java keeps a fresh per-segment chain; the old
+/// shared visited-list blanked the repeat and warned "Config loop").
+#[test]
+fn repeated_references_are_not_false_cycles() {
+    setup();
+    let app = AppConfigReader::get_instance();
+    assert_eq!(
+        app.get_property("subst.repeated").as_deref(),
+        Some("localhost localhost")
+    );
+    assert_eq!(
+        app.get_property("subst.diamond").as_deref(),
+        Some("http://localhost:8085/x on localhost")
+    );
+}
+
+/// F13: `.properties` follows java.util.Properties.load — `:`/whitespace
+/// separators, backslash continuations, escapes, trailing whitespace kept.
+#[test]
+fn properties_syntax_matches_java_util_properties() {
+    setup();
+    let props = ConfigReader::load("classpath:/props-syntax.properties").unwrap();
+    assert_eq!(
+        props.get_property("colon.key").as_deref(),
+        Some("colon value")
+    );
+    assert_eq!(
+        props.get_property("space.key").as_deref(),
+        Some("value with space separator")
+    );
+    assert_eq!(
+        props.get_property("multi.line").as_deref(),
+        Some("first second")
+    );
+    assert_eq!(props.get_property("escaped.tab").as_deref(), Some("a\tb"));
+    assert_eq!(props.get_property("unicode.key").as_deref(), Some("ABC"));
+    assert_eq!(
+        props.get_property("slash.path").as_deref(),
+        Some("C:\\temp")
+    );
+    // Java preserves the value's trailing whitespace (no trimming)
+    assert_eq!(
+        props.get_property("trailing.space").as_deref(),
+        Some("keep   ")
+    );
+    // both comment forms skipped
+    assert!(!props.exists("!"));
+    assert!(!props.exists("#"));
+}

--- a/crates/platform-core/tests/event_bus.rs
+++ b/crates/platform-core/tests/event_bus.rs
@@ -175,16 +175,46 @@ fn envelope_round_trips_through_msgpack() {
 // ---- registry ----
 
 #[tokio::test]
-async fn route_validation_and_duplicates_are_rejected() {
+async fn route_validation_replacement_and_worker_clamp_match_java() {
     setup_config();
     let platform = Platform::new();
     assert!(platform.register("badroute", Arc::new(Echo), 1).is_err());
     assert!(platform.register("UPPER.case", Arc::new(Echo), 1).is_err());
-    assert!(platform.register("v1.echo", Arc::new(Echo), 0).is_err());
+    // Java ServiceDef.setConcurrency clamps to 1..=1000 (increment 55,
+    // parity F10): zero is accepted (→ 1), excess is capped
+    platform
+        .register("v1.echo.clamped", Arc::new(Echo), 0)
+        .unwrap();
+    assert_eq!(platform.instances("v1.echo.clamped"), Some(1));
+    platform
+        .register("v1.echo.capped", Arc::new(Echo), 5000)
+        .unwrap();
+    assert_eq!(platform.instances("v1.echo.capped"), Some(1000));
     platform.register("v1.echo", Arc::new(Echo), 1).unwrap();
     assert!(platform.has_route("v1.echo"));
-    // duplicate registration is refused
-    assert!(platform.register("v1.echo", Arc::new(Echo), 1).is_err());
+    // Java Platform.register RELOADS an existing route (replace, not reject) —
+    // the replacement function serves subsequent requests
+    let replaced = Arc::new(AtomicUsize::new(0));
+    let counter = Counter {
+        calls: replaced.clone(),
+        in_flight: Arc::new(AtomicUsize::new(0)),
+        max_in_flight: Arc::new(AtomicUsize::new(0)),
+        delay: Duration::ZERO,
+    };
+    platform.register("v1.echo", Arc::new(counter), 1).unwrap();
+    let po = PostOffice::new(&platform);
+    let reply = po
+        .request(
+            EventEnvelope::new()
+                .set_to("v1.echo")
+                .set_body("x")
+                .unwrap(),
+            Duration::from_secs(2),
+        )
+        .await
+        .expect("reloaded route serves");
+    assert!(!reply.has_error());
+    assert_eq!(replaced.load(Ordering::SeqCst), 1, "the REPLACEMENT ran");
     // release closes the route
     assert!(platform.release("v1.echo"));
     assert!(!platform.has_route("v1.echo"));

--- a/crates/platform-core/tests/resources/application.yml
+++ b/crates/platform-core/tests/resources/application.yml
@@ -12,6 +12,9 @@ subst:
   env: '${PC_TEST_HOME:none}'
   default: '${PC_TEST_MISSING:fallback-value}'
   ref: 'http://${server.host}:${server.port}/x'
+  # increment 55 (parity F11): repeated references are NOT cycles
+  repeated: '${server.host} ${server.host}'
+  diamond: '${subst.ref} on ${server.host}'
 
 looptest:
   a: '${looptest.b}'

--- a/crates/platform-core/tests/resources/props-syntax.properties
+++ b/crates/platform-core/tests/resources/props-syntax.properties
@@ -1,0 +1,10 @@
+colon.key: colon value
+space.key value with space separator
+multi.line=first \
+    second
+escaped.tab=a\tb
+unicode.key=\u0041BC
+slash.path=C\:\\temp
+trailing.space=keep   
+! bang comment line
+# hash comment line

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -71,6 +71,7 @@
 | 52 | parity remediation 3 — Event Script safety: `max.model.array.size` cap enforced on dynamic RHS indices (+ docs contradiction fixed), flow-launch `body` precondition | 2026-07-21 | — | 217 |
 | 53 | parity remediation 4 — date/time plugins: full Java-pattern tokenizer (names, 12h/AM-PM, SSS, quoted literals, offsets; loud failure on unsupported letters), `f:dateTime` zone argument + ISO_DATE_TIME no-arg form | 2026-07-21 | — | 218 |
 | 54 | parity remediation 5 — fetcher cache key = dictionary-declared inputs only (`{node}.dd.{alias}.*`, Java makeRegularHttpCall parity); call-counting red/green regression | 2026-07-21 | — | 218 |
+| 55 | parity remediation 6 — registration replaces + clamps 1..=1000 (Java Platform.register/ServiceDef), config resolver per-segment loop chain (no false cycles), .properties full java.util.Properties syntax | 2026-07-21 | — | 220 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1480,6 +1481,35 @@ provider call Java reuses — including side-effecting POSTs.
   response. (The assessment recommended exactly this call-counting regression in each
   repository — the Java repo can adopt the same fixture.) Workspace 218 tests /
   clippy 0 / fmt.
+
+---
+
+## Increment 55 — parity remediation 6: registration + configuration semantics (2026-07-21)
+
+Sixth increment of the parity-remediation program — three Medium findings (F10/F11/F13):
+
+- **F10 — registration semantics** (`platform.rs`): re-registering an existing route now
+  RELOADS it exactly like Java `Platform.register` — warn "Reloading", release the old
+  service, register the new one (previously rejected with "already exists"); the worker
+  count clamps to `1..=1000` like `ServiceDef.setConcurrency` (zero → 1, excess capped —
+  previously zero was a 400 and there was no ceiling). The lifecycle's repeat-execution
+  no-op is Atomic-guarded, unaffected.
+- **F11 — config resolver false cycles** (`config_reader.rs`): the `${...}` loop guard is
+  now a true resolution CHAIN (push, resolve, pop) — the Java per-segment equivalent — so
+  `x: "${a} ${a}"` and diamond references resolve fully instead of blanking the repeat
+  with a spurious "Config loop" warning. Genuine `a→b→a` cycles still resolve to empty
+  with the warning (existing test unchanged).
+- **F13 — `.properties` full syntax** (`config_reader.rs`): the loader now implements
+  `java.util.Properties.load` — `=`/`:`/whitespace separators, backslash line
+  continuations (odd-backslash rule), `\t`/`\n`/`\r`/`\f`/`\uXXXX`/`\x` escapes in
+  keys and values, malformed `\u` errors like Java, and the value's trailing whitespace
+  preserved (previously only trimmed `key=value` parsed; other separators were silently
+  dropped).
+- **Tests (red/green-verified — all fail on the pre-fix source):** the registration test
+  reworked to the Java contract (replacement function serves, clamp 0→1 and 5000→1000);
+  `repeated_references_are_not_false_cycles` (+ new fixture keys);
+  `properties_syntax_matches_java_util_properties` (+ `props-syntax.properties` fixture
+  covering every syntax form). Workspace 220 tests / clippy 0 / fmt.
 
 ---
 

--- a/docs/design/platform-core-port.md
+++ b/docs/design/platform-core-port.md
@@ -122,7 +122,12 @@ impl ConfigReader {
 }
 ```
 
-**Formats:** `.yml`/`.yaml` (YAML), `.json`, `.properties` (line-based `k=v`, sorted-key load).
+**Formats:** `.yml`/`.yaml` (YAML), `.json`, `.properties` (full `java.util.Properties.load`
+syntax since increment 55, parity F13: `=`/`:`/whitespace separators, backslash line
+continuations, `\uXXXX` + single-char escapes, value trailing-whitespace preserved;
+sorted-key load). `${...}` resolution keeps a per-segment chain (increment 55, parity F11 —
+a repeated `${a} ${a}` or diamond reference is not a false cycle; genuine cycles still
+resolve to empty with a warning).
 Tabs in YAML are tolerated (replaced with two spaces — ported quirk).
 
 **Lookup precedence in `get(key)`** (ported exactly):

--- a/memory/archive/2026-Q3.md
+++ b/memory/archive/2026-Q3.md
@@ -348,3 +348,22 @@
   `@PreLoad`, no Kafka/Spring), verified against source. The AI docs stay agent-optimized and
   separate; the in-app help pages are already done. → serves: vision-mercury
   <!-- id: ot-human-guides-backlog | created: 2026-07-19 | last_used: 2026-07-20 | uses: 7 | tier: archive-candidate | origin: 2026-07-19-181641.md -->
+
+## 2026-07-21 — archived via archive-fact (faded)
+
+### Faded facts
+
+- [x] **Discovery commands for deployed flows and graph models — DONE 2026-07-20 (increment 42,
+  BOTH ports).** From tut-11 finding #38: the `list` command grows two read-only forms —
+  `list graphs` (compiled registry ∪ deployed-folder models, each with the root's `purpose`:
+  living documentation) and `list flows` (Event Script flows) — valid `extension=` /
+  `extension=flow://` targets discoverable without an out-of-band brief, on the console AND both
+  companion endpoints. Rust: `commands.rs` + `playground.rs` assertions (workspace 202/clippy
+  0/fmt). Java: `GraphCommandService` + `/sync` test in `CompanionSyncTest` (70-test suite
+  green); **PR [#199](https://github.com/Accenture/mercury-composable/pull/199) MERGED (2026-07-20)**
+  (3 commits: feature + description/purpose refinements + webapp-bundle refresh) — discovery
+  is live in BOTH engines. AI grammar +
+  catalog + agent-guide recipe + skills-reference + `help list.md` all updated; rollup #38 →
+  DONE. Design note: discovery rides the command surface (no new REST endpoints — `/sync`
+  already gives agents REST access to every command). → serves: vision-mercury
+  <!-- id: ot-discovery-commands-backlog | created: 2026-07-19 | last_used: 2026-07-20 | uses: 6 | tier: archive-candidate | origin: 2026-07-19-171653.md -->

--- a/memory/archive/INDEX.md
+++ b/memory/archive/INDEX.md
@@ -27,3 +27,4 @@
 - plugin-numeric-promotion — Numeric promotion for the simple-plugin arithmetic family (increment 39, BOTH ports). — faded — 2026-Q3.md
 - join-barrier-valid-completions — LATENT BUG fixed (both ports): join barrier counted failed/reset branches (increment 40). — faded — 2026-Q3.md
 - ot-human-guides-backlog — Prepare `docs/guides` for the human reader — COMPLETE 2026-07-20 (increments 43–46, — faded — 2026-Q3.md
+- ot-discovery-commands-backlog — Discovery commands for deployed flows and graph models — DONE 2026-07-20 (increment 42, — faded — 2026-Q3.md

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,8 +15,8 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-212346)
-- **last_review:** 2026-07-21 | through 2026-07-21-021231
+- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-214043)
+- **last_review:** 2026-07-21 | through 2026-07-21-214043
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
 - **vision:** `memory/vision.md` (north star, set at enable — Blueprint gaps to be derived)
@@ -70,7 +70,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Rust layer by layer, foundation → UI (platform-core, then event-script, then active
   knowledge graph), preserving the Java project's behavior. The Java repo is the canonical
   spec (map, don't mirror).
-  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 65 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 66 | tier: active | origin: 2026-07-15-215538.md -->
 ## Conventions
 
 > Established with the first code (increment 1, 2026-07-15); enforced from the first commit.
@@ -94,7 +94,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   2026-07-16): annotated functions + `platform_core::auto_start_main!();` with the app's
   `resources/` beside its `Cargo.toml` — never cargo examples inside a library crate.
   Event-script and knowledge-graph demos land as sibling `examples/<name>/` crates.
-  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 64 | tier: active | origin: 2026-07-15-224707.md -->
+  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 65 | tier: active | origin: 2026-07-15-224707.md -->
 
 ## Open Threads
 
@@ -263,21 +263,6 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   workspace 202 tests / clippy 0 / fmt clean. `/sync` unaffected (commands still arrive as strings in
   both engines, even mislabeled as JSON). → serves: vision-mercury
   <!-- id: http-boundary-content-type-parity | created: 2026-07-19 | last_used: 2026-07-19 | uses: 1 | tier: working | origin: 2026-07-19-213516.md -->
-
-- [x] **Discovery commands for deployed flows and graph models — DONE 2026-07-20 (increment 42,
-  BOTH ports).** From tut-11 finding #38: the `list` command grows two read-only forms —
-  `list graphs` (compiled registry ∪ deployed-folder models, each with the root's `purpose`:
-  living documentation) and `list flows` (Event Script flows) — valid `extension=` /
-  `extension=flow://` targets discoverable without an out-of-band brief, on the console AND both
-  companion endpoints. Rust: `commands.rs` + `playground.rs` assertions (workspace 202/clippy
-  0/fmt). Java: `GraphCommandService` + `/sync` test in `CompanionSyncTest` (70-test suite
-  green); **PR [#199](https://github.com/Accenture/mercury-composable/pull/199) MERGED (2026-07-20)**
-  (3 commits: feature + description/purpose refinements + webapp-bundle refresh) — discovery
-  is live in BOTH engines. AI grammar +
-  catalog + agent-guide recipe + skills-reference + `help list.md` all updated; rollup #38 →
-  DONE. Design note: discovery rides the command surface (no new REST endpoints — `/sync`
-  already gives agents REST access to every command). → serves: vision-mercury
-  <!-- id: ot-discovery-commands-backlog | created: 2026-07-19 | last_used: 2026-07-20 | uses: 6 | tier: archive-candidate | origin: 2026-07-19-171653.md -->
 
 ### Blueprint — gaps from Current State (greenfield) to the Vision  (serves: vision-mercury)
 > Derived 2026-07-15 from the maintainer-set Vision. Each `(blueprint)` thread is a
@@ -493,9 +478,13 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   (declared inputs only, Java makeRegularHttpCall parity; log + trace annotation now
   report dd-scoped keys); call-counting red/green regression (rust-cache-key fixture +
   mock.cache.counter — pre-fix 2 calls, fixed 1; Java repo can adopt the same fixture);
-  workspace 218/clippy 0/fmt; (6) registration semantics (Java replaces on re-register,
-  clamps instances 1..=1000), config resolver false-cycle on repeated `${a} ${a}`,
-  .properties full syntax; (7) REST routing parity (multi-value query params, 405-vs-404 +
+  workspace 218/clippy 0/fmt; (6) registration + config semantics — DONE
+  2026-07-21 (increment 55): register replaces (Java "Reloading" + release) + clamps
+  1..=1000 (ServiceDef.setConcurrency; zero no longer 400), resolver loop guard = true
+  push/pop chain (repeated/diamond refs resolve; genuine cycles still warn+empty),
+  .properties = full java.util.Properties.load (separators/continuations/escapes/
+  trailing-whitespace; malformed \u errors); red/green tests incl. reworked
+  registration contract test; workspace 220/clippy 0/fmt; (7) REST routing parity (multi-value query params, 405-vs-404 +
   OPTIONS, cookies map/raw query/https flag — https is hardcoded false; wildcard deltas both
   directions incl. Rust-only empty-remainder match); (8) remaining mappings: nested `[]`
   append recursion, list→text `List.toString()` parity, UTF-16 length/substring semantics,
@@ -505,7 +494,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   **F2 (null-on-spill) needs a maintainer decision**, not a fix: documented design, but the
   consequence (Nil visibility varies with load) is stated nowhere — document or normalize.
   Full verdict table in the session log. → serves: vision-mercury (faithful port)
-  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 6 | tier: working | origin: 2026-07-21-030938.md -->
+  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 7 | tier: working | origin: 2026-07-21-030938.md -->
 
 - [ ] **(backlog) Port `ManagedCache` (+ sibling `SimpleCache`).** Java platform-core ships
   `org.platformlambda.core.util.ManagedCache` — a named, self-managing TTL+size-bounded

--- a/memory/sessions/2026-07-21-214043.md
+++ b/memory/sessions/2026-07-21-214043.md
@@ -1,0 +1,49 @@
+# Session (2026-07-21T21:40:43.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Increment 55 — parity remediation 6: registration + configuration semantics**
+(findings F10/F11/F13, all Medium):
+
+- **F10** (`platform.rs`): `register_with_options` now RELOADS an existing route (Java
+  `Platform.register`: warn "Reloading", release old, register new — previously a 400
+  "already exists") and clamps the worker count to `1..=1000` per
+  `ServiceDef.setConcurrency` (zero → 1 silently; previously a 400; no ceiling before).
+  The lifecycle repeat-run no-op is Atomic-guarded — unaffected.
+- **F11** (`config_reader.rs`): the `${...}` loop guard became a true resolution chain
+  (push → resolve → pop, the Java per-segment equivalent) — `"${a} ${a}"` and diamond
+  references now resolve fully instead of blanking the repeat with a spurious "Config
+  loop" warning; genuine `a→b→a` cycles still warn + resolve empty (existing test holds).
+- **F13** (`config_reader.rs`): `.properties` loader = full `java.util.Properties.load`
+  syntax — `=`/`:`/whitespace separators, odd-backslash line continuations,
+  `\t\n\r\f`/`\uXXXX`/`\x` escapes in keys and values (malformed `\u` errors like Java),
+  value trailing-whitespace preserved.
+
+Tests, **red/green-verified via `git stash push -- src`**: the registration test reworked
+to the Java contract (`route_validation_replacement_and_worker_clamp_match_java` — the
+replacement function serves; clamp 0→1, 5000→1000);
+`repeated_references_are_not_false_cycles` (+ `subst.repeated`/`subst.diamond` fixture
+keys); `properties_syntax_matches_java_util_properties` (+ `props-syntax.properties`
+fixture covering every syntax form incl. trailing spaces). Workspace 220 tests /
+clippy 0 / fmt. Docs: INCREMENTS.md §55; design-doc §4 formats + resolver notes updated.
+
+## Memory References
+
+- referenced: ot-parity-remediation (item 6 → DONE), port-bottom-up-faithful,
+  conventions-rust-baseline
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>
+
+## Memory Review (2026-07-21, through 2026-07-21-214043)
+- Reactivated:   0
+- Superseded:    0
+- Archived:      1 completed thread → memory/archive/2026-Q3.md (faded past archive_window 20:
+                 ot-discovery-commands-backlog sslu 21)
+- Swept threads: (the one archived above; other [x] threads completed too recently — kept)
+- Archive-verify: pass (memory-lint 0 errors; no id in both continuity and archive)
+- Tier changes:  footers current via refresh-metadata (run before the review; nothing further)
+- Invariants:    not due (last confirmed 2026-07-21; ~10 of 40 sessions elapsed)
+- Contradiction scan: none found (ot-parity-remediation items consistent with the ledger)
+- Promoted core: 0 (auto-core off)


### PR DESCRIPTION
## What

Increment 55 — parity remediation item 6, three Medium findings:

- **Registration semantics (F10):** re-registering an existing route now RELOADS it
  exactly like Java `Platform.register` (warn "Reloading", release the old service,
  register the new) instead of rejecting; the worker count clamps to `1..=1000` like
  `ServiceDef.setConcurrency` (zero → 1 silently, excess capped).
- **Config resolver false cycles (F11):** the `${...}` loop guard is now a true resolution
  chain (push → resolve → pop, Java's per-segment equivalent), so `"${a} ${a}"` and
  diamond references resolve fully instead of blanking the repeat with a spurious
  "Config loop" warning. Genuine cycles still warn and resolve empty.
- **`.properties` full syntax (F13):** the loader implements `java.util.Properties.load` —
  `=`/`:`/whitespace separators, backslash line continuations, `\t\n\r\f`/`\uXXXX`/`\x`
  escapes in keys and values (malformed `\u` errors as in Java), and the value's trailing
  whitespace preserved.

## Why

All three are verified findings from the maintainer-approved parity remediation. The old
registration contract broke Java's hot-reload idiom and let worker counts grow unbounded;
the false-cycle bug silently blanked legitimate config values that reference the same key
twice; and the minimal `.properties` parser silently dropped colon/whitespace-separated
lines — in tension with the D9 rule that config files port between the two engines
unchanged.

Red/green-verified (all tests fail on the pre-fix source): the registration test reworked
to the Java contract (the replacement function serves; clamp 0→1 and 5000→1000),
`repeated_references_are_not_false_cycles`, and
`properties_syntax_matches_java_util_properties` with a fixture covering every syntax form.
Workspace 220 tests green, clippy clean, fmt applied. `INCREMENTS.md` and the design doc
updated. The scheduled memory review also ran in this increment (cadence): one faded
thread archived, lint clean.

Co-Authored-By: Claude Code <noreply@anthropic.com>