### PR TITLE
feat(platform-core): private functions — preload is_private attribute and register_private API (increment 60)

### DIFF
--- a/crates/platform-core/src/app_starter.rs
+++ b/crates/platform-core/src/app_starter.rs
@@ -143,7 +143,7 @@ impl AppStarter {
         elastic_queue::start_housekeeping();
         let platform = Platform::get_instance();
         if !platform.has_route(crate::telemetry::DISTRIBUTED_TRACING) {
-            if let Err(e) = platform.register(
+            if let Err(e) = platform.register_private(
                 crate::telemetry::DISTRIBUTED_TRACING,
                 std::sync::Arc::new(crate::telemetry::Telemetry::new(&platform)),
                 1,
@@ -167,7 +167,7 @@ impl AppStarter {
                 (crate::actuator::LIVENESS_ACTUATOR, ActuatorKind::Liveness),
             ];
             for (route, kind) in actuators {
-                if let Err(e) = platform.register(
+                if let Err(e) = platform.register_private(
                     route,
                     Arc::new(ActuatorServices::new(kind, context.clone())),
                     1,
@@ -187,7 +187,7 @@ impl AppStarter {
                 .get_property("worker.instances.no.op")
                 .and_then(|value| value.parse::<usize>().ok())
                 .unwrap_or(500);
-            if let Err(e) = platform.register(
+            if let Err(e) = platform.register_private(
                 "no.op",
                 Arc::new(crate::function::NoOpFunction),
                 no_op_instances,
@@ -207,6 +207,8 @@ impl AppStarter {
                 FunctionOptions {
                     zero_traced: false,
                     interceptor: true,
+                    // Java EssentialServiceLoader: registerPrivate
+                    private: true,
                 },
             ) {
                 if !platform.has_route(crate::automation::ASYNC_HTTP_REQUEST) {
@@ -391,6 +393,7 @@ impl AutoStart {
                 FunctionOptions {
                     zero_traced: entry.zero_tracing,
                     interceptor: entry.interceptor,
+                    private: entry.is_private,
                 },
             );
         }

--- a/crates/platform-core/src/automation/ws_server.rs
+++ b/crates/platform-core/src/automation/ws_server.rs
@@ -315,6 +315,8 @@ fn ensure_housekeeper(platform: &Platform) {
             1,
             FunctionOptions {
                 zero_traced: true,
+                // Java WsRequestHandler: registerPrivate
+                private: true,
                 interceptor: true,
             },
         );
@@ -390,6 +392,8 @@ async fn run_session<S>(
         1,
         FunctionOptions {
             zero_traced: true,
+            // Java WsRequestHandler: registerPrivate
+            private: true,
             interceptor: false,
         },
     );

--- a/crates/platform-core/src/platform.rs
+++ b/crates/platform-core/src/platform.rs
@@ -70,6 +70,8 @@ enum MailboxMessage {
 }
 
 struct RouteEntry {
+    /// Java ServiceDef.isPrivateFunction (see FunctionOptions::private).
+    private: bool,
     mailbox: mpsc::Sender<MailboxMessage>,
     stop: Arc<Notify>,
     instances: usize,
@@ -110,6 +112,11 @@ const MAX_INSTANCES: usize = 1000;
 #[derive(Clone, Copy, Debug, Default)]
 pub struct FunctionOptions {
     pub zero_traced: bool,
+    /// Java `isPrivate`: a private function is reachable only inside this
+    /// application instance — Event over HTTP rejects it with 403. `register`
+    /// creates PUBLIC functions (Java parity); use `register_private` or the
+    /// `#[preload]` macro (private by default, like Java `@PreLoad`).
+    pub private: bool,
     pub interceptor: bool,
 }
 
@@ -156,6 +163,36 @@ impl Platform {
         self.register_with_options(route, function, instances, FunctionOptions::default())
     }
 
+    /// Register a PRIVATE function (Java `platform.registerPrivate`): callable
+    /// only inside this application instance — Event over HTTP rejects it
+    /// with 403. Engine internals register this way (increment 60).
+    pub fn register_private(
+        &self,
+        route: &str,
+        function: Arc<dyn ComposableFunction>,
+        instances: usize,
+    ) -> Result<(), AppError> {
+        self.register_with_options(
+            route,
+            function,
+            instances,
+            FunctionOptions {
+                private: true,
+                ..FunctionOptions::default()
+            },
+        )
+    }
+
+    /// Whether a registered route is private (Java `ServiceDef.isPrivateFunction`);
+    /// `None` when the route is not registered.
+    pub fn is_private(&self, route: &str) -> Option<bool> {
+        self.routes
+            .read()
+            .expect("route registry poisoned")
+            .get(route)
+            .map(|entry| entry.private)
+    }
+
     /// Register with explicit options (increment E-3 extends the increment-10
     /// zero-trace flag with the event-interceptor mode).
     pub fn register_with_options(
@@ -185,6 +222,7 @@ impl Platform {
             routes.insert(
                 route.to_string(),
                 RouteEntry {
+                    private: options.private,
                     mailbox: mailbox_tx.clone(),
                     stop: stop.clone(),
                     instances,

--- a/crates/platform-core/src/registry.rs
+++ b/crates/platform-core/src/registry.rs
@@ -36,6 +36,10 @@ pub struct PreloadEntry {
     /// that must hold at startup for this route to register; `None` = always
     /// register. Evaluated by [`crate::util::feature::is_required`].
     pub optional_service: Option<&'static str>,
+    /// Java `@PreLoad.isPrivate` (default true): a private function is
+    /// reachable only inside this application instance — Event over HTTP
+    /// rejects it with 403.
+    pub is_private: bool,
     /// Java `@ZeroTracing`: this route's executions are excluded from
     /// distributed-trace recording.
     pub zero_tracing: bool,

--- a/crates/platform-core/tests/annotations.rs
+++ b/crates/platform-core/tests/annotations.rs
@@ -26,7 +26,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -118,6 +118,24 @@ impl ComposableFunction for ZeroTracedFn {
             Ordering::SeqCst,
         );
         EventEnvelope::new().set_body("ok")
+    }
+}
+
+/// Increment 60 (Event over HTTP phase 2): a function that opts into PUBLIC
+/// visibility — Java `@PreLoad(isPrivate = false)`. Preloaded functions are
+/// private by default, exactly like Java.
+#[preload(route = "anno.public.echo", is_private = false)]
+struct AnnoPublicEcho;
+
+#[async_trait]
+impl ComposableFunction for AnnoPublicEcho {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        Ok(EventEnvelope::new().set_raw_body(input.body().clone()))
     }
 }
 
@@ -282,6 +300,29 @@ async fn annotation_macros_end_to_end() {
     assert!(platform.has_route("anno.typed.echo"));
     assert!(platform.has_route("anno.untyped.echo"));
     assert!(platform.has_route("anno.zero.traced"));
+
+    // increment 60: #[preload] functions are PRIVATE by default (Java
+    // @PreLoad isPrivate default true); is_private = false opts into public
+    assert_eq!(platform.is_private("anno.typed.echo"), Some(true));
+    assert_eq!(platform.is_private("anno.zero.traced"), Some(true));
+    assert!(platform.has_route("anno.public.echo"));
+    assert_eq!(platform.is_private("anno.public.echo"), Some(false));
+    // programmatic paths: register() = public, register_private() = private
+    platform
+        .register("anno.prog.public", Arc::new(AnnoPublicEcho), 1)
+        .unwrap();
+    assert_eq!(platform.is_private("anno.prog.public"), Some(false));
+    platform
+        .register_private("anno.prog.private", Arc::new(AnnoPublicEcho), 1)
+        .unwrap();
+    assert_eq!(platform.is_private("anno.prog.private"), Some(true));
+    assert_eq!(platform.is_private("no.such.route"), None);
+    // engine internals are private (Java EssentialServiceLoader parity)
+    assert_eq!(platform.is_private("no.op"), Some(true));
+    assert_eq!(
+        platform.is_private(platform_core::automation::ASYNC_HTTP_REQUEST),
+        Some(true)
+    );
 
     // #[optional_service] is first-class and order-independent: a satisfied
     // condition registers (both stacking orders); an unsatisfied one skips

--- a/crates/platform-core/tests/http_client_tls.rs
+++ b/crates/platform-core/tests/http_client_tls.rs
@@ -51,6 +51,7 @@ fn register_http_client(platform: &Platform) {
             FunctionOptions {
                 zero_traced: false,
                 interceptor: true,
+                private: false,
             },
         )
         .expect("http client route");

--- a/crates/platform-core/tests/interceptor.rs
+++ b/crates/platform-core/tests/interceptor.rs
@@ -126,6 +126,7 @@ impl ComposableFunction for Capture {
 const INTERCEPTOR: FunctionOptions = FunctionOptions {
     zero_traced: false,
     interceptor: true,
+    private: false,
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/platform-macros/src/lib.rs
+++ b/crates/platform-macros/src/lib.rs
@@ -67,6 +67,10 @@ use syn::{parse_macro_input, ItemStruct, LitInt, LitStr};
 /// - `instances = N` (default 1)
 /// - `env_instances = "config.key"` — read the instance count from application
 ///   configuration at startup, falling back to `instances` (Java `envInstances`)
+/// - `is_private = false` — a PUBLIC function, callable from another
+///   application instance through Event over HTTP. Java `@PreLoad` parity:
+///   preloaded functions are **private by default** (in-instance only);
+///   opt into public visibility explicitly (Java `isPrivate = false`)
 /// - `typed` — the struct implements `TypedFunction<I, O>`; it is wrapped in a
 ///   `TypedAdapter` (without this flag the struct must implement
 ///   `ComposableFunction`)
@@ -90,6 +94,9 @@ pub fn preload(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut typed = false;
     let mut zero_tracing = false;
     let mut interceptor = false;
+    // Java @PreLoad: isPrivate() default TRUE — a preloaded function is
+    // private unless it explicitly opts into public visibility
+    let mut is_private = true;
     let parser = syn::meta::parser(|meta| {
         if meta.path.is_ident("route") {
             route = Some(meta.value()?.parse()?);
@@ -104,11 +111,14 @@ pub fn preload(args: TokenStream, input: TokenStream) -> TokenStream {
             zero_tracing = true;
         } else if meta.path.is_ident("interceptor") {
             interceptor = true;
+        } else if meta.path.is_ident("is_private") {
+            let lit: syn::LitBool = meta.value()?.parse()?;
+            is_private = lit.value();
         } else {
             return Err(meta.error(
                 "unknown preload parameter (expected route, instances, env_instances, \
-                 typed, zero_tracing, interceptor; a conditional registration is declared \
-                 with the separate #[optional_service(\"...\")] attribute)",
+                 typed, zero_tracing, interceptor, is_private; a conditional registration \
+                 is declared with the separate #[optional_service(\"...\")] attribute)",
             ));
         }
         Ok(())
@@ -144,6 +154,7 @@ pub fn preload(args: TokenStream, input: TokenStream) -> TokenStream {
                 optional_service: #optional_expr,
                 zero_tracing: #zero_tracing,
                 interceptor: #interceptor,
+                is_private: #is_private,
                 factory: || #factory,
             }
         }

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -76,6 +76,7 @@
 | 57 | parity remediation 8 (final) — nested `[]` append recursion, list→text List.toString, UTF-16 length/substring, launch-failure 500, session-guard case, `-0` concat rendering, HostUri lastIndexOf split | 2026-07-21 | — | 230 |
 | 58 | F2 resolution (maintainer: NORMALIZE) — Nil map entries strip deterministically on every hop incl. the in-process fast path; the load-dependent null visibility is gone | 2026-07-21 | — | 231 |
 | 59 | Event over HTTP phase 2, increment 1 — standard envelope wire-format conformance: body absent-as-nil default, round_trip field, unset-field omission; Java golden vectors decode + round-trip | 2026-07-21 | — | 233 |
+| 60 | Event over HTTP phase 2, increment 2 — private functions, both Java paths: `#[preload]` private-by-default with `is_private = false` opt-out + `register_private` API + `is_private()` query; engine internals registered private | 2026-07-21 | — | 233 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1645,6 +1646,33 @@ design decision D4's "revisit if interop is ever required" clause in the port's 
   paths — a `#[preload]` attribute for the declarative form and a programmatic
   `register_private` API), then the `/api/event` service + client and the live
   cross-language interop pairing.
+
+---
+
+## Increment 60 — Event over HTTP phase 2 / 2: private functions (2026-07-21)
+
+The security gate before `/api/event` ships — Java's private-function concept, ported on
+BOTH declaration paths per the maintainer's directive:
+
+- **Declarative** (`platform-macros`): `#[preload]` gains `is_private` — and mirrors
+  Java's crucial default: `@PreLoad` functions are **private by default**
+  (`isPrivate() default true`); `is_private = false` opts into public visibility. Every
+  existing `#[preload]` function (engine internals included) therefore becomes private
+  with no per-site changes — exactly the Java posture, and behavior-neutral today since
+  only the `/api/event` boundary (increment 3) consumes the flag.
+- **Programmatic** (`platform.rs`): `register_private(route, function, instances)`
+  (Java `registerPrivate`); plain `register(...)` stays public (Java parity).
+  `is_private(route) -> Option<bool>` is the query surface the `/api/event` 403 gate
+  will use (Java `ServiceDef.isPrivateFunction`).
+- **Engine internals registered private** like Java's `EssentialServiceLoader` +
+  `WsRequestHandler`: `distributed.tracing`, the four actuators, `no.op`,
+  `async.http.request`, and the per-connection websocket routes.
+- **Tests** (`annotations.rs`): preload default-private, `is_private = false` opt-out,
+  `register` = public / `register_private` = private, unregistered → `None`, and the
+  engine internals' private status. Docs: macros-reference + the event-driven AI guide
+  gain the attribute row (and macros-reference's stale "duplicate route fails at
+  startup" claim corrected to the increment-55 reload semantics). Workspace 233 tests /
+  clippy 0 / fmt.
 
 ---
 

--- a/docs/guides/event-driven/ai-agent-guide.md
+++ b/docs/guides/event-driven/ai-agent-guide.md
@@ -67,6 +67,7 @@ struct MyFunction;
 | `typed` | flag | off | The struct implements `TypedFunction<I, O>` instead of `ComposableFunction`; the engine bridges it with a `TypedAdapter`. |
 | `zero_tracing` | flag | off | Exclude this route from distributed tracing (also stackable as `#[zero_tracing]`). |
 | `interceptor` | flag | off | Event-interceptor mode: the function sees the raw incoming `EventEnvelope` and the engine does **not** auto-reply on success (failures still route to the caller). Also stackable as `#[event_interceptor]`. |
+| `is_private` | bool | `true` | Preloaded functions are **private by default** (in-instance only — Java `@PreLoad` parity); set `is_private = false` to make the function callable from another application instance through Event over HTTP. Everything inside the instance (REST automation, flows, graphs) reaches private functions normally. Programmatic pair: `platform.register_private(...)`; plain `register(...)` = public. |
 
 *(The Java engine's `isPrivate`, `inputPojoClass`, `customSerializer`, and
 `inputStrategy`/`outputStrategy` parameters have no Rust equivalent — everything is process-local,

--- a/docs/guides/macros-reference.md
+++ b/docs/guides/macros-reference.md
@@ -33,6 +33,7 @@ Registers a composable function at startup and binds it to a route — the Java
 | `typed` | The struct implements `TypedFunction<I, O>` instead of `ComposableFunction`. |
 | `zero_tracing` | Flag form of the stacked `#[zero_tracing]` marker (below). |
 | `interceptor` | Flag form of the stacked `#[event_interceptor]` marker (below). |
+| `is_private = false` | Opt into **public** visibility — callable from another application instance through Event over HTTP. Preloaded functions are **private by default**, exactly like Java `@PreLoad` (`isPrivate` defaults to `true`); private functions stay reachable by everything inside the instance (REST automation, flows, graphs) and are rejected only at the `/api/event` boundary. The programmatic pair is `platform.register_private(...)` — plain `register(...)` creates public functions (Java parity). |
 
 Without `typed`, the struct must implement `ComposableFunction` (raw `EventEnvelope` in and
 out). With `typed`, it implements `TypedFunction<I, O>` with your own `serde` types and the
@@ -72,7 +73,8 @@ configured value when the key is set:
 struct UntypedEcho;
 ```
 
-An invalid route name or a duplicate route fails the application at startup, so wiring
+An invalid route name fails the application at startup (a duplicate route RELOADS the
+existing one, exactly like Java `Platform.register` — see increment 55), so wiring
 mistakes never reach runtime.
 
 !!! note "Rust port"

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-233234)
+- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-235034)
 - **last_review:** 2026-07-21 | through 2026-07-21-214043
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -70,7 +70,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Rust layer by layer, foundation → UI (platform-core, then event-script, then active
   knowledge graph), preserving the Java project's behavior. The Java repo is the canonical
   spec (map, don't mirror).
-  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 70 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 71 | tier: active | origin: 2026-07-15-215538.md -->
 ## Conventions
 
 > Established with the first code (increment 1, 2026-07-15); enforced from the first commit.
@@ -94,7 +94,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   2026-07-16): annotated functions + `platform_core::auto_start_main!();` with the app's
   `resources/` beside its `Cargo.toml` — never cargo examples inside a library crate.
   Event-script and knowledge-graph demos land as sibling `examples/<name>/` crates.
-  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 69 | tier: active | origin: 2026-07-15-224707.md -->
+  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 70 | tier: active | origin: 2026-07-15-224707.md -->
 
 ## Open Threads
 
@@ -497,13 +497,17 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   round_trip field, unset-field omission; the five Java golden vectors (copied verbatim)
   decode + round-trip; encoder contract locked (fresh envelope = id + headers only).
   Compact (legacy) format deliberately NOT decoded — v1 standard-only, 400 on compact
-  peers. **Next: increment 2 = private functions (MAINTAINER DIRECTIVE: both Java paths —
-  a `private` attribute on the `#[preload]` macro for the declarative form AND a
-  programmatic `register_private` API; engine internals then registered private);
-  increment 3 = /api/event service + client (x-ttl/x-async semantics, trace propagation
-  via x-trace-id + traceparent) + live interop pairing with the Java session (both
-  directions, RPC + async, 404/403/408 + trace continuity).** → serves: vision-mercury
-  <!-- id: ot-event-over-http | created: 2026-07-21 | last_used: 2026-07-21 | uses: 1 | tier: working | origin: 2026-07-21-233234.md -->
+  peers. **Increment 2 DONE 2026-07-21 (increment 60): private functions, both Java paths** —
+  `#[preload]` is PRIVATE BY DEFAULT with `is_private = false` opt-out (mirrors Java
+  `@PreLoad isPrivate() default true` — a deliberate posture: engine internals become
+  private automatically), `register_private` API + `is_private()` query, engine internals
+  (distributed.tracing, actuators, no.op, async.http.request, ws routes) registered
+  private like Java's EssentialServiceLoader/WsRequestHandler. **Next: increment 3 =
+  /api/event service + client (x-ttl/x-async semantics, 403 via is_private, trace
+  propagation via x-trace-id + traceparent) + live interop pairing with the Java session
+  (both directions, RPC + async, 404/403/408 + trace continuity; the interop target
+  function must be declared `is_private = false`).** → serves: vision-mercury
+  <!-- id: ot-event-over-http | created: 2026-07-21 | last_used: 2026-07-21 | uses: 2 | tier: working | origin: 2026-07-21-233234.md -->
 
 - [ ] **(knowledge-harvest) Harvest the canonical vision/specs from mercury-composable (Java).**
   **Gate satisfied 2026-07-15** — the maintainer added `~/sandbox/mercury-composable` and

--- a/memory/sessions/2026-07-21-233234.md
+++ b/memory/sessions/2026-07-21-233234.md
@@ -33,6 +33,9 @@ a `private` attribute on the `#[preload]` macro (declarative, Java @PreLoad pari
 programmatic `register_private` API; engine internals then registered private.**
 Increment 3 = /api/event service + client + live cross-language interop pairing.
 
+Also: shipped as PR [#163](https://github.com/Accenture/mercury/pull/163), MERGED
+2026-07-21 (true merge, CI green).
+
 ## Memory References
 
 - created: ot-event-over-http (born tier: working)

--- a/memory/sessions/2026-07-21-235034.md
+++ b/memory/sessions/2026-07-21-235034.md
@@ -1,0 +1,34 @@
+# Session (2026-07-21T23:50:34.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Increment 60 — Event over HTTP phase 2 / increment 2: private functions**, the security
+gate before /api/event, implemented on BOTH Java declaration paths per the maintainer's
+directive:
+
+- **Declarative:** `#[preload]` gains `is_private`, mirroring Java's crucial default —
+  `@PreLoad` functions are PRIVATE BY DEFAULT (`isPrivate() default true`); Java-source
+  verified. `is_private = false` opts into public. All existing `#[preload]` functions
+  (engine internals included) become private with zero per-site edits — the Java posture;
+  behavior-neutral today since only /api/event (increment 3) consumes the flag.
+- **Programmatic:** `Platform::register_private` (Java registerPrivate); `register` stays
+  public (Java parity). `is_private(route) -> Option<bool>` = the 403 gate's query
+  surface (Java ServiceDef.isPrivateFunction).
+- **Engine internals private** like Java EssentialServiceLoader/WsRequestHandler:
+  distributed.tracing, the four actuators, no.op, async.http.request, per-connection ws
+  routes (each Java-verified).
+
+Tests in `annotations.rs`: default-private, opt-out, register vs register_private,
+None-for-unknown, internals' status. Docs swept per the increment-58 lesson:
+macros-reference + event-driven AI guide gain the attribute row; macros-reference's stale
+"duplicate route fails at startup" corrected to increment-55 reload semantics; docs
+strict-build green. Workspace 233 / clippy 0 / fmt. INCREMENTS.md §60.
+
+## Memory References
+
+- referenced: ot-event-over-http (increment 2 → DONE; next = /api/event + interop),
+  port-bottom-up-faithful, conventions-rust-baseline
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

Event over HTTP phase 2, increment 2 — Java's private-function concept, ported on both
declaration paths:

- **Declarative:** `#[preload]` gains `is_private`, mirroring Java's default — `@PreLoad`
  functions are **private by default** (`isPrivate() default true`); `is_private = false`
  opts into public visibility (the form an Event-over-HTTP target uses). Every existing
  `#[preload]` function, engine internals included, becomes private with zero per-site
  changes — exactly the Java posture.
- **Programmatic:** `Platform::register_private(...)` (Java `registerPrivate`); plain
  `register(...)` stays public. `is_private(route)` is the query surface for the
  `/api/event` 403 gate (Java `ServiceDef.isPrivateFunction`).
- **Engine internals registered private** like Java's `EssentialServiceLoader` and
  `WsRequestHandler`: `distributed.tracing`, the four actuators, `no.op`,
  `async.http.request`, and the per-connection websocket routes.

## Why

This is the security gate the phase-2 review identified: without a private-function
concept, `/api/event` (next increment) would expose reserved engine routes, the telemetry
sink, and RPC inboxes to any remote poster. Java rejects private functions at that
boundary, and its internals are private — the port now matches on both counts. The change
is behavior-neutral today (nothing consumes the flag until `/api/event` lands); everything
inside the instance reaches private functions normally, as in Java.

Tests cover default-private, the opt-out, both programmatic paths, and the internals'
status. Docs: macros-reference + the event-driven AI guide gain the attribute row (and a
stale duplicate-route claim was corrected to the increment-55 reload semantics); docs
strict-build green. Workspace 233 tests green, clippy clean, fmt applied.

Co-Authored-By: Claude Code <noreply@anthropic.com>