### PR TITLE
fix(parity): remaining mapping and edge-case findings — the final remediation increment (increment 57)

### DIFF
--- a/crates/event-script/src/conversions.rs
+++ b/crates/event-script/src/conversions.rs
@@ -46,36 +46,61 @@ pub fn display(value: &Value) -> String {
 }
 
 /// Java `getTextValue`: strings pass through, bytes decode as UTF-8, maps
-/// render as JSON, everything else via `display`.
+/// render as JSON — and a LIST renders as Java `List.toString()` (`[a, b]`),
+/// exactly the fall-through to `String.valueOf` (increment 57, parity F19;
+/// previously lists were JSON-serialized like maps).
 pub fn get_text_value(value: &Value) -> String {
     match value {
         Value::String(s) => s.as_str().unwrap_or_default().to_string(),
         Value::Binary(b) => String::from_utf8_lossy(b).to_string(),
-        Value::Map(_) | Value::Array(_) => to_json_string(value),
+        Value::Map(_) => to_json_string(value),
+        Value::Array(_) => java_to_string(value),
         other => display(other),
     }
 }
 
 /// Java `getBinaryValue`: bytes pass through, strings encode as UTF-8, maps
-/// render as JSON bytes, everything else via `display` bytes.
+/// render as JSON bytes — and a LIST as `List.toString()` bytes (parity F19).
 pub fn get_binary_value(value: &Value) -> Vec<u8> {
     match value {
         Value::Binary(b) => b.clone(),
         Value::String(s) => s.as_str().unwrap_or_default().as_bytes().to_vec(),
-        Value::Map(_) | Value::Array(_) => to_json_string(value).into_bytes(),
+        Value::Map(_) => to_json_string(value).into_bytes(),
+        Value::Array(_) => java_to_string(value).into_bytes(),
         other => display(other).into_bytes(),
     }
 }
 
-/// Java `getLength`: null → 0; bytes/list → element count; string → character
-/// count; everything else → length of its display form.
+/// The Java `toString()` shape of a collection tree — `[a, b]` for lists and
+/// `{k=v, k2=v2}` for nested maps, elements via `String.valueOf` (`display`).
+fn java_to_string(value: &Value) -> String {
+    match value {
+        Value::Array(items) => {
+            let inner: Vec<String> = items.iter().map(java_to_string).collect();
+            format!("[{}]", inner.join(", "))
+        }
+        Value::Map(entries) => {
+            let inner: Vec<String> = entries
+                .iter()
+                .map(|(k, v)| format!("{}={}", display(k), java_to_string(v)))
+                .collect();
+            format!("{{{}}}", inner.join(", "))
+        }
+        other => display(other),
+    }
+}
+
+/// Java `getLength`: null → 0; bytes/list → element count; string →
+/// `String.length()` = UTF-16 code units (increment 57, parity F20 — a
+/// non-BMP character such as an emoji counts 2, not 1); everything else →
+/// the UTF-16 length of its display form.
 pub fn get_length(value: &Value) -> i64 {
     match value {
         Value::Nil => 0,
         Value::Binary(b) => b.len() as i64,
-        Value::String(s) => s.as_str().unwrap_or_default().chars().count() as i64,
+        Value::String(s) => s.as_str().unwrap_or_default().encode_utf16().count() as i64,
         Value::Array(list) => list.len() as i64,
-        other => display(other).chars().count() as i64,
+        other => display(other).encode_utf16().count() as i64,
     }
 }
 
@@ -253,5 +278,28 @@ mod tests {
             get_length(&Value::Array(vec![Value::from(1), Value::from(2)])),
             2
         );
+    }
+
+    /// Increment 57 (parity F19): a list converts to text as Java
+    /// `List.toString()` — not JSON; maps stay JSON like Java.
+    #[test]
+    fn list_to_text_matches_java_tostring() {
+        let list = Value::Array(vec![Value::from("a"), Value::from(2), Value::Nil]);
+        assert_eq!(get_text_value(&list), "[a, 2, null]");
+        assert_eq!(get_binary_value(&list), b"[a, 2, null]".to_vec());
+        let nested = Value::Array(vec![Value::Map(vec![(Value::from("k"), Value::from("v"))])]);
+        assert_eq!(get_text_value(&nested), "[{k=v}]");
+        // maps are unchanged: JSON, exactly like Java getTextValue
+        let map = Value::Map(vec![(Value::from("k"), Value::from("v"))]);
+        assert_eq!(get_text_value(&map), "{\"k\":\"v\"}");
+    }
+
+    /// Increment 57 (parity F20): string length counts UTF-16 code units —
+    /// an emoji is 2, exactly Java String.length().
+    #[test]
+    fn length_counts_utf16_code_units() {
+        assert_eq!(get_length(&Value::from("abc")), 3);
+        assert_eq!(get_length(&Value::from("😀")), 2);
+        assert_eq!(get_length(&Value::from("a😀b")), 4);
     }
 }

--- a/crates/event-script/src/manager.rs
+++ b/crates/event-script/src/manager.rs
@@ -38,7 +38,9 @@ pub const SERVICE_NAME: &str = "event.script.manager";
 pub const BUSINESS_CORRELATION_ID: &str = "correlation_id";
 
 /// Handle one launch event (the interceptor body). Errors are routed back to
-/// the caller when a reply address exists (Java parity).
+/// the caller when a reply address exists, always as status 500 — Java
+/// `EventScriptManager.handleEvent` hard-codes it (increment 57, parity F21;
+/// previously the original 400s leaked through).
 pub async fn handle(
     platform: &Platform,
     headers: HashMap<String, String>,
@@ -51,7 +53,7 @@ pub async fn handle(
             let error = EventEnvelope::new()
                 .set_to(reply_to)
                 .set_correlation_id(cid)
-                .set_status(e.status())
+                .set_status(500)
                 .set_raw_body(Value::from(e.message()));
             let _ = po.send(error).await;
         }

--- a/crates/event-script/src/mlm.rs
+++ b/crates/event-script/src/mlm.rs
@@ -217,7 +217,10 @@ impl MultiLevelMap {
     }
 
     /// Java `appendIndex`: replace the first `[]` with the current length of
-    /// the list at that prefix (0 when absent).
+    /// the list at that prefix (0 when absent), then RECURSE until no `[]`
+    /// remains — nested appends like `model.rows[].items[]` resolve fully
+    /// (increment 57, parity F17; previously only the first marker expanded
+    /// and the leftover `[]` failed the mapping).
     fn append_index(&self, composite_path: &str) -> String {
         let Some(empty) = composite_path.find("[]") else {
             return composite_path.to_string();
@@ -227,7 +230,7 @@ impl MultiLevelMap {
             Some(Value::Array(list)) => list.len(),
             _ => 0,
         };
-        format!("{prefix}[{len}]{}", &composite_path[empty + 2..])
+        self.append_index(&format!("{prefix}[{len}]{}", &composite_path[empty + 2..]))
     }
 
     /// Remove by composite path: map keys are removed; list slots become null
@@ -491,6 +494,31 @@ mod tests {
         assert_eq!(
             m.get_element("$.fetcher-ext.result[*].account_details"),
             Some(Value::Array(vec![Value::from("a"), Value::from("b")]))
+        );
+    }
+
+    /// Increment 57 (parity F17): nested `[]` markers all expand — Java
+    /// appendIndex recurses until none remain.
+    #[test]
+    fn nested_append_markers_expand_recursively() {
+        let mut m = MultiLevelMap::new();
+        m.set_element("model.rows[].items[]", Value::from("a"))
+            .unwrap();
+        m.set_element("model.rows[0].items[]", Value::from("b"))
+            .unwrap();
+        m.set_element("model.rows[].items[]", Value::from("c"))
+            .unwrap();
+        assert_eq!(
+            m.get_element("model.rows[0].items[0]"),
+            Some(Value::from("a"))
+        );
+        assert_eq!(
+            m.get_element("model.rows[0].items[1]"),
+            Some(Value::from("b"))
+        );
+        assert_eq!(
+            m.get_element("model.rows[1].items[0]"),
+            Some(Value::from("c"))
         );
     }
 }

--- a/crates/event-script/src/plugins.rs
+++ b/crates/event-script/src/plugins.rs
@@ -224,8 +224,13 @@ fn plugin_substring(args: &[Value]) -> Result<Value, String> {
     let text = get_text_value(value);
     let start = rest.first().map(convert_integer).unwrap_or(-1);
     let end = rest.get(1).map(convert_integer).unwrap_or(-1);
-    let chars: Vec<char> = text.chars().collect();
-    let len = chars.len() as i64;
+    // Java String.substring indexes are UTF-16 code units (increment 57,
+    // parity F20 — previously Unicode scalars, shifting indexes for emoji
+    // and other non-BMP input). Micro-divergence: an index that splits a
+    // surrogate pair yields U+FFFD (Java keeps the unpaired surrogate,
+    // which Rust strings cannot represent).
+    let units: Vec<u16> = text.encode_utf16().collect();
+    let len = units.len() as i64;
     // Java isOutOfBounds: end past the text, start past the text, or flipped
     let out_of_bounds = (end >= 0 && end > len)
         || (start >= 0 && start > len)
@@ -236,15 +241,13 @@ fn plugin_substring(args: &[Value]) -> Result<Value, String> {
         ));
     }
     if start >= 0 && end >= 0 {
-        Ok(Value::from(
-            chars[start as usize..end as usize]
-                .iter()
-                .collect::<String>(),
-        ))
+        Ok(Value::from(String::from_utf16_lossy(
+            &units[start as usize..end as usize],
+        )))
     } else if start >= 0 && start < len {
-        Ok(Value::from(
-            chars[start as usize..].iter().collect::<String>(),
-        ))
+        Ok(Value::from(String::from_utf16_lossy(
+            &units[start as usize..],
+        )))
     } else {
         Ok(Value::from(text))
     }
@@ -684,5 +687,28 @@ mod tests {
         )
         .expect("parse millis");
         assert_eq!(ms, Value::from(expected + 250));
+    }
+
+    /// Increment 57 (parity F20): substring indexes are UTF-16 code units —
+    /// Java "a😀b".substring(3) == "b" (the emoji occupies units 1..3).
+    #[test]
+    fn substring_uses_utf16_code_units() {
+        assert_eq!(
+            calculate("substring", &[Value::from("a😀b"), Value::from(3)]),
+            Ok(Value::from("b"))
+        );
+        assert_eq!(
+            calculate(
+                "substring",
+                &[Value::from("a😀b"), Value::from(0), Value::from(1)]
+            ),
+            Ok(Value::from("a"))
+        );
+        // out-of-bounds uses the UTF-16 length (4), exactly like Java
+        assert!(calculate(
+            "substring",
+            &[Value::from("a😀b"), Value::from(0), Value::from(5)]
+        )
+        .is_err());
     }
 }

--- a/crates/event-script/tests/flow_runtime.rs
+++ b/crates/event-script/tests/flow_runtime.rs
@@ -844,6 +844,18 @@ async fn flows_run_end_to_end_like_java() {
         Some("test-header")
     );
 
+    // --- an unknown flow id: the manager replies 500 like Java
+    // EventScriptManager (increment 57, parity F21 — previously the
+    // original 400 leaked through)
+    let reply = run_flow(
+        &platform,
+        "no-such-flow-xyz",
+        http_dataset(Some("nobody"), &[]),
+        "biz-cid-f21",
+    )
+    .await;
+    assert_eq!(reply.status(), 500, "launch failures are 500 (Java parity)");
+
     // --- a dangling sub-flow reference aborts at runtime
     let reply = run_flow(
         &platform,

--- a/crates/knowledge-graph/src/commands.rs
+++ b/crates/knowledge-graph/src/commands.rs
@@ -286,7 +286,11 @@ async fn handle_command(
     if command.starts_with('{') && command.ends_with('}') {
         return handle_json_command(po, out_route, command).await;
     }
-    if command.to_lowercase().starts_with("session") || forwarded {
+    // Java GraphCommandService: this guard is CASE-SENSITIVE (a capitalized
+    // "Session ..." falls through and is forwarded/deduped like any other
+    // command; the downstream keyword dispatch stays case-insensitive) —
+    // increment 57, parity F22
+    if command.starts_with("session") || forwarded {
         return single_or_multi_line(platform, po, command, in_route, out_route).await;
     }
     // the dedup guard protects the WS UI from double-submits; a synchronous

--- a/crates/knowledge-graph/src/fetcher.rs
+++ b/crates/knowledge-graph/src/fetcher.rs
@@ -50,7 +50,12 @@ pub const ROUTE: &str = "graph.api.fetcher";
 const WARNING_INTERVAL_MS: i64 = 30000;
 
 /// Java `HostUri`: split a provider URL into target host and URI, tolerating
-/// `{path}` brackets and spaces.
+/// `{path}` brackets and spaces — the EXACT Java split (increment 57, parity
+/// F24): the URI path is derived like `java.net.URI.getPath()` and the split
+/// point is `lastIndexOf(path)` on the bracket-sanitized URL, quirks
+/// included (a path that recurs verbatim in the query splits at the LAST
+/// occurrence). The scheme check stays a Rust guard — Java tolerates other
+/// schemes here only to fail later in the HTTP client.
 pub struct HostUri {
     pub host: String,
     pub uri: String,
@@ -58,23 +63,47 @@ pub struct HostUri {
 
 impl HostUri {
     pub fn parse(url: &str) -> Result<Self, AppError> {
-        let (scheme, rest) = if let Some(rest) = url.strip_prefix("http://") {
-            ("http://", rest)
-        } else if let Some(rest) = url.strip_prefix("https://") {
-            ("https://", rest)
-        } else {
+        if !url.starts_with("http://") && !url.starts_with("https://") {
             return Err(invalid(format!("Invalid provider URL {url}")));
+        }
+        // Java: hide path-parameter brackets and spaces from the URI parser
+        let safe: String = url
+            .chars()
+            .map(|c| match c {
+                '{' => '(',
+                '}' => ')',
+                ' ' => '+',
+                other => other,
+            })
+            .collect();
+        // java.net.URI.getPath(): from the first '/' after the authority,
+        // ending before any query or fragment
+        let after_scheme = safe.find("://").map(|i| i + 3).unwrap_or(0);
+        let path = match safe[after_scheme..].find('/') {
+            Some(offset) => {
+                let start = after_scheme + offset;
+                let rest = &safe[start..];
+                let end = rest.find(['?', '#']).unwrap_or(rest.len());
+                &safe[start..start + end]
+            }
+            None => "",
         };
-        match rest.find('/') {
-            Some(slash) => Ok(HostUri {
-                host: format!("{scheme}{}", &rest[..slash]),
-                uri: rest[slash..].to_string(),
-            }),
-            None => Ok(HostUri {
+        // Java: sep = path.isEmpty() ? -1 : safeUrl.lastIndexOf(path)
+        let sep = if path.is_empty() {
+            None
+        } else {
+            safe.rfind(path)
+        };
+        Ok(match sep {
+            None => HostUri {
                 host: url.to_string(),
                 uri: "/".to_string(),
-            }),
-        }
+            },
+            Some(sep) => HostUri {
+                host: url[..sep].to_string(),
+                uri: url[sep..].to_string(),
+            },
+        })
     }
 }
 
@@ -783,4 +812,33 @@ async fn run_http_batch(requests: Vec<Value>, ttl: i64) -> Vec<HttpResponseView>
         }));
     }
     results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HostUri;
+
+    /// Increment 57 (parity F24): the split point is Java's
+    /// `lastIndexOf(path)` — a path that recurs verbatim in the query splits
+    /// at the LAST occurrence, quirks included.
+    #[test]
+    fn host_uri_split_matches_java_lastindexof() {
+        let normal = HostUri::parse("https://host.example/api/x?q=1").unwrap();
+        assert_eq!(normal.host, "https://host.example");
+        assert_eq!(normal.uri, "/api/x?q=1");
+        // no path at all -> whole url is the host, uri is "/"
+        let bare = HostUri::parse("https://host.example").unwrap();
+        assert_eq!(bare.host, "https://host.example");
+        assert_eq!(bare.uri, "/");
+        // the Java quirk: the path text recurs in the query -> LAST occurrence
+        let quirky = HostUri::parse("https://host/search?q=/search").unwrap();
+        assert_eq!(quirky.host, "https://host/search?q=");
+        assert_eq!(quirky.uri, "/search");
+        // brackets and spaces are tolerated ({id} placeholders)
+        let braced = HostUri::parse("http://h:8080/api/mdm/profile/{id}").unwrap();
+        assert_eq!(braced.host, "http://h:8080");
+        assert_eq!(braced.uri, "/api/mdm/profile/{id}");
+        // non-http schemes stay rejected (Rust guard; Java fails later)
+        assert!(HostUri::parse("ftp://host/x").is_err());
+    }
 }

--- a/crates/knowledge-graph/src/math/evaluator.rs
+++ b/crates/knowledge-graph/src/math/evaluator.rs
@@ -215,6 +215,10 @@ fn number_to_string(d: f64) -> String {
         "NaN".to_string()
     } else if d.is_infinite() {
         if d > 0.0 { "Infinity" } else { "-Infinity" }.to_string()
+    } else if d == 0.0 {
+        // BigDecimal has no signed zero: -0.0 renders "0" like Java
+        // (increment 57, parity F23 — Rust's Display keeps the sign)
+        "0".to_string()
     } else {
         // Rust's Display is already the minimal plain-decimal form
         // (BigDecimal stripTrailingZeros + toPlainString in Java)

--- a/crates/knowledge-graph/tests/expression_engine.rs
+++ b/crates/knowledge-graph/tests/expression_engine.rs
@@ -235,3 +235,14 @@ fn random_and_argument_checks() {
     let e3 = engine.eval_number("sqrt('4')").unwrap_err();
     assert_eq!("Cannot coerce string to number: \"4\"", e3.message());
 }
+
+/// Increment 57 (parity F23): a CONCATENATED negative zero renders "0" like
+/// Java (numberToString goes through BigDecimal, which has no signed zero),
+/// while the direct display view keeps "-0.0" — exactly Java's
+/// Double.toString. Two surfaces, two Java behaviors, both mirrored.
+#[test]
+fn negative_zero_renders_like_java() {
+    let engine = ExpressionEngine::new();
+    assert!(engine.eval_boolean("('n=' + (0 * -1)) == 'n=0'").unwrap());
+    assert_eq!("-0.0", engine.evaluate_value("0 * -1").unwrap().as_string());
+}

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -73,6 +73,7 @@
 | 54 | parity remediation 5 — fetcher cache key = dictionary-declared inputs only (`{node}.dd.{alias}.*`, Java makeRegularHttpCall parity); call-counting red/green regression | 2026-07-21 | — | 218 |
 | 55 | parity remediation 6 — registration replaces + clamps 1..=1000 (Java Platform.register/ServiceDef), config resolver per-segment loop chain (no false cycles), .properties full java.util.Properties syntax | 2026-07-21 | — | 220 |
 | 56 | parity remediation 7 — REST routing/request/response parity: full wildcard grammar, 405 + OPTIONS semantics, multi-value query params, cookies map, raw query + https flag, trace-path query, Accept-negotiated content type | 2026-07-21 | — | 224 |
+| 57 | parity remediation 8 (final) — nested `[]` append recursion, list→text List.toString, UTF-16 length/substring, launch-failure 500, session-guard case, `-0` concat rendering, HostUri lastIndexOf split | 2026-07-21 | — | 230 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1543,6 +1544,45 @@ Accept-negotiation sub-item queued at increment 50):
   `response_content_negotiation_matches_java`, the trace-path query assertion, and the
   existing suite updated to send explicit Accept headers (real clients do). Workspace 224
   tests / clippy 0 / fmt.
+
+---
+
+## Increment 57 — parity remediation 8: the remaining mappings (2026-07-21)
+
+Eighth and FINAL code increment of the parity-remediation program — the seven remaining
+Medium/Low findings, each an exact Java mirror:
+
+- **F17** (`mlm.rs`): `append_index` recurses like Java `appendIndex`, so nested append
+  markers (`model.rows[].items[]`) expand fully instead of failing the mapping.
+- **F19** (`conversions.rs`): a LIST converts to text/binary as Java `List.toString()`
+  (`[a, 2, null]`, nested maps `{k=v}`) — the `String.valueOf` fall-through; maps stay
+  JSON. The doc comment and code now agree (meta-fix).
+- **F20** (`conversions.rs` + `plugins.rs`): string length and substring indexes are
+  UTF-16 code units (Java `String.length`/`substring`) — an emoji counts 2. Documented
+  micro-divergence: an index splitting a surrogate pair yields U+FFFD (Java keeps the
+  unpaired surrogate, which Rust strings cannot represent).
+- **F21** (`manager.rs`): every launch failure replies **500** like Java
+  `EventScriptManager` (the client-side `FlowExecutor` preconditions stay 400, as in
+  Java where they throw to the caller). The false "Java parity" comment corrected.
+- **F22** (`commands.rs`): the session-command guard is case-SENSITIVE like Java
+  (`startsWith("session")`); a capitalized `Session ...` falls through to
+  forward/dedup, and the downstream keyword dispatch stays case-insensitive (already
+  matching Java).
+- **F23** (`math/evaluator.rs`): a concatenated negative zero renders `"0"` (Java's
+  `numberToString` goes through BigDecimal, which has no signed zero); the direct
+  display view keeps `"-0.0"` — exactly Java `Double.toString`. Both surfaces mirrored.
+- **F24** (`fetcher.rs`): `HostUri` splits at Java's `lastIndexOf(path)` on the
+  bracket-sanitized URL, quirks included (a path recurring verbatim in the query splits
+  at the LAST occurrence); the java.net.URI path derivation is reproduced. The non-http
+  scheme guard stays (Java merely fails later); the doc comment now states the exact
+  contract (meta-fix).
+- **Tests:** nested-append, List.toString + UTF-16 length, UTF-16 substring (emoji),
+  unknown-flow 500 (red/green), negative-zero both surfaces (red/green), HostUri quirk
+  suite (red/green). Workspace 230 tests / clippy 0 / fmt.
+
+With this increment, all 8 remediation items are DONE — every CONFIRMED finding from the
+verified assessment is fixed. The one open remnant is the F2 null-on-spill documentation
+decision (maintainer call: document the load-dependent consequence, or normalize).
 
 ---
 

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-220215)
+- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-223548)
 - **last_review:** 2026-07-21 | through 2026-07-21-214043
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -70,7 +70,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Rust layer by layer, foundation → UI (platform-core, then event-script, then active
   knowledge graph), preserving the Java project's behavior. The Java repo is the canonical
   spec (map, don't mirror).
-  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 67 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 68 | tier: active | origin: 2026-07-15-215538.md -->
 ## Conventions
 
 > Established with the first code (increment 1, 2026-07-15); enforced from the first commit.
@@ -94,7 +94,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   2026-07-16): annotated functions + `platform_core::auto_start_main!();` with the app's
   `resources/` beside its `Cargo.toml` — never cargo examples inside a library crate.
   Event-script and knowledge-graph demos land as sibling `examples/<name>/` crates.
-  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 66 | tier: active | origin: 2026-07-15-224707.md -->
+  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 67 | tier: active | origin: 2026-07-15-224707.md -->
 
 ## Open Threads
 
@@ -490,15 +490,21 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   x-forwarded-proto, trace-path query suffix, AND the increment-50 leftover: Accept-driven
   fallback content negotiation (html wrap; xml→json deferral; no Accept ⇒ no content-type)
   + actuator explicit envelope types (Java ActuatorServices); red/green suite; workspace
-  224/clippy 0/fmt; (8) remaining mappings: nested `[]`
-  append recursion, list→text `List.toString()` parity, UTF-16 length/substring semantics,
-  launch-failure 500, `Session` case routing, `-0` rendering, HostUri lastIndexOf quirk.
+  224/clippy 0/fmt; (8) remaining mappings — DONE
+  2026-07-21 (increment 57, the FINAL code item): nested `[]` append recursion, list→text
+  `List.toString()`, UTF-16 length/substring (emoji = 2 units; split-surrogate → U+FFFD
+  documented), launch-failure 500 (manager; client preconditions stay 400 like Java),
+  session-guard case-sensitivity, `-0` concat rendering (direct view keeps "-0.0" =
+  Double.toString — both Java surfaces), HostUri lastIndexOf split with the
+  repeat-in-query quirk; red/green; workspace 230/clippy 0/fmt. **ALL 8 ITEMS DONE — every
+  CONFIRMED assessment finding is fixed.** Remaining in this thread: ONLY the F2
+  null-on-spill maintainer decision below.
   **Meta-fix:** several Rust doc comments claim "Java parity" where behavior diverges (F8,
   F19, F21, fetcher cache, HostUri) — fix alongside code (no-silent-divergence convention).
   **F2 (null-on-spill) needs a maintainer decision**, not a fix: documented design, but the
   consequence (Nil visibility varies with load) is stated nowhere — document or normalize.
   Full verdict table in the session log. → serves: vision-mercury (faithful port)
-  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 8 | tier: working | origin: 2026-07-21-030938.md -->
+  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 9 | tier: working | origin: 2026-07-21-030938.md -->
 
 - [ ] **(backlog) Port `ManagedCache` (+ sibling `SimpleCache`).** Java platform-core ships
   `org.platformlambda.core.util.ManagedCache` — a named, self-managing TTL+size-bounded

--- a/memory/sessions/2026-07-21-223548.md
+++ b/memory/sessions/2026-07-21-223548.md
@@ -1,0 +1,45 @@
+# Session (2026-07-21T22:35:48.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Increment 57 — parity remediation 8 (the FINAL code item): the seven remaining
+mapping/edge findings**, each an exact Java mirror:
+
+- **F17** `mlm.rs`: `append_index` recurses (Java `appendIndex`) — nested
+  `model.rows[].items[]` markers expand fully.
+- **F19** `conversions.rs`: lists convert to text/binary as Java `List.toString()`
+  (`[a, 2, null]`, nested `{k=v}`); maps stay JSON; comment/code agree again (meta-fix).
+- **F20** `conversions.rs` + `plugins.rs`: string length + substring in UTF-16 code units
+  (emoji = 2); split-surrogate → U+FFFD documented as the unavoidable micro-divergence.
+- **F21** `manager.rs`: launch failures reply 500 (Java `EventScriptManager` hard-codes);
+  client-side `FlowExecutor` preconditions stay 400 like Java's thrown exceptions; false
+  parity comment corrected.
+- **F22** `commands.rs`: the session guard is case-SENSITIVE like Java; downstream keyword
+  dispatch already case-insensitive (verified matching Java's equalsIgnoreCase).
+- **F23** `math/evaluator.rs`: concatenated `-0` renders "0" (BigDecimal path); the direct
+  `as_string` view was ALREADY faithful ("-0.0" = `Double.toString`) — test asserts both
+  Java surfaces (my first draft wrongly expected "0" there; Java keeps the signed zero in
+  Double.toString).
+- **F24** `fetcher.rs`: `HostUri` = Java's `lastIndexOf(path)` split on the
+  bracket-sanitized URL incl. the repeat-in-query quirk; java.net.URI path derivation
+  reproduced; scheme guard retained (Java fails later); contract stated in the comment.
+
+Tests: 6 new (nested-append; List.toString + UTF-16 length; emoji substring;
+unknown-flow 500; negative-zero two-surface; HostUri quirk suite) — integration-level ones
+red/green-verified via targeted stash. Workspace 230 tests / clippy 0 / fmt. INCREMENTS.md
+§57.
+
+**Program status: ALL 8 remediation items DONE — every CONFIRMED finding from the verified
+assessment is fixed.** The `ot-parity-remediation` thread stays open for exactly one
+remnant: the **F2 null-on-spill maintainer decision** (documented deliberate design whose
+observable consequence — Nil-entry visibility varying with queue load — is stated nowhere:
+document it, or normalize both paths).
+
+## Memory References
+
+- referenced: ot-parity-remediation (item 8 → DONE; F2 decision pending),
+  port-bottom-up-faithful, conventions-rust-baseline
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

Increment 57 — parity remediation item 8, closing the last seven CONFIRMED findings:

- **F17:** nested `[]` append markers (`model.rows[].items[]`) expand fully — `append_index`
  recurses like Java `appendIndex`.
- **F19:** lists convert to text/binary as Java `List.toString()` (`[a, 2, null]`); maps
  stay JSON.
- **F20:** string length and substring indexes are UTF-16 code units (an emoji counts 2),
  exactly Java `String.length()`/`substring()`; the one unavoidable micro-divergence
  (split surrogate → U+FFFD) is documented.
- **F21:** every flow-launch failure replies 500 like Java `EventScriptManager`;
  client-side `FlowExecutor` preconditions stay 400 (Java throws those to the caller).
- **F22:** the session-command guard is case-sensitive like Java; the downstream keyword
  dispatch stays case-insensitive (already matching).
- **F23:** a concatenated negative zero renders `"0"` (Java's BigDecimal path); the direct
  display view keeps `"-0.0"` — exactly Java `Double.toString`. Both surfaces mirrored.
- **F24:** `HostUri` reproduces Java's `lastIndexOf(path)` split, quirks included.

Three false "Java parity" doc comments corrected alongside their code (the
no-silent-divergence meta-fix).

## Why

These close out the maintainer-approved parity remediation: with this increment, **all 8
items are done and every CONFIRMED finding from the independently verified correctness
assessment is fixed** — the Critical, all five Highs, and every Medium/Low. The one open
remnant is a documentation decision, not code: F2 (null-strip-on-spill is a documented
deliberate design whose observable consequence isn't stated anywhere — document or
normalize), which stays with the maintainer.

Tests: six new regressions (nested append, `List.toString` + UTF-16 length, emoji
substring, unknown-flow 500, negative-zero both surfaces, the HostUri quirk suite);
integration-level fixes red/green-verified. Workspace 230 tests green, clippy clean, fmt
applied. `INCREMENTS.md` updated.

Co-Authored-By: Claude Code <noreply@anthropic.com>