### PR TITLE
fix(platform-core): REST routing, request-model, and content-negotiation parity (increment 56)

### DIFF
--- a/crates/platform-core/src/actuator.rs
+++ b/crates/platform-core/src/actuator.rs
@@ -153,30 +153,37 @@ impl ComposableFunction for ActuatorServices {
         let context = &self.context;
         match self.kind {
             ActuatorKind::Liveness => {
+                // Java ActuatorServices: explicit text/plain on the envelope
                 if context.health_status.load(Ordering::SeqCst) {
-                    EventEnvelope::new().set_body("OK")
+                    Ok(EventEnvelope::new()
+                        .set_header("content-type", "text/plain")
+                        .set_body("OK")?)
                 } else {
                     Ok(EventEnvelope::new()
                         .set_status(400)
+                        .set_header("content-type", "text/plain")
                         .set_body("Unhealthy. Please check '/health' endpoint.")?)
                 }
             }
             ActuatorKind::Info => {
                 let now = std::time::SystemTime::now();
                 let uptime = now.duration_since(context.start_time).unwrap_or_default();
-                EventEnvelope::new().set_body(serde_json::json!({
-                    "app": context.app_block(),
-                    "runtime": {
-                        "language": "rust",
-                        "platform_core": env!("CARGO_PKG_VERSION"),
-                    },
-                    "origin": Platform::origin(),
-                    "time": {
-                        "start": trace::iso8601_utc(context.start_time),
-                        "current": trace::iso8601_utc(now),
-                    },
-                    "up_time": elapsed_time(uptime),
-                }))
+                // Java ActuatorServices: explicit application/json envelope type
+                EventEnvelope::new()
+                    .set_header("content-type", "application/json")
+                    .set_body(serde_json::json!({
+                        "app": context.app_block(),
+                        "runtime": {
+                            "language": "rust",
+                            "platform_core": env!("CARGO_PKG_VERSION"),
+                        },
+                        "origin": Platform::origin(),
+                        "time": {
+                            "start": trace::iso8601_utc(context.start_time),
+                            "current": trace::iso8601_utc(now),
+                        },
+                        "up_time": elapsed_time(uptime),
+                    }))
             }
             ActuatorKind::Env => {
                 let config = AppConfigReader::get_instance();
@@ -199,13 +206,15 @@ impl ComposableFunction for ActuatorServices {
                     let value = config.get_property(&name).unwrap_or_default();
                     properties.insert(name, serde_json::Value::String(value));
                 }
-                EventEnvelope::new().set_body(serde_json::json!({
-                    "app": context.app_block(),
-                    "env": {
-                        "environment": environment,
-                        "properties": properties,
-                    },
-                }))
+                EventEnvelope::new()
+                    .set_header("content-type", "application/json")
+                    .set_body(serde_json::json!({
+                        "app": context.app_block(),
+                        "env": {
+                            "environment": environment,
+                            "properties": properties,
+                        },
+                    }))
             }
             ActuatorKind::Health => {
                 let po = PostOffice::new(&context.platform);
@@ -236,6 +245,7 @@ impl ComposableFunction for ActuatorServices {
                 result.insert("name".into(), serde_json::Value::String(Platform::name()));
                 Ok(EventEnvelope::new()
                     .set_status(if up { 200 } else { 400 }) // Java parity
+                    .set_header("content-type", "application/json")
                     .set_body(serde_json::Value::Object(result))?)
             }
         }

--- a/crates/platform-core/src/automation/routing.rs
+++ b/crates/platform-core/src/automation/routing.rs
@@ -66,8 +66,13 @@ enum Segment {
     Literal(String),
     /// `{param}` capture with its name.
     Param(String),
-    /// Trailing `*` — matches the remainder.
-    Wildcard,
+    /// A bare `*` segment — matches any single segment; in trailing position
+    /// it also lets the URL run longer (Java `matchRoute` wildcard rule).
+    Any,
+    /// `foo*` — case-insensitive prefix match on one segment (Java
+    /// `notMatched` `endsWith("*")`); trailing position also lets the URL
+    /// run longer.
+    Prefix(String),
 }
 
 /// A reusable `cors:` block (Java `CorsInfo`).
@@ -261,7 +266,7 @@ impl RoutingTable {
                 .iter()
                 .filter(|s| matches!(s, Segment::Literal(_)))
                 .count();
-            let wildcard = info.segments.iter().any(|s| matches!(s, Segment::Wildcard));
+            let wildcard = info.is_open_ended();
             let better = match &best {
                 None => true,
                 // prefer non-wildcard, then more literal segments
@@ -283,36 +288,63 @@ impl RoutingTable {
         }
         best.map(|(_, _, assigned)| assigned)
     }
+
+    /// True when the path matches SOME entry regardless of method — the Java
+    /// `getSimilarRoute` marker (increment 56, parity F14c): a known path
+    /// with a wrong method answers 405 "Method not allowed", never 404.
+    pub fn path_matches_any_method(&self, path: &str) -> bool {
+        let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+        self.routes
+            .iter()
+            .any(|info| info.match_path(&segments).is_some())
+    }
 }
 
 impl RouteInfo {
-    /// Match URL segments against this entry (case-insensitive literals),
+    /// True when the pattern ends with a `*`-suffixed segment (bare `*` or
+    /// `foo*`) — Java's `configured.endsWith("*")` wildcard flag: the URL may
+    /// then run LONGER than the pattern, but never shorter (`/api/files/*`
+    /// does NOT match `/api/files` — the increment-56 fix of the Rust-only
+    /// empty-remainder match).
+    fn is_open_ended(&self) -> bool {
+        matches!(
+            self.segments.last(),
+            Some(Segment::Any) | Some(Segment::Prefix(_))
+        )
+    }
+
+    /// Match URL segments against this entry — the exact Java `matchRoute` +
+    /// `notMatched` rules (case-insensitive literals and prefixes),
     /// returning the extracted `{param}` values on success.
     fn match_path(&self, request_segments: &[&str]) -> Option<HashMap<String, String>> {
+        if self.is_open_ended() {
+            if self.segments.len() > request_segments.len() {
+                return None;
+            }
+        } else if self.segments.len() != request_segments.len() {
+            return None;
+        }
         let mut params = HashMap::new();
-        let mut request_index = 0;
-        for segment in &self.segments {
+        for (i, segment) in self.segments.iter().enumerate() {
+            let actual = request_segments.get(i)?;
             match segment {
-                Segment::Wildcard => return Some(params), // consumes the rest (even empty)
+                Segment::Any => {}
                 Segment::Literal(expected) => {
-                    let actual = request_segments.get(request_index)?;
                     if actual.to_lowercase() != *expected {
                         return None;
                     }
-                    request_index += 1;
+                }
+                Segment::Prefix(prefix) => {
+                    if !actual.to_lowercase().starts_with(prefix.as_str()) {
+                        return None;
+                    }
                 }
                 Segment::Param(name) => {
-                    let actual = request_segments.get(request_index)?;
                     params.insert(name.clone(), actual.to_string());
-                    request_index += 1;
                 }
             }
         }
-        if request_index == request_segments.len() {
-            Some(params)
-        } else {
-            None
-        }
+        Some(params)
     }
 }
 
@@ -380,20 +412,19 @@ fn parse_route(
         }
         methods.push(method);
     }
-    // segments: literal / {param} / trailing *
+    // segments: literal / {param} / bare `*` (any one segment) / `foo*`
+    // (prefix) — the full Java RoutingEntry grammar (increment 56, parity
+    // F14b: mid-path `*` and segment prefixes were previously rejected or
+    // treated as literals)
     let mut segments = Vec::new();
     let parts: Vec<&str> = url.split('/').filter(|s| !s.is_empty()).collect();
-    for (position, part) in parts.iter().enumerate() {
+    for part in &parts {
         if let Some(name) = part.strip_prefix('{').and_then(|p| p.strip_suffix('}')) {
             segments.push(Segment::Param(name.to_string()));
         } else if *part == "*" {
-            if position != parts.len() - 1 {
-                return Err(AppError::new(
-                    400,
-                    format!("rest[{index}] wildcard '*' must be the trailing segment"),
-                ));
-            }
-            segments.push(Segment::Wildcard);
+            segments.push(Segment::Any);
+        } else if let Some(prefix) = part.strip_suffix('*') {
+            segments.push(Segment::Prefix(prefix.to_lowercase()));
         } else {
             segments.push(Segment::Literal(part.to_lowercase()));
         }
@@ -712,9 +743,10 @@ headers:
             "rest:\n  - service: 'https://example.com'\n    methods: ['GET']\n    url: /a\n"
         )
         .is_err());
-        // non-trailing wildcard
+        // mid-path `*` is VALID since increment 56 (Java RoutingEntry parity:
+        // it matches exactly one segment)
         assert!(
-            table("rest:\n  - service: x.y\n    methods: ['GET']\n    url: '/a/*/b'\n").is_err()
+            table("rest:\n  - service: x.y\n    methods: ['GET']\n    url: '/a/*/b'\n").is_ok()
         );
         // cors line must be Access-Control-*
         assert!(table(

--- a/crates/platform-core/src/automation/server.rs
+++ b/crates/platform-core/src/automation/server.rs
@@ -166,6 +166,11 @@ async fn handle(
         Err(_) => Bytes::new(),
     };
     let Some(assigned) = state.table.find(&method, &path) else {
+        // Java HttpRequestHandler: a known path under a WRONG method is 405,
+        // never 404 (increment 56, parity F14c — the getSimilarRoute marker)
+        if state.table.path_matches_any_method(&path) {
+            return Ok(error_response(405, "Method not allowed"));
+        }
         // static HTML content from resources/public — including "/" →
         // index.html — served only when rest.yaml claims no route (a "/"
         // entry in rest.yaml always wins)
@@ -178,13 +183,22 @@ async fn handle(
         }
         return Ok(error_response(404, "Resource not found"));
     };
-    // CORS preflight (OPTIONS is auto-added per the grammar)
+    // CORS preflight (OPTIONS is auto-added per the grammar). Java
+    // handleOptionsMethod: without a CORS block (or with empty options) the
+    // answer is 405 "Method not allowed", never a bare 204 (increment 56,
+    // parity F14c)
     if method == "OPTIONS" {
+        let Some(cors) = assigned
+            .info
+            .cors
+            .as_ref()
+            .filter(|c| !c.options.is_empty())
+        else {
+            return Ok(error_response(405, "Method not allowed"));
+        };
         let mut response = Response::builder().status(StatusCode::NO_CONTENT);
-        if let Some(cors) = &assigned.info.cors {
-            for (name, value) in &cors.options {
-                response = response.header(name, value);
-            }
+        for (name, value) in &cors.options {
+            response = response.header(name, value);
         }
         return Ok(response
             .body(Full::new(Bytes::new()))
@@ -258,23 +272,56 @@ async fn process(
         }
     });
     headers.insert(MY_CORRELATION_ID.to_string(), cid.clone());
-    // AsyncHttpRequest-shaped event body (Java parity keys)
-    let mut query: HashMap<String, String> = HashMap::new();
+    // AsyncHttpRequest-shaped event body (Java parity keys).
+    // Repeated query parameters keep EVERY value — one occurrence is a
+    // string, more become a list (Java HttpRouter: params.getAll;
+    // increment 56, parity F14a — previously last-wins)
+    let mut query: HashMap<String, serde_json::Value> = HashMap::new();
     for pair in query_text.split('&').filter(|p| !p.is_empty()) {
         let (name, value) = pair.split_once('=').unwrap_or((pair, ""));
-        query.insert(url_decode(name), url_decode(value));
+        let (name, value) = (url_decode(name), url_decode(value));
+        match query.get_mut(&name) {
+            None => {
+                query.insert(name, serde_json::Value::String(value));
+            }
+            Some(serde_json::Value::Array(values)) => {
+                values.push(serde_json::Value::String(value));
+            }
+            Some(existing) => {
+                let first = existing.clone();
+                *existing = serde_json::Value::Array(vec![first, serde_json::Value::String(value)]);
+            }
+        }
     }
     let path_params: HashMap<String, String> = assigned
         .path_params
         .iter()
         .map(|(k, v)| (k.clone(), url_decode(v)))
         .collect();
+    // the cookie header becomes a parsed cookies map and is WITHHELD from
+    // the request headers (Java setRequestCookies; increment 56, parity
+    // F14d — previously the raw header rode through and no map existed)
+    let cookies: HashMap<String, String> = headers
+        .remove("cookie")
+        .map(|header| {
+            header
+                .split(';')
+                .filter_map(|item| item.split_once('='))
+                .map(|(name, value)| (name.trim().to_string(), value.trim().to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    // the request's Accept header drives the response's fallback content
+    // negotiation (Java AsyncContextHolder.accept), captured before the
+    // headers map moves into the event body
+    let accept = headers.get("accept").cloned();
     let parsed = parse_body(&headers, &body_bytes);
     // form fields become query parameters, on top of the URL's own
-    // (Java handleTextContent's url-encode branch: setQueryParameter each)
+    // (Java handleTextContent's url-encode branch: setQueryParameter each —
+    // single values, replacing)
     if let ParsedBody::Form(form) = &parsed {
         for (name, value) in form {
-            query.insert(name.clone(), value.clone());
+            query.insert(name.clone(), serde_json::Value::String(value.clone()));
         }
     }
     let body_value = match &parsed {
@@ -287,11 +334,13 @@ async fn process(
         ParsedBody::Bytes(bytes) => Some(bytes.as_slice()),
         _ => None,
     };
-    let http_request = serde_json::json!({
+    let mut http_request = serde_json::json!({
         "method": method,
         "url": path,
         "ip": peer.ip().to_string(),
-        "https": false,
+        // Java: setSecure(x-forwarded-proto == "https") — increment 56,
+        // parity F14d (previously hardcoded false)
+        "https": headers.get("x-forwarded-proto").map(String::as_str) == Some("https"),
         "host": headers.get("host").cloned().unwrap_or_default(),
         "headers": headers,
         "parameters": {"path": path_params, "query": query},
@@ -300,8 +349,21 @@ async fn process(
         // the flow TTL from it)
         "timeout": info.timeout.as_secs(),
     });
+    // the raw query string rides as Java's top-level "query" key; cookies
+    // appear only when present (Java toMap omits empty)
+    if !query_text.is_empty() {
+        http_request["query"] = serde_json::Value::String(query_text.clone());
+    }
+    if !cookies.is_empty() {
+        http_request["cookies"] = serde_json::to_value(&cookies).unwrap_or_default();
+    }
     let po = PostOffice::new(&state.platform);
-    let trace_path = format!("{method} {path}");
+    // Java appends the query string to the trace path (HttpRouter)
+    let trace_path = if query_text.is_empty() {
+        format!("{method} {path}")
+    } else {
+        format!("{method} {path}?{query_text}")
+    };
     // optional authentication before dispatch (simple route form)
     if let Some(auth_route) = &info.authentication {
         let auth_event = build_event(
@@ -340,8 +402,7 @@ async fn process(
     // updateHeadersAndContentType + updateHeaders)
     let status = status_of(result.status());
     let is_head = method == "HEAD";
-    let (derived_type, payload) = envelope_payload(&result);
-    let mut content_type = derived_type.map(str::to_string);
+    let mut content_type: Option<String> = None;
     let mut set_cookies: Vec<String> = Vec::new();
     let mut response_headers: HashMap<String, String> = HashMap::new();
     for (name, value) in result.headers() {
@@ -352,7 +413,7 @@ async fn process(
             // and withheld from the wire, never leaked as literal headers
             "x-stream-id" if value.starts_with("stream.") && value.contains(".in") => {}
             "x-ttl" => {}
-            // a function-set content type overrides the body-derived one
+            // a function-set content type overrides negotiation
             // (Java: response.putHeader directly, lowercased; skipped for HEAD)
             "content-type" => {
                 if !is_head {
@@ -369,6 +430,14 @@ async fn process(
             }
         }
     }
+    // Without a function-set type, the fallback comes from the request's
+    // Accept header (Java updateContentType — increment 56, the negotiation
+    // sub-item queued at increment 50; previously derived from body shape),
+    // and map/list bodies render per the negotiated type (handleMapContent).
+    if content_type.is_none() && !is_head {
+        content_type = accept_fallback_type(accept.as_deref(), result.body());
+    }
+    let payload = render_payload(result.body(), content_type.as_deref());
     // the rest.yaml response transform filters the merged header map (Java
     // filterHeaders); content-type and cookies bypass it, as in Java
     if let Some(header_info) = &info.headers {
@@ -753,6 +822,51 @@ async fn run_static_filter(
 
 /// Map an envelope body to HTTP payload + content type (shared by the normal
 /// dispatch and the filter pass-through).
+/// The fallback response content type from the request's Accept header —
+/// Java `AsyncHttpResponse.updateContentType` (increment 56): html → html,
+/// json or `*/*` → json, no Accept → NO content-type header at all; anything
+/// else → text/plain. Java's `application/xml` branch renders XML, which this
+/// port defers (D10) — an xml Accept negotiates JSON instead, never claiming
+/// xml on the wire.
+fn accept_fallback_type(accept: Option<&str>, _body: &rmpv::Value) -> Option<String> {
+    let accept = accept?;
+    if accept.contains("text/html") {
+        Some("text/html".to_string())
+    } else if accept.contains("application/json")
+        || accept.contains("*/*")
+        || accept.contains("application/xml")
+    {
+        Some("application/json".to_string())
+    } else {
+        Some("text/plain".to_string())
+    }
+}
+
+/// Render the response body per the effective content type — Java
+/// `AsyncHttpResponse.handleContent`: strings and bytes ride raw regardless
+/// of the negotiated type; map/list bodies render as JSON, wrapped in
+/// `<html><body><pre>` when the effective type is text/html
+/// (`handleMapContent`/`handleArrayContent`).
+fn render_payload(body: &rmpv::Value, content_type: Option<&str>) -> Bytes {
+    match body {
+        rmpv::Value::Nil => Bytes::new(),
+        rmpv::Value::String(text) => Bytes::from(text.as_str().unwrap_or_default().to_string()),
+        rmpv::Value::Binary(bytes) => Bytes::from(bytes.clone()),
+        _ => {
+            // Omit Nil map entries unless serializer.null.transport=true (Java Gson parity).
+            let stripped = crate::serializer::strip_nulls(body);
+            let json = serde_json::to_value(&stripped).unwrap_or_default();
+            if content_type.is_some_and(|t| t.starts_with("text/html"))
+                && matches!(body, rmpv::Value::Map(_) | rmpv::Value::Array(_))
+            {
+                Bytes::from(format!("<html><body><pre>\n{json}\n</pre></body></html>"))
+            } else {
+                Bytes::from(json.to_string())
+            }
+        }
+    }
+}
+
 fn envelope_payload(result: &EventEnvelope) -> (Option<&'static str>, Bytes) {
     match result.body() {
         rmpv::Value::Nil => (None, Bytes::new()),

--- a/crates/platform-core/tests/rest_automation.rs
+++ b/crates/platform-core/tests/rest_automation.rs
@@ -167,6 +167,31 @@ impl ComposableFunction for BodyProbe {
     }
 }
 
+/// Increment 56: exposes the Java request-model keys — repeated query
+/// values, the parsed cookies map, the raw query string, and the https flag.
+struct RequestView;
+
+#[async_trait]
+impl ComposableFunction for RequestView {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let request: serde_json::Value = input.body_as()?;
+        EventEnvelope::new().set_body(serde_json::json!({
+            "q": request["parameters"]["query"]["q"],
+            "single": request["parameters"]["query"]["single"],
+            "cookie_first": request["cookies"]["first"],
+            "cookie_second": request["cookies"]["second"],
+            "cookie_header": request["headers"]["cookie"],
+            "query": request["query"],
+            "https": request["https"],
+        }))
+    }
+}
+
 /// Authorizer: allows only when header x-api-key == "open-sesame".
 struct ApiKeyCheck;
 
@@ -223,6 +248,22 @@ rest:
     url: "/api/headers"
     timeout: 5s
     headers: header_1
+  - service: "request.view"
+    methods: ['GET']
+    url: "/api/request/view"
+    timeout: 5s
+  - service: "plain.text"
+    methods: ['GET']
+    url: "/api/files/*"
+    timeout: 5s
+  - service: "plain.text"
+    methods: ['GET']
+    url: "/api/v*/ping"
+    timeout: 5s
+  - service: "plain.text"
+    methods: ['GET']
+    url: "/api/mid/*/end"
+    timeout: 5s
   - service: "trace.probe"
     methods: ['GET']
     url: "/api/traced"
@@ -319,6 +360,9 @@ async fn server() -> TestServer {
         .unwrap();
     platform
         .register("header.probe", Arc::new(HeaderProbe), 1)
+        .unwrap();
+    platform
+        .register("request.view", Arc::new(RequestView), 1)
         .unwrap();
     let addr = automation::start_http_server(&platform).await.unwrap();
     TestServer {
@@ -438,11 +482,13 @@ async fn get_with_path_query_and_generated_cid() {
         server.port,
         "GET",
         "/api/echo/eric?q=hello%20world",
-        &[],
+        &[("Accept", "application/json")],
         "",
     )
     .await;
     assert_eq!(status, 200);
+    // increment 56: the fallback content type is negotiated from Accept
+    // (Java updateContentType), no longer derived from the body shape
     assert_eq!(headers["content-type"], "application/json");
     // response header transform + CORS headers applied
     assert_eq!(headers["x-served-by"], "mercury");
@@ -610,7 +656,7 @@ async fn edge_starts_trace_and_traceparent_parent_is_adopted() {
     let (status, _, _) = http(
         server.port,
         "GET",
-        "/api/traced",
+        "/api/traced?flag=on",
         &[
             ("traceparent", traceparent.as_str()),
             ("X-Correlation-Id", "biz-9"),
@@ -627,7 +673,8 @@ async fn edge_starts_trace_and_traceparent_parent_is_adopted() {
         .clone()
         .expect("probe ran");
     assert_eq!(seen.0.as_deref(), Some(upstream_trace));
-    assert_eq!(seen.1.as_deref(), Some("GET /api/traced"));
+    // Java appends the query string to the trace path (increment 56)
+    assert_eq!(seen.1.as_deref(), Some("GET /api/traced?flag=on"));
     assert_eq!(seen.2.as_deref(), Some("biz-9"));
     // and the telemetry span adopted the caller's span as parent
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
@@ -641,7 +688,7 @@ async fn edge_starts_trace_and_traceparent_parent_is_adopted() {
             );
             assert_eq!(
                 dataset["trace"]["path"],
-                serde_json::json!("GET /api/traced")
+                serde_json::json!("GET /api/traced?flag=on")
             );
             assert_eq!(dataset["trace"]["from"], serde_json::json!("http.request"));
             break;
@@ -657,10 +704,135 @@ async fn edge_starts_trace_and_traceparent_parent_is_adopted() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn text_response_maps_to_text_plain() {
     let server = server().await;
-    let (status, headers, body) = http(server.port, "GET", "/api/text", &[], "").await;
+    // increment 56 (Java updateContentType): text/plain is the negotiated
+    // fallback for an Accept that is not html/xml/json/any
+    let (status, headers, body) = http(
+        server.port,
+        "GET",
+        "/api/text",
+        &[("Accept", "text/plain")],
+        "",
+    )
+    .await;
     assert_eq!(status, 200);
     assert_eq!(headers["content-type"], "text/plain");
     assert_eq!(body, "plain response");
+}
+
+/// Increment 56 — the Java content negotiation (updateContentType +
+/// handleMapContent): the fallback type comes from Accept, `*/*` negotiates
+/// JSON even for a text body, text/html wraps a map body in an HTML shell,
+/// and NO Accept means NO content-type header at all.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn response_content_negotiation_matches_java() {
+    let server = server().await;
+    // */* on a TEXT body: content-type application/json, body raw (Java quirk)
+    let (_, headers, body) = http(server.port, "GET", "/api/text", &[("Accept", "*/*")], "").await;
+    assert_eq!(headers["content-type"], "application/json");
+    assert_eq!(body, "plain response");
+    // text/html on a MAP body: HTML-wrapped JSON
+    let (_, headers, body) = http(
+        server.port,
+        "GET",
+        "/api/echo/html?q=1",
+        &[("Accept", "text/html")],
+        "",
+    )
+    .await;
+    assert_eq!(headers["content-type"], "text/html");
+    assert!(
+        body.starts_with("<html><body><pre>\n") && body.ends_with("\n</pre></body></html>"),
+        "{body}"
+    );
+    // NO Accept: no content-type header at all (Java's "?" marker)
+    let (_, head, _) = http_raw(server.port, "GET", "/api/text").await;
+    assert!(!head.contains("content-type"), "{head}");
+}
+
+/// Increment 56 (parity F14a/d) — the request model: repeated query values
+/// become a list, cookies arrive as a parsed map (the raw header withheld),
+/// the raw query string and https flag ride the Java keys, and the trace
+/// path carries the query string.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_model_matches_java_keys() {
+    let server = server().await;
+    let (status, _, body) = http(
+        server.port,
+        "GET",
+        "/api/request/view?q=a&q=b&single=1",
+        &[
+            ("Accept", "application/json"),
+            ("Cookie", "first=alpha; second=beta"),
+            ("X-Forwarded-Proto", "https"),
+        ],
+        "",
+    )
+    .await;
+    assert_eq!(status, 200);
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    // repeated query parameter -> list; single stays a string (Java getAll)
+    assert_eq!(json["q"], serde_json::json!(["a", "b"]));
+    assert_eq!(json["single"], "1");
+    // cookies parsed into a map; the raw cookie header withheld
+    assert_eq!(json["cookie_first"], "alpha");
+    assert_eq!(json["cookie_second"], "beta");
+    assert_eq!(json["cookie_header"], serde_json::Value::Null);
+    // Java top-level keys: raw query string + https from x-forwarded-proto
+    assert_eq!(json["query"], "q=a&q=b&single=1");
+    assert_eq!(json["https"], true);
+}
+
+/// Increment 56 (parity F14b) — the full Java wildcard grammar: mid-path `*`
+/// (one segment), segment prefix `v*`, and the trailing `*` that no longer
+/// matches an EMPTY remainder.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wildcard_grammar_matches_java() {
+    let server = server().await;
+    let ok = |status: u16| assert_eq!(status, 200);
+    // trailing * requires at least one remaining segment (Java matchRoute)
+    let (status, _, _) = http(
+        server.port,
+        "GET",
+        "/api/files/a/b",
+        &[("Accept", "*/*")],
+        "",
+    )
+    .await;
+    ok(status);
+    let (status, _, _) = http(server.port, "GET", "/api/files", &[("Accept", "*/*")], "").await;
+    assert_eq!(status, 404, "trailing * must NOT match an empty remainder");
+    // segment prefix wildcard v*
+    let (status, _, _) = http(server.port, "GET", "/api/v2/ping", &[("Accept", "*/*")], "").await;
+    ok(status);
+    // mid-path bare * matches exactly one segment
+    let (status, _, _) = http(
+        server.port,
+        "GET",
+        "/api/mid/x/end",
+        &[("Accept", "*/*")],
+        "",
+    )
+    .await;
+    ok(status);
+    let (status, _, _) = http(server.port, "GET", "/api/mid/end", &[("Accept", "*/*")], "").await;
+    assert_eq!(status, 404, "mid-path * consumes exactly one segment");
+}
+
+/// Increment 56 (parity F14c) — a known path under a wrong method is 405,
+/// and OPTIONS without a CORS block is 405, never a bare 204.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn known_path_wrong_method_is_405() {
+    let server = server().await;
+    let (status, _, body) = http(server.port, "PUT", "/api/text", &[("Accept", "*/*")], "").await;
+    assert_eq!(status, 405);
+    assert!(body.contains("Method not allowed"), "{body}");
+    // OPTIONS on a route WITH cors options: 204 + the options headers
+    let (status, headers, _) = http(server.port, "OPTIONS", "/api/echo/x", &[], "").await;
+    assert_eq!(status, 204);
+    assert_eq!(headers["access-control-allow-origin"], "*");
+    // OPTIONS on a route WITHOUT cors: 405 (Java handleOptionsMethod)
+    let (status, _, _) = http(server.port, "OPTIONS", "/api/text", &[], "").await;
+    assert_eq!(status, 405);
 }
 
 /// Increment E-3: a rest.yaml `flow:` binding injects the x-flow-id request

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -72,6 +72,7 @@
 | 53 | parity remediation 4 — date/time plugins: full Java-pattern tokenizer (names, 12h/AM-PM, SSS, quoted literals, offsets; loud failure on unsupported letters), `f:dateTime` zone argument + ISO_DATE_TIME no-arg form | 2026-07-21 | — | 218 |
 | 54 | parity remediation 5 — fetcher cache key = dictionary-declared inputs only (`{node}.dd.{alias}.*`, Java makeRegularHttpCall parity); call-counting red/green regression | 2026-07-21 | — | 218 |
 | 55 | parity remediation 6 — registration replaces + clamps 1..=1000 (Java Platform.register/ServiceDef), config resolver per-segment loop chain (no false cycles), .properties full java.util.Properties syntax | 2026-07-21 | — | 220 |
+| 56 | parity remediation 7 — REST routing/request/response parity: full wildcard grammar, 405 + OPTIONS semantics, multi-value query params, cookies map, raw query + https flag, trace-path query, Accept-negotiated content type | 2026-07-21 | — | 224 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1510,6 +1511,38 @@ Sixth increment of the parity-remediation program — three Medium findings (F10
   `repeated_references_are_not_false_cycles` (+ new fixture keys);
   `properties_syntax_matches_java_util_properties` (+ `props-syntax.properties` fixture
   covering every syntax form). Workspace 220 tests / clippy 0 / fmt.
+
+---
+
+## Increment 56 — parity remediation 7: REST routing + request/response model (2026-07-21)
+
+Seventh increment of the parity-remediation program (finding F14, all sub-claims, plus the
+Accept-negotiation sub-item queued at increment 50):
+
+- **Wildcard grammar** (`routing.rs`): the full Java `RoutingEntry` rules — mid-path `*`
+  (one segment), `foo*` segment prefixes, and open-ended trailing wildcards that let the
+  URL run longer but never shorter (the Rust-only empty-remainder match is gone:
+  `/api/files/*` no longer matches `/api/files`).
+- **405 + OPTIONS** (`server.rs`): a known path under a wrong method answers 405 "Method
+  not allowed" (Java's getSimilarRoute marker), and OPTIONS without a CORS block (or with
+  empty options) is 405, never a bare 204.
+- **Request model**: repeated query parameters keep every value (one → string, more →
+  list, Java `params.getAll`); the cookie header becomes a parsed `cookies` map and is
+  withheld from the request headers; the raw query string rides Java's top-level `query`
+  key; `https` derives from `x-forwarded-proto` (was hardcoded false); the trace path
+  carries the query string.
+- **Response negotiation** (Java `updateContentType` + `handleMapContent`): without a
+  function-set content type, the fallback comes from the Accept header — html →
+  text/html with map/list bodies HTML-wrapped, json or `*/*` → application/json (even for
+  text bodies — the Java quirk), NO Accept → no content-type header at all, else
+  text/plain; an xml Accept negotiates JSON (the port's XML deferral, never claiming xml
+  on the wire). The actuator endpoints now set explicit envelope content types exactly
+  like Java `ActuatorServices` (they were riding the body-shape fallback).
+- **Tests (red/green-verified):** `request_model_matches_java_keys`,
+  `wildcard_grammar_matches_java`, `known_path_wrong_method_is_405`,
+  `response_content_negotiation_matches_java`, the trace-path query assertion, and the
+  existing suite updated to send explicit Accept headers (real clients do). Workspace 224
+  tests / clippy 0 / fmt.
 
 ---
 

--- a/docs/design/platform-core-port.md
+++ b/docs/design/platform-core-port.md
@@ -413,9 +413,17 @@ authoritative schema is the Java project's own `docs/guides/rest-automation/rest
   `tracing`, per-entry `trace.id.header`/`correlation.id.header` impedance overrides) +
   `cors` blocks (options/headers, `Access-Control-*` lines) + `headers` blocks
   (request/response add/drop/keep). Parser invariants enforced per the grammar.
-- **Dispatch:** method+path match (exact literals > `{param}` captures > trailing wildcard),
-  request mapped to the **`AsyncHttpRequest`** shape (`method`, `url`, `ip`, `headers`,
-  `parameters.path`/`parameters.query`, `body`, `https`, `host`). The body follows the Java
+- **Dispatch:** method+path match with the FULL Java RoutingEntry grammar (increment 56,
+  parity F14): exact literals > `{param}` captures > wildcards; mid-path `*` matches one
+  segment, `foo*` prefix-matches one segment, and a trailing `*`/`foo*` lets the URL run
+  longer — but never shorter (`/api/files/*` does not match `/api/files`). A known path
+  under a wrong method answers **405** "Method not allowed" (the Java getSimilarRoute
+  marker); OPTIONS without a CORS block (or with empty options) is 405, never a bare 204.
+  Request mapped to the **`AsyncHttpRequest`** shape (`method`, `url`, `ip`, `headers`,
+  `parameters.path`/`parameters.query` — repeated query values become a LIST, single stays
+  a string — `body`, `https` from `x-forwarded-proto`, `host`, top-level `query` = the raw
+  query string, `cookies` = the parsed cookie map with the raw header withheld; the trace
+  path carries the query string). The body follows the Java
   `handlePayload` content-type dispatch **exactly** (parity fix 2026-07-19; no JSON sniffing,
   no default content type): `application/json` → map/list when bracket-wrapped, else raw text
   (parse failure falls back to text; empty → `{}`); `application/xml` → raw text (XML parse
@@ -436,8 +444,12 @@ authoritative schema is the Java project's own `docs/guides/rest-automation/rest
   map that the rest.yaml response transform filters (content-type/cookies bypass the filter,
   as in Java). HEAD responses carry headers, never a body. Envelope header model matches Java
   `EventEnvelope`: case-insensitive `header()` lookup, CR/LF filtered on `set_header()`.
-  Still open (tracked in `ot-parity-remediation`): Java's `Accept`-based fallback content
-  negotiation (`updateContentType`) — the Rust port derives the fallback from body shape only.
+  The fallback content type is negotiated from the request's `Accept` header (increment 56,
+  Java `updateContentType`): html → text/html (map/list bodies HTML-wrapped, `handleMapContent`),
+  json or `*/*` → application/json, NO Accept → no content-type header at all, anything else →
+  text/plain; an `application/xml` Accept negotiates JSON (the port's XML deferral — never
+  claiming xml on the wire). Actuator endpoints set explicit envelope content types exactly
+  like Java `ActuatorServices`.
   Errors are the Java JSON shape `{status, message, type:"error"}`; timeout → 408; OPTIONS
   preflight → CORS options headers.
 - **The edge starts traces** (the piece increments 5 was built for): a **business

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-214043)
+- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-220215)
 - **last_review:** 2026-07-21 | through 2026-07-21-214043
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -70,7 +70,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Rust layer by layer, foundation → UI (platform-core, then event-script, then active
   knowledge graph), preserving the Java project's behavior. The Java repo is the canonical
   spec (map, don't mirror).
-  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 66 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 67 | tier: active | origin: 2026-07-15-215538.md -->
 ## Conventions
 
 > Established with the first code (increment 1, 2026-07-15); enforced from the first commit.
@@ -94,7 +94,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   2026-07-16): annotated functions + `platform_core::auto_start_main!();` with the app's
   `resources/` beside its `Cargo.toml` — never cargo examples inside a library crate.
   Event-script and knowledge-graph demos land as sibling `examples/<name>/` crates.
-  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 65 | tier: active | origin: 2026-07-15-224707.md -->
+  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 66 | tier: active | origin: 2026-07-15-224707.md -->
 
 ## Open Threads
 
@@ -440,7 +440,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   pre-graduation current-state/mental-model framing refreshed in `memory/vision.md`
   (maintainer-approved). Cadence was 54 sessions since the 2026-07-18 check ≥
   `verify_invariants_every: 40`.
-  <!-- id: ot-reverify-invariants-2026-07-21 | created: 2026-07-21 | last_used: 2026-07-21 | uses: 2 | tier: active | origin: 2026-07-21-021231.md -->
+  <!-- id: ot-reverify-invariants-2026-07-21 | created: 2026-07-21 | last_used: 2026-07-21 | uses: 2 | tier: archive-candidate | origin: 2026-07-21-021231.md -->
 
 - [ ] **(blueprint) Parity remediation — maintainer-approved 2026-07-21.** A GitHub Copilot
   correctness assessment (24 findings) was independently verified finding-by-finding against
@@ -456,9 +456,8 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   rest.yaml response filter on the merged map, HEAD = headers-no-body) + the F9 envelope
   header model (case-insensitive `header()`, CR/LF-filtered `set_header()`); 4 new tests
   (raw-socket multi-Set-Cookie assertions); workspace 213/clippy 0/fmt. NEW sub-item
-  discovered while porting: Java's `Accept`-based fallback content negotiation
-  (`updateContentType` + `handleContent` body rendering) remains unported — Rust derives
-  the fallback content type from body shape only (queued with item 7); (2) trace continuity — DONE
+  discovered while porting: Java's `Accept`-based fallback content negotiation — CLOSED
+  with item 7 (increment 56); (2) trace continuity — DONE
   2026-07-21 (increment 51): zero-traced hops keep a telemetry-suppressed bracket (trace
   flows to replies + nested calls, no dataset, no span — Java gates only
   startTracing/sendTracingInfo), `send_later` captures context at schedule time (Java
@@ -484,9 +483,14 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   push/pop chain (repeated/diamond refs resolve; genuine cycles still warn+empty),
   .properties = full java.util.Properties.load (separators/continuations/escapes/
   trailing-whitespace; malformed \u errors); red/green tests incl. reworked
-  registration contract test; workspace 220/clippy 0/fmt; (7) REST routing parity (multi-value query params, 405-vs-404 +
-  OPTIONS, cookies map/raw query/https flag — https is hardcoded false; wildcard deltas both
-  directions incl. Rust-only empty-remainder match); (8) remaining mappings: nested `[]`
+  registration contract test; workspace 220/clippy 0/fmt; (7) REST routing/request/response parity — DONE
+  2026-07-21 (increment 56): full Java wildcard grammar (mid-path `*`, `foo*` prefixes,
+  no empty-remainder match), 405 for known-path-wrong-method + OPTIONS-without-CORS,
+  multi-value query params, cookies map (raw header withheld), raw `query` key, https from
+  x-forwarded-proto, trace-path query suffix, AND the increment-50 leftover: Accept-driven
+  fallback content negotiation (html wrap; xml→json deferral; no Accept ⇒ no content-type)
+  + actuator explicit envelope types (Java ActuatorServices); red/green suite; workspace
+  224/clippy 0/fmt; (8) remaining mappings: nested `[]`
   append recursion, list→text `List.toString()` parity, UTF-16 length/substring semantics,
   launch-failure 500, `Session` case routing, `-0` rendering, HostUri lastIndexOf quirk.
   **Meta-fix:** several Rust doc comments claim "Java parity" where behavior diverges (F8,
@@ -494,7 +498,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   **F2 (null-on-spill) needs a maintainer decision**, not a fix: documented design, but the
   consequence (Nil visibility varies with load) is stated nowhere — document or normalize.
   Full verdict table in the session log. → serves: vision-mercury (faithful port)
-  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 7 | tier: working | origin: 2026-07-21-030938.md -->
+  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 8 | tier: working | origin: 2026-07-21-030938.md -->
 
 - [ ] **(backlog) Port `ManagedCache` (+ sibling `SimpleCache`).** Java platform-core ships
   `org.platformlambda.core.util.ManagedCache` — a named, self-managing TTL+size-bounded

--- a/memory/sessions/2026-07-21-220215.md
+++ b/memory/sessions/2026-07-21-220215.md
@@ -1,0 +1,40 @@
+# Session (2026-07-21T22:02:15.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Increment 56 — parity remediation 7: REST routing + request/response model** (finding
+F14, all sub-claims, plus the Accept-negotiation sub-item queued at increment 50):
+
+- **Wildcard grammar** (`routing.rs`): full Java RoutingEntry rules — new `Segment::Any`
+  (mid-path `*`, one segment) + `Segment::Prefix` (`foo*`); open-ended trailing wildcards
+  let the URL run longer but never shorter (the Rust-only empty-remainder match removed);
+  parser no longer rejects mid-path `*` (unit test updated to the new contract).
+- **405/OPTIONS** (`server.rs` + `path_matches_any_method`): known path + wrong method →
+  405 (Java getSimilarRoute marker); OPTIONS without CORS options → 405, never bare 204.
+- **Request model**: multi-value query params (string vs list, Java `getAll`); `cookies`
+  parsed map with the raw cookie header withheld; top-level raw `query` key; `https` from
+  `x-forwarded-proto`; trace path carries the query string.
+- **Response negotiation** (Java `updateContentType`/`handleMapContent`): Accept-driven
+  fallback — html (map/list bodies HTML-wrapped), json or `*/*` → json (even for text
+  bodies, the Java quirk), NO Accept ⇒ NO content-type header, else text/plain; xml Accept
+  negotiates JSON (the port's XML deferral — never claims xml on the wire). Actuator
+  endpoints now set explicit envelope content types exactly like Java `ActuatorServices`
+  (they had been riding the body-shape fallback — found when their tests surfaced the
+  negotiation change).
+
+Tests **red/green-verified via `git stash push -- src`** (the pre-fix source fails the
+suite broadly): `request_model_matches_java_keys`, `wildcard_grammar_matches_java`,
+`known_path_wrong_method_is_405`, `response_content_negotiation_matches_java`, trace-path
+query assertion; existing tests updated to send explicit Accept headers (the old
+assertions encoded body-shape typing). Workspace 224 tests / clippy 0 / fmt. Docs:
+INCREMENTS.md §56; design doc D10 dispatch + negotiation passages rewritten; the
+increment-50 "queued" note closed in the remediation thread.
+
+## Memory References
+
+- referenced: ot-parity-remediation (item 7 → DONE; only item 8 + the F2 maintainer
+  decision remain), port-bottom-up-faithful, conventions-rust-baseline
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

Increment 56 — parity remediation item 7 (finding F14, all sub-claims, plus the
Accept-negotiation sub-item queued at increment 50):

- **Wildcard grammar**: the full Java `RoutingEntry` rules — mid-path `*` (one segment),
  `foo*` segment prefixes, and open-ended trailing wildcards that let the URL run longer
  but never shorter (`/api/files/*` no longer matches `/api/files`).
- **405 + OPTIONS**: a known path under a wrong method answers 405 "Method not allowed"
  (Java's `getSimilarRoute` marker) instead of 404; OPTIONS without a CORS block (or with
  empty options) is 405, never a bare 204.
- **Request model**: repeated query parameters keep every value (one → string, more →
  list); the cookie header becomes a parsed `cookies` map with the raw header withheld;
  the raw query string rides Java's top-level `query` key; `https` derives from
  `x-forwarded-proto` (was hardcoded false); the trace path carries the query string.
- **Response negotiation** (Java `updateContentType` + `handleMapContent`): the fallback
  content type comes from the Accept header — text/html wraps map/list bodies in an HTML
  shell, json or `*/*` negotiate application/json (even for text bodies — the Java quirk),
  no Accept means no content-type header at all; an xml Accept negotiates JSON (the port's
  XML deferral, never claiming xml on the wire). The actuator endpoints now set explicit
  envelope content types exactly like Java `ActuatorServices`.

## Why

These close the remaining REST-boundary divergences from the verified assessment: lost
query values, unreachable cookie/raw-query/https state, wrong status codes for
known-but-mismatched routes, wildcard behavior differing in both directions, and a
response content type that ignored the client's Accept header. The two engines' HTTP
boundaries now agree on routing, the request event shape, and response typing.

Red/green-verified — the pre-fix source fails the suite broadly. New tests cover the
request model, wildcard grammar, 405/OPTIONS semantics, and content negotiation; existing
tests updated to send explicit Accept headers (their old assertions encoded the
body-shape typing this PR removes). Workspace 224 tests green, clippy clean, fmt applied.
`INCREMENTS.md` and design doc D10 updated.

Co-Authored-By: Claude Code <noreply@anthropic.com>