### PR TITLE
fix(platform-core): deterministic null transport on every hop — the F2 resolution (increment 58)

### DIFF
--- a/crates/platform-core/src/envelope.rs
+++ b/crates/platform-core/src/envelope.rs
@@ -220,6 +220,10 @@ impl EventEnvelope {
 
     // ---- crate-internal mutators (worker bookkeeping) ----
 
+    pub(crate) fn set_body_internal(&mut self, body: rmpv::Value) {
+        self.body = body;
+    }
+
     pub(crate) fn set_cid_internal(&mut self, cid: Option<String>) {
         self.cid = cid;
     }
@@ -250,11 +254,13 @@ impl EventEnvelope {
     /// Encode the envelope as MsgPack bytes (idiomatic serde — design D4).
     ///
     /// The body's `Nil` map entries are omitted unless `serializer.null.transport`
-    /// is `true` — the Rust mirror of Java `MsgPack.packMap`'s null-skip. This is
-    /// only reached on the ElasticQueue (back-pressure/spill) path, never on the
-    /// in-memory fast path. The clone + strip runs **only** when the body actually
-    /// carries a strippable `Nil` (`has_nil_map_entry`); otherwise — a scalar body,
-    /// a structured body with no nulls, or transport on — `self` encodes directly
+    /// is `true` — the Rust mirror of Java `MsgPack.packMap`'s null-skip. Since
+    /// increment 58 (the F2 decision) the same strip also runs explicitly on the
+    /// in-memory fast path (`platform::normalize_null_transport`), so delivery
+    /// semantics are deterministic on every hop — here it is normally a no-op.
+    /// The clone + strip runs **only** when the body actually carries a
+    /// strippable `Nil` (`has_nil_map_entry`); otherwise — a scalar body, a
+    /// structured body with no nulls, or transport on — `self` encodes directly
     /// with no extra allocation, so the common case pays only a read-only scan.
     pub fn to_bytes(&self) -> Result<Vec<u8>, AppError> {
         if crate::serializer::null_transport() || !crate::serializer::has_nil_map_entry(&self.body)

--- a/crates/platform-core/src/platform.rs
+++ b/crates/platform-core/src/platform.rs
@@ -269,6 +269,8 @@ impl Platform {
     /// Crate-internal: deliver an event into a route's manager mailbox. Awaits
     /// when the bounded mailbox is full — back-pressure, not drops.
     pub(crate) async fn deliver(&self, route: &str, event: EventEnvelope) -> Result<(), AppError> {
+        let mut event = event;
+        normalize_null_transport(&mut event);
         // an RPC inbox is addressable like any destination (Java parity: the
         // TemporaryInbox route receives replies through normal dispatch) — so
         // a function replying MANUALLY via po.send(reply_to) also works
@@ -295,6 +297,20 @@ impl Platform {
             .send(MailboxMessage::Event(Box::new(event)))
             .await
             .map_err(|_| AppError::new(500, format!("Route {route} is closed")))
+    }
+}
+
+/// Deterministic null transport on EVERY hop (increment 58, the F2 decision —
+/// maintainer chose normalization over documentation): Java serializes every
+/// event-bus hop, so `Nil` map entries are stripped consistently when
+/// `serializer.null.transport=false`. The Rust fast path deliberately skips
+/// serialization (the documented performance divergence stays), so the strip
+/// is applied explicitly here — predicate-guarded: a body without Nil map
+/// entries costs one allocation-free read-only walk.
+fn normalize_null_transport(event: &mut EventEnvelope) {
+    if !crate::serializer::null_transport() && crate::serializer::has_nil_map_entry(event.body()) {
+        let stripped = crate::serializer::strip_nulls_always(event.body());
+        event.set_body_internal(stripped);
     }
 }
 
@@ -555,6 +571,8 @@ async fn worker_loop(
                 response.set_from_internal(&route);
                 response.set_to_internal(&reply_route);
                 response.set_exec_time_internal(elapsed_ms);
+                // the reply is a bus hop too — same deterministic null strip
+                normalize_null_transport(&mut response);
                 if let Some((trace_id, trace_path, span_id)) = trace_triple {
                     response.set_trace_internal(&trace_id, &trace_path);
                     if let Some(span_id) = span_id {

--- a/crates/platform-core/tests/event_bus.rs
+++ b/crates/platform-core/tests/event_bus.rs
@@ -595,3 +595,72 @@ fn envelope_header_values_are_sanitized_for_crlf() {
     let event = EventEnvelope::new().set_header("x-answer", "one\r\ntwo\rthree\nfour");
     assert_eq!(event.header("x-answer"), Some("onetwothreefour"));
 }
+
+/// Reports which map keys arrived on the wire (Nil-transport probe).
+struct KeyProbe;
+
+#[async_trait]
+impl ComposableFunction for KeyProbe {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let keys: Vec<String> = match input.body() {
+            rmpv::Value::Map(entries) => entries
+                .iter()
+                .filter_map(|(k, _)| k.as_str().map(str::to_string))
+                .collect(),
+            _ => Vec::new(),
+        };
+        EventEnvelope::new().set_body(keys)
+    }
+}
+
+/// Increment 58 (the F2 decision — maintainer chose NORMALIZE): with
+/// serializer.null.transport=false, Nil map entries are stripped on EVERY
+/// hop, including the in-process fast path — delivery semantics no longer
+/// depend on whether an event happened to spill under back-pressure (Java
+/// serializes every hop, so its strip is always deterministic).
+#[tokio::test]
+async fn null_map_entries_strip_deterministically_on_the_fast_path() {
+    setup_config();
+    let platform = Platform::new();
+    platform
+        .register("v1.null.probe", Arc::new(KeyProbe), 1)
+        .unwrap();
+    let po = PostOffice::new(&platform);
+    // warm the route so the worker is Ready and the probe request takes the
+    // FAST path — a cold route buffers (spills), which serializes and strips
+    // even on pre-fix code (that race IS the F2 nondeterminism)
+    let _ = po
+        .request(
+            EventEnvelope::new()
+                .set_to("v1.null.probe")
+                .set_body("warm")
+                .unwrap(),
+            Duration::from_secs(2),
+        )
+        .await
+        .expect("warm-up");
+    let body = rmpv::Value::Map(vec![
+        (rmpv::Value::from("keep"), rmpv::Value::from("x")),
+        (rmpv::Value::from("drop"), rmpv::Value::Nil),
+    ]);
+    let reply = po
+        .request(
+            EventEnvelope::new()
+                .set_to("v1.null.probe")
+                .set_raw_body(body),
+            Duration::from_secs(2),
+        )
+        .await
+        .expect("probe rpc");
+    let keys: Vec<String> = reply.body_as().expect("key list");
+    assert!(keys.contains(&"keep".to_string()));
+    assert!(
+        !keys.contains(&"drop".to_string()),
+        "a Nil map entry must be stripped on the fast path too (Java parity): {keys:?}"
+    );
+}

--- a/crates/platform-core/tests/rest_automation.rs
+++ b/crates/platform-core/tests/rest_automation.rs
@@ -561,13 +561,16 @@ async fn body_dispatch_mirrors_java_content_type_rules() {
     let unsniffed = probe(vec![("Content-Type", "text/plain")], r#"{"item":"book"}"#).await;
     assert_eq!(unsniffed["kind"], "text");
     assert_eq!(unsniffed["content"], r#"{"item":"book"}"#);
-    // form fields decode into query parameters; the body stays null
+    // form fields decode into query parameters; the null body key is
+    // STRIPPED on the bus hop (increment 58, the F2 normalization — Java's
+    // always-serialize wire drops it too, and AsyncHttpRequest.getBody()
+    // reads absent-as-null, so the two are indistinguishable in Java)
     let form = probe(
         vec![("Content-Type", "application/x-www-form-urlencoded")],
         "a=1&b=hello+world",
     )
     .await;
-    assert_eq!(form["kind"], "null");
+    assert_eq!(form["kind"], "missing");
     assert_eq!(form["query"]["a"], "1");
     assert_eq!(form["query"]["b"], "hello world");
     // no content type -> raw bytes (Java handleBinaryContent), never sniffed

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -74,6 +74,7 @@
 | 55 | parity remediation 6 — registration replaces + clamps 1..=1000 (Java Platform.register/ServiceDef), config resolver per-segment loop chain (no false cycles), .properties full java.util.Properties syntax | 2026-07-21 | — | 220 |
 | 56 | parity remediation 7 — REST routing/request/response parity: full wildcard grammar, 405 + OPTIONS semantics, multi-value query params, cookies map, raw query + https flag, trace-path query, Accept-negotiated content type | 2026-07-21 | — | 224 |
 | 57 | parity remediation 8 (final) — nested `[]` append recursion, list→text List.toString, UTF-16 length/substring, launch-failure 500, session-guard case, `-0` concat rendering, HostUri lastIndexOf split | 2026-07-21 | — | 230 |
+| 58 | F2 resolution (maintainer: NORMALIZE) — Nil map entries strip deterministically on every hop incl. the in-process fast path; the load-dependent null visibility is gone | 2026-07-21 | — | 231 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1583,6 +1584,35 @@ Medium/Low findings, each an exact Java mirror:
 With this increment, all 8 remediation items are DONE — every CONFIRMED finding from the
 verified assessment is fixed. The one open remnant is the F2 null-on-spill documentation
 decision (maintainer call: document the load-dependent consequence, or normalize).
+
+---
+
+## Increment 58 — F2 resolution: deterministic null transport (2026-07-21)
+
+The last open remnant of the parity-remediation program. F2 was verified INTENTIONAL (the
+no-serialization fast path is a documented deliberate divergence) but its observable
+consequence was stated nowhere: with `serializer.null.transport=false`, a `Nil` map entry
+survived the in-process fast path yet was stripped whenever back-pressure spilled the
+event through the elastic queue — consumer-visible semantics varied with load. **The
+maintainer chose normalization over documentation.**
+
+- **Fix** (`platform.rs`): `normalize_null_transport` strips `Nil` map entries explicitly
+  at `deliver()` (every initial hop: normal routes, reserved direct routes, RPC inboxes)
+  and on the worker auto-reply — predicate-guarded by the allocation-free
+  `has_nil_map_entry`, so a body without nulls pays one read-only walk. The
+  no-serialization performance divergence itself stays; only the null semantics are now
+  deterministic and Java-identical (Java serializes every hop, so its strip was always
+  deterministic).
+- **Ripple, itself Java-faithful:** the HTTP boundary's `body: null` key (form-encoded
+  requests) is now stripped on the bus hop — exactly what Java's wire does
+  (`MsgPack.packMap` drops it, and `AsyncHttpRequest.getBody()` reads absent-as-null, so
+  the two are indistinguishable in Java). The body-dispatch test updated accordingly.
+- **Test:** `null_map_entries_strip_deterministically_on_the_fast_path` —
+  **red/green-verified on a WARMED route** (the first red attempt raced worker startup
+  into the spill path and passed on pre-fix code: a live demonstration of the very
+  nondeterminism this increment removes). Workspace 231 tests / clippy 0 / fmt.
+
+**The parity-remediation program is COMPLETE: all 8 items plus the F2 decision.**
 
 ---
 

--- a/docs/design/platform-core-port.md
+++ b/docs/design/platform-core-port.md
@@ -286,7 +286,11 @@ Increment 2's shared-MPMC dispatch was a simplification; the faithful Java desig
   senders await (back-pressure, not drops).
 - **Deliberate divergences** (doc-commented): envelopes are serialized (MsgPack) only when
   crossing into the elastic queue (Java serializes every bus message; in-process Rust moves
-  are free — the on-disk format stays byte-identical); RPC inboxes ride the same route
+  are free — the on-disk format stays byte-identical). **Null transport is normalized
+  regardless** (increment 58, the F2 decision — maintainer chose normalization): `Nil` map
+  entries are stripped explicitly on every hop when `serializer.null.transport=false`
+  (`normalize_null_transport`, predicate-guarded), so consumer-visible semantics never
+  depend on whether an event happened to spill under load; RPC inboxes ride the same route
   machinery (Java's `AsyncInbox` bypasses `ServiceQueue` — a lighter dedicated inbox is a
   possible later refinement); the RUNNING keep-alive timer, expired-store scan, and
   shutdown-hook housekeeping await the lifecycle increment.

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -347,13 +347,20 @@ queue).
 |---|---|
 | boolean | `false` |
 
-Null handling at every wire boundary (JSON HTTP responses, websocket frames, outbound HTTP
-request bodies, and the MsgPack envelope encoder). Default `false`: null **map** key-values
-are omitted from the output — absent means null. Set `true` when a downstream must
-distinguish "key present with null value" from "key absent". Only map key-values are
-affected — array elements (including nulls) are always kept so ordering is preserved, and
-an empty `[]` or `{}` is a real value, never treated as null. Read once at startup by
-`crates/platform-core` (serializer) and cached for the process lifetime.
+Null handling at every boundary — the wire (JSON HTTP responses, websocket frames,
+outbound HTTP request bodies, the MsgPack envelope encoder) **and every in-memory
+event-bus hop**. Default `false`: null **map** key-values are omitted — absent means null,
+and a receiving function sees the key absent regardless of delivery path. Set `true` when
+a downstream must distinguish "key present with null value" from "key absent". Only map
+key-values are affected — array elements (including nulls) are always kept so ordering is
+preserved, and an empty `[]` or `{}` is a real value, never treated as null. Read once at
+startup by `crates/platform-core` (serializer) and cached for the process lifetime.
+
+!!! note "Port note"
+    Since increment 58 the strip is applied deterministically on every hop, exactly like
+    the Java engine (which serializes every bus message). Earlier Rust builds stripped
+    only when back-pressure spilled an event to disk, so null visibility could vary with
+    load — that nondeterminism is gone.
 
 ## Event Script (flow engine)
 

--- a/docs/guides/event-driven/ai-agent-guide.md
+++ b/docs/guides/event-driven/ai-agent-guide.md
@@ -330,7 +330,7 @@ boundaries). The Java engine's Gson/MsgPack integer-downcast gotchas do not carr
 | Reading the body | `body_as::<T>()` converts numbers per serde rules; deserialize into the type you want (`i64`, `f64`, your struct) rather than matching raw `rmpv::Value` variants |
 | Header values | always `String` — parse numerics explicitly (`str::parse`), defaulting on failure |
 | Map keys | always strings on the wire — never rely on non-string keys |
-| Null handling | map entries with null values are **omitted** on the wire by default (`serializer.null.transport=false`, Java parity) — treat absent as null when reading |
+| Null handling | map entries with null values are **omitted** by default on the wire AND on every in-memory hop (`serializer.null.transport=false`, Java parity — deterministic on every delivery path) — treat absent as null when reading |
 | Field-name style | put `#[serde(rename_all = "…")]` on your own types; there are no engine-level snake/camel switches |
 
 ---

--- a/docs/guides/event-envelope-reference.md
+++ b/docs/guides/event-envelope-reference.md
@@ -193,10 +193,11 @@ wire shape in memory — typed values pass through `serde` on `set_body`/`body_a
   `application/json`, a string body as `text/plain`, and a binary body as
   `application/octet-stream`; websocket frames and outbound HTTP client bodies are JSON as
   well.
-- **Null omission — absent means null.** At every wire boundary (JSON and MsgPack alike),
-  null **map** key-values are omitted by default, so a consumer must treat an absent key
-  and a null value as the same thing. Set `serializer.null.transport: true` to transport
-  nulls explicitly. Array elements are never dropped (ordering is preserved), and an empty
+- **Null omission — absent means null.** At every boundary — the wire (JSON and MsgPack
+  alike) and every in-memory event-bus hop — null **map** key-values are omitted by
+  default, so a consumer must treat an absent key and a null value as the same thing; the
+  behavior is deterministic and identical to the Java engine on every delivery path. Set
+  `serializer.null.transport: true` to transport nulls explicitly. Array elements are never dropped (ordering is preserved), and an empty
   `[]` or `{}` is a real value. See the
   [Configuration Reference](configuration-reference.md#serializernulltransport).
 

--- a/docs/guides/rest-automation.md
+++ b/docs/guides/rest-automation.md
@@ -334,9 +334,13 @@ anything else, or no content type
 The function's reply envelope maps back to HTTP:
 
 - **Status** — the envelope status (HTTP semantics; ≥ 400 is an error).
-- **Body** — by type: a map or list is rendered as JSON with `content-type: application/json`
-  (null map entries are omitted unless `serializer.null.transport=true`); a string becomes
-  `text/plain`; bytes become `application/octet-stream`; an empty body sends no content type.
+- **Body and content type** — a function-set `content-type` envelope header always wins;
+  otherwise the fallback is negotiated from the request's `Accept` header (Java parity):
+  `text/html` renders a map/list body as JSON wrapped in an HTML shell,
+  `application/json` or `*/*` negotiate JSON, no `Accept` sends **no content-type header**,
+  anything else is `text/plain`; an `application/xml` Accept negotiates JSON (the port's
+  XML deferral). Strings and bytes always ride raw regardless of the negotiated type. Null
+  map entries are omitted unless `serializer.null.transport=true`.
 - **Headers** — the response transforms of the entry's `headers` block are applied, then the
   entry's CORS `headers` lines are added.
 

--- a/memory/archive/2026-Q3.md
+++ b/memory/archive/2026-Q3.md
@@ -367,3 +367,24 @@
   DONE. Design note: discovery rides the command surface (no new REST endpoints — `/sync`
   already gives agents REST access to every command). → serves: vision-mercury
   <!-- id: ot-discovery-commands-backlog | created: 2026-07-19 | last_used: 2026-07-20 | uses: 6 | tier: archive-candidate | origin: 2026-07-19-171653.md -->
+
+## 2026-07-21 — archived via archive-fact (faded)
+
+### Faded facts
+
+- [x] **HTTP redirection backlog — RESOLVED 2026-07-20: story WITHDRAWN (parity confirmed
+  empirically; maintainer's stated criterion met).** A temporary JUnit probe in the Java
+  repo (`RedirectProbeTest`, PostOffice → `async.http.request`, live `https://google.com`)
+  returned **301 / location: www.google.com / 220-char body — byte-identical to the Rust
+  port's drive-#3 result**. Reactor-Netty supports `followRedirect` but mercury-composable
+  never enables it, so raw-3xx-to-the-caller is canonical behavior in BOTH engines; finding
+  #61's grammar rule ("the fetcher never follows redirects; point the Provider url at the
+  target") documents the shared contract. Nothing to port. Probe file removed after
+  evidence capture (live-endpoint dependency — not CI material); verbatim transcript +
+  decision record now in `docs/design/platform-core-port.md` §5j. **Maintainer rationale
+  (2026-07-20): deliberate design, not an omission** — the engines target BACKEND
+  applications; redirect-following is browser-side automation; a backend needing it (e.g.
+  SSO) handles it programmatically (layer 1) or declaratively via `{node}.status` routing
+  (layers 2/3); years of Java production confirm it is not normally required. The raw 3xx
+  IS the correct answer for a backend client. → serves: vision-mercury
+  <!-- id: ot-http-redirect-backlog | created: 2026-07-20 | last_used: 2026-07-20 | uses: 2 | tier: archive-candidate | origin: 2026-07-20-051617.md -->

--- a/memory/archive/INDEX.md
+++ b/memory/archive/INDEX.md
@@ -28,3 +28,4 @@
 - join-barrier-valid-completions — LATENT BUG fixed (both ports): join barrier counted failed/reset branches (increment 40). — faded — 2026-Q3.md
 - ot-human-guides-backlog — Prepare `docs/guides` for the human reader — COMPLETE 2026-07-20 (increments 43–46, — faded — 2026-Q3.md
 - ot-discovery-commands-backlog — Discovery commands for deployed flows and graph models — DONE 2026-07-20 (increment 42, — faded — 2026-Q3.md
+- ot-http-redirect-backlog — HTTP redirection backlog — RESOLVED 2026-07-20: story WITHDRAWN (parity confirmed — faded — 2026-Q3.md

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-223548)
+- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-225928)
 - **last_review:** 2026-07-21 | through 2026-07-21-214043
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -70,7 +70,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Rust layer by layer, foundation → UI (platform-core, then event-script, then active
   knowledge graph), preserving the Java project's behavior. The Java repo is the canonical
   spec (map, don't mirror).
-  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 68 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 69 | tier: active | origin: 2026-07-15-215538.md -->
 ## Conventions
 
 > Established with the first code (increment 1, 2026-07-15); enforced from the first commit.
@@ -94,7 +94,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   2026-07-16): annotated functions + `platform_core::auto_start_main!();` with the app's
   `resources/` beside its `Cargo.toml` — never cargo examples inside a library crate.
   Event-script and knowledge-graph demos land as sibling `examples/<name>/` crates.
-  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 67 | tier: active | origin: 2026-07-15-224707.md -->
+  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 68 | tier: active | origin: 2026-07-15-224707.md -->
 
 ## Open Threads
 
@@ -370,23 +370,6 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   → serves: vision-mercury
   <!-- id: ot-sync-companion-contract-gaps | created: 2026-07-20 | last_used: 2026-07-20 | uses: 2 | tier: archive-candidate | origin: 2026-07-20-051617.md -->
 
-- [x] **HTTP redirection backlog — RESOLVED 2026-07-20: story WITHDRAWN (parity confirmed
-  empirically; maintainer's stated criterion met).** A temporary JUnit probe in the Java
-  repo (`RedirectProbeTest`, PostOffice → `async.http.request`, live `https://google.com`)
-  returned **301 / location: www.google.com / 220-char body — byte-identical to the Rust
-  port's drive-#3 result**. Reactor-Netty supports `followRedirect` but mercury-composable
-  never enables it, so raw-3xx-to-the-caller is canonical behavior in BOTH engines; finding
-  #61's grammar rule ("the fetcher never follows redirects; point the Provider url at the
-  target") documents the shared contract. Nothing to port. Probe file removed after
-  evidence capture (live-endpoint dependency — not CI material); verbatim transcript +
-  decision record now in `docs/design/platform-core-port.md` §5j. **Maintainer rationale
-  (2026-07-20): deliberate design, not an omission** — the engines target BACKEND
-  applications; redirect-following is browser-side automation; a backend needing it (e.g.
-  SSO) handles it programmatically (layer 1) or declaratively via `{node}.status` routing
-  (layers 2/3); years of Java production confirm it is not normally required. The raw 3xx
-  IS the correct answer for a backend client. → serves: vision-mercury
-  <!-- id: ot-http-redirect-backlog | created: 2026-07-20 | last_used: 2026-07-20 | uses: 2 | tier: archive-candidate | origin: 2026-07-20-051617.md -->
-
 - [x] **Back-port the AI-doc grammar hardening to the Java repo — EXECUTED + VALIDATED
   2026-07-20 (PR [#203](https://github.com/Accenture/mercury-composable/pull/203) MERGED 2026-07-20 —
   the battle-tested grammar is live in BOTH engines).** Gold
@@ -442,7 +425,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   `verify_invariants_every: 40`.
   <!-- id: ot-reverify-invariants-2026-07-21 | created: 2026-07-21 | last_used: 2026-07-21 | uses: 2 | tier: archive-candidate | origin: 2026-07-21-021231.md -->
 
-- [ ] **(blueprint) Parity remediation — maintainer-approved 2026-07-21.** A GitHub Copilot
+- [x] **(blueprint) Parity remediation — COMPLETE 2026-07-21 (increments 50–58: all 8 items + the F2 decision).** A GitHub Copilot
   correctness assessment (24 findings) was independently verified finding-by-finding against
   both codebases (4 parallel agents + direct checks, file:line evidence both sides):
   **20 CONFIRMED real divergences, 2 INTENTIONAL-documented (null-on-spill design; XML
@@ -501,10 +484,13 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   null-on-spill maintainer decision below.
   **Meta-fix:** several Rust doc comments claim "Java parity" where behavior diverges (F8,
   F19, F21, fetcher cache, HostUri) — fix alongside code (no-silent-divergence convention).
-  **F2 (null-on-spill) needs a maintainer decision**, not a fix: documented design, but the
-  consequence (Nil visibility varies with load) is stated nowhere — document or normalize.
+  **F2 RESOLVED 2026-07-21 (increment 58): maintainer chose NORMALIZE** — Nil map entries
+  strip deterministically on every hop (predicate-guarded `normalize_null_transport` at
+  deliver + worker reply); the no-serialization fast path stays; red/green on a warmed
+  route (the cold-route race demonstrated the nondeterminism live). Ripple: the HTTP
+  boundary's null body key strips on the wire exactly like Java's.
   Full verdict table in the session log. → serves: vision-mercury (faithful port)
-  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 9 | tier: working | origin: 2026-07-21-030938.md -->
+  <!-- id: ot-parity-remediation | created: 2026-07-21 | last_used: 2026-07-21 | uses: 10 | tier: active | origin: 2026-07-21-030938.md -->
 
 - [ ] **(backlog) Port `ManagedCache` (+ sibling `SimpleCache`).** Java platform-core ships
   `org.platformlambda.core.util.ManagedCache` — a named, self-managing TTL+size-bounded

--- a/memory/sessions/2026-07-21-223548.md
+++ b/memory/sessions/2026-07-21-223548.md
@@ -37,6 +37,9 @@ remnant: the **F2 null-on-spill maintainer decision** (documented deliberate des
 observable consequence — Nil-entry visibility varying with queue load — is stated nowhere:
 document it, or normalize both paths).
 
+Also: shipped as PR [#161](https://github.com/Accenture/mercury/pull/161), MERGED 2026-07-21
+(true merge, CI green) — the remediation program is code-complete.
+
 ## Memory References
 
 - referenced: ot-parity-remediation (item 8 → DONE; F2 decision pending),

--- a/memory/sessions/2026-07-21-225928.md
+++ b/memory/sessions/2026-07-21-225928.md
@@ -1,0 +1,37 @@
+# Session (2026-07-21T22:59:28.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Increment 58 — the F2 resolution (maintainer ceremony: NORMALIZE chosen over
+document-only), closing the parity-remediation program.**
+
+The decision was presented with both options; the maintainer chose normalization:
+`Nil` map entries now strip deterministically on EVERY hop when
+`serializer.null.transport=false` — a predicate-guarded `normalize_null_transport`
+(allocation-free `has_nil_map_entry` scan) at `Platform::deliver` (normal routes,
+reserved direct routes, RPC inboxes) and on the worker auto-reply. The documented
+no-serialization fast path stays; only the load-dependent null visibility is gone.
+
+Two instructive finds along the way:
+- **The red test initially PASSED on pre-fix code** — it raced worker startup into the
+  spill path, which serializes and strips: a live demonstration of the exact
+  nondeterminism being removed. Red/green established properly on a WARMED route.
+- **Ripple, itself Java-faithful:** the HTTP boundary's `body: null` key (form requests)
+  now strips on the bus hop — precisely what Java's always-serialize wire does
+  (`MsgPack.packMap` drops it; `AsyncHttpRequest.getBody()` reads absent-as-null). The
+  body-dispatch test's old "null" expectation had encoded the fast-path leak; updated to
+  "missing" with the rationale in place.
+
+Workspace 231 tests / clippy 0 / fmt. Docs: INCREMENTS.md §58; design-doc deliberate-
+divergences passage rewritten; `to_bytes` doc comment updated (strip now normally a no-op
+there). **`ot-parity-remediation` is CLOSED — all 8 items (increments 50–57) + F2
+(increment 58). Every finding from the verified assessment is resolved.**
+
+## Memory References
+
+- referenced + closed: ot-parity-remediation (COMPLETE — the full program)
+- referenced: port-bottom-up-faithful, conventions-rust-baseline
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>

--- a/memory/sessions/2026-07-21-225928.md
+++ b/memory/sessions/2026-07-21-225928.md
@@ -29,6 +29,15 @@ divergences passage rewritten; `to_bytes` doc comment updated (strip now normall
 there). **`ot-parity-remediation` is CLOSED — all 8 items (increments 50–57) + F2
 (increment 58). Every finding from the verified assessment is resolved.**
 
+Also: maintainer review caught missing HUMAN-guide updates — fixed in a follow-up commit
+on the PR branch: configuration-reference (`serializer.null.transport` now states the
+every-hop determinism + a port note on the pre-58 spill-only behavior),
+event-envelope-reference (null-omission bullet covers in-memory hops), the event-driven AI
+guide row, AND rest-automation.md's response-mapping passage (still described pre-56
+body-shape typing — now the Accept-negotiation truth). Docs strict-build green. Lesson:
+increments that change observable behavior must sweep docs/guides/, not just the design
+doc — the maintainer's question caught two stale pages.
+
 ## Memory References
 
 - referenced + closed: ot-parity-remediation (COMPLETE — the full program)


### PR DESCRIPTION
## What

`normalize_null_transport` strips `Nil` map entries explicitly on every bus hop when
`serializer.null.transport=false` — at `Platform::deliver` (normal routes, reserved direct
routes, RPC inboxes) and on the worker auto-reply. It is predicate-guarded by the
allocation-free `has_nil_map_entry` scan, so a body without nulls pays one read-only walk;
the documented no-serialization fast path (the performance divergence the design doc
defends) stays untouched.

## Why

The last open item of the parity remediation. F2 was a verified-intentional design whose
observable consequence was documented nowhere: a `Nil` map entry survived the in-process
fast path but was stripped whenever back-pressure spilled the event — consumer-visible
semantics varied with load. The maintainer reviewed both options and chose normalization:
delivery semantics are now deterministic and Java-identical (Java serializes every hop, so
its strip was always deterministic).

Two notes from the work itself: the red test initially *passed* on pre-fix code because it
raced worker startup into the spill path — a live demonstration of the exact nondeterminism
this change removes (red/green established on a warmed route); and the one ripple (the HTTP
boundary's `body: null` key for form requests now strips on the wire) is itself
Java-faithful — `MsgPack.packMap` drops it and `AsyncHttpRequest.getBody()` reads
absent-as-null, so the two are indistinguishable in Java.

Workspace 231 tests green, clippy clean, fmt applied. `INCREMENTS.md`, the design doc's
deliberate-divergences passage, and the `to_bytes` doc comment updated.

**This completes the parity-remediation program: increments 50–58, all 8 items plus the F2
decision — every finding from the independently verified assessment is resolved.**

Co-Authored-By: Claude Code <noreply@anthropic.com>