### PR TITLE
feat(platform-core): /api/event service and client — Event over HTTP (increment 61)

### DIFF
--- a/crates/platform-core/src/app_starter.rs
+++ b/crates/platform-core/src/app_starter.rs
@@ -155,6 +155,21 @@ impl AppStarter {
                 }
             }
         }
+        // the event-over-http service (Java EssentialServiceLoader): reached
+        // through REST automation's default /api/event route. Registered
+        // PRIVATE — it is never itself a remote target. 250 workers (Java
+        // parity: the endpoint fans out concurrent RPC forwards).
+        if !platform.has_route(crate::automation::EVENT_API_SERVICE) {
+            if let Err(e) = platform.register_private(
+                crate::automation::EVENT_API_SERVICE,
+                Arc::new(crate::automation::EventApiService::new(&platform)),
+                250,
+            ) {
+                if !platform.has_route(crate::automation::EVENT_API_SERVICE) {
+                    return Err(e);
+                }
+            }
+        }
         // actuator endpoints (Java EssentialServiceLoader parity): /info /env
         // /health /livenessprobe, exposed via REST automation's default routes
         if !platform.has_route(crate::actuator::INFO_ACTUATOR) {

--- a/crates/platform-core/src/automation/event_api.rs
+++ b/crates/platform-core/src/automation/event_api.rs
@@ -1,0 +1,233 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Event over HTTP (increment 61) — Rust port of Java
+//! `org.platformlambda.core.services.EventApiService` + the `EventEmitter`
+//! event-over-http client. A serialized [`EventEnvelope`] (the **standard**
+//! wire format, increment 59) is exchanged over `POST /api/event`, so a
+//! function in one application instance can call a **public** function
+//! (`is_private = false`) in another — the only cross-instance coupling, and
+//! opt-in by design.
+//!
+//! The service is reached through REST automation (the `/api/event` entry
+//! ships in the default `rest.yaml`, merged like the actuators). It decodes
+//! the posted envelope, enforces the visibility boundary (403 for a private
+//! target — a remote caller must never reach engine internals or an
+//! unpublished function), and dispatches: async (`x-async: true`) is
+//! drop-n-forget with a 202 ack; otherwise RPC up to `x-ttl` ms.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rmpv::Value;
+
+use crate::automation::http_client::{AsyncHttpRequest, ASYNC_HTTP_REQUEST};
+use crate::envelope::EventEnvelope;
+use crate::function::{AppError, ComposableFunction};
+use crate::platform::Platform;
+use crate::post_office::PostOffice;
+use crate::util::w3c_trace;
+
+/// Route of the event-over-http service (Java `EventApiService.EVENT_API_SERVICE`).
+pub const EVENT_API_SERVICE: &str = "event.api.service";
+
+const OCTET_STREAM: &str = "application/octet-stream";
+const X_TTL: &str = "x-ttl";
+const X_ASYNC: &str = "x-async";
+
+/// The `/api/event` service (Java `EventApiService`). Registered PRIVATE — it
+/// is reached only through the REST boundary, never as a remote target.
+pub struct EventApiService {
+    platform: Platform,
+}
+
+impl EventApiService {
+    pub fn new(platform: &Platform) -> Self {
+        EventApiService {
+            platform: platform.clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl ComposableFunction for EventApiService {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let request = AsyncHttpRequest::from_value(input.body());
+        let timeout_ms = request
+            .header(X_TTL)
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(0)
+            .max(1000);
+        let is_async = request.header(X_ASYNC) == Some("true");
+        // the HTTP body is the serialized envelope; octet-stream arrives as a
+        // MsgPack-binary body on the request map (Java parity)
+        let Value::Binary(bytes) = request.body() else {
+            return Ok(reply(500, b"Invalid event-over-http data format".to_vec()));
+        };
+        // v1 accepts the standard wire format only (phase-2 decision); a
+        // compact (all single-char keys) envelope is rejected clearly
+        if is_compact_envelope(bytes) {
+            return Ok(reply(
+                400,
+                error_envelope(
+                    400,
+                    "compact format not supported - set event.over.http.format=standard on the sender",
+                ),
+            ));
+        }
+        let inner = match EventEnvelope::from_bytes(bytes) {
+            Ok(envelope) => envelope,
+            // the format is unknown when decode fails (Java falls back to a
+            // compact error reply; we answer 400 with a plain message)
+            Err(e) => return Ok(reply(400, error_envelope(400, e.message()))),
+        };
+        let Some(to) = inner.to().map(str::to_string) else {
+            return Ok(reply(400, error_envelope(400, "Missing routing path")));
+        };
+        if !self.platform.has_route(&to) {
+            return Ok(reply(
+                404,
+                error_envelope(404, &format!("Route {to} not found")),
+            ));
+        }
+        if self.platform.is_private(&to) == Some(true) {
+            return Ok(reply(403, error_envelope(403, &format!("{to} is private"))));
+        }
+        let po = PostOffice::new(&self.platform);
+        if is_async {
+            // drop-n-forget: deliver and acknowledge (Java 202 ack shape)
+            po.send(inner).await?;
+            let ack = EventEnvelope::new()
+                .set_status(202)
+                .set_body(serde_json::json!({
+                    "type": "async",
+                    "delivered": true,
+                    "time": crate::trace::iso8601_utc_now(),
+                }))?;
+            Ok(reply(200, ack.to_bytes()?))
+        } else {
+            // RPC: forward and mirror the target's envelope back (or 408)
+            match po.request(inner, Duration::from_millis(timeout_ms)).await {
+                Ok(result) => Ok(reply(200, result.to_bytes()?)),
+                Err(e) => Ok(reply(408, error_envelope(408, e.message()))),
+            }
+        }
+    }
+}
+
+/// Build the HTTP response envelope: the body is a serialized envelope carried
+/// raw as `application/octet-stream` (Java `sendResponse`/`sendError`). The
+/// outer status is 200 for a successful dispatch (the real result status rides
+/// inside the serialized body) and the error code for a service-level error.
+fn reply(http_status: i32, body: Vec<u8>) -> EventEnvelope {
+    EventEnvelope::new()
+        .set_status(http_status)
+        .set_header("content-type", OCTET_STREAM)
+        .set_raw_body(Value::Binary(body))
+}
+
+/// A serialized error envelope (status + message body) — the payload the
+/// client deserializes and hands back to its caller.
+fn error_envelope(status: i32, message: &str) -> Vec<u8> {
+    EventEnvelope::new()
+        .set_status(status)
+        .set_raw_body(Value::from(message))
+        .to_bytes()
+        .unwrap_or_default()
+}
+
+/// A compact (legacy Java) envelope has ONLY single-character top-level keys;
+/// the standard format's keys are all longer, so the namespaces are disjoint.
+fn is_compact_envelope(bytes: &[u8]) -> bool {
+    match rmp_serde::from_slice::<Value>(bytes) {
+        Ok(Value::Map(entries)) if !entries.is_empty() => entries
+            .iter()
+            .all(|(k, _)| k.as_str().is_some_and(|s| s.chars().count() == 1)),
+        _ => false,
+    }
+}
+
+/// Event-over-http client (Java `EventEmitter.asyncRequest`/`eRequest` over an
+/// endpoint): POST `event` to `{endpoint}` as a serialized standard envelope.
+/// `rpc = true` awaits the target's reply up to `timeout`; `rpc = false` is
+/// drop-n-forget (the 202 ack envelope is returned). Trace context propagates
+/// via `x-trace-id` + W3C `traceparent` so cross-language traces chain.
+pub async fn event_over_http(
+    po: &PostOffice,
+    endpoint: &str,
+    event: EventEnvelope,
+    timeout: Duration,
+    rpc: bool,
+) -> Result<EventEnvelope, AppError> {
+    let (host, path) = split_endpoint(endpoint)?;
+    let trace_id = event.trace_id().map(str::to_string);
+    let span_id = event.span_id().map(str::to_string);
+    let payload = event.to_bytes()?;
+    let mut http = AsyncHttpRequest::new()
+        .set_method("POST")
+        .set_url(&path)
+        .set_target_host(&host)
+        .set_header("content-type", OCTET_STREAM)
+        .set_header(X_TTL, &timeout.as_millis().max(1000).to_string())
+        .set_body(Value::Binary(payload));
+    if !rpc {
+        http = http.set_header(X_ASYNC, "true");
+    }
+    // trace propagation (Java sets both headers so the receiver chains onto
+    // this span as its parent)
+    if let Some(trace_id) = &trace_id {
+        http = http.set_header("x-trace-id", trace_id);
+        if let Some(span_id) = &span_id {
+            if let Some(traceparent) = w3c_trace::format(trace_id, span_id) {
+                http = http.set_header(w3c_trace::TRACEPARENT, &traceparent);
+            }
+        }
+    }
+    let http_event = EventEnvelope::new()
+        .set_to(ASYNC_HTTP_REQUEST)
+        .set_raw_body(http.to_value());
+    let response = po.request(http_event, timeout).await?;
+    // the response body is the serialized reply envelope (octet-stream →
+    // binary); anything else is a transport-level failure
+    match response.body() {
+        Value::Binary(bytes) => EventEnvelope::from_bytes(bytes),
+        other => Err(AppError::new(
+            500,
+            format!("Invalid event-over-http response: {other:?}"),
+        )),
+    }
+}
+
+/// Split `http://host:port/api/event` into (`http://host:port`, `/api/event`).
+fn split_endpoint(endpoint: &str) -> Result<(String, String), AppError> {
+    let scheme_end = endpoint
+        .find("://")
+        .map(|i| i + 3)
+        .ok_or_else(|| AppError::new(400, format!("Invalid endpoint {endpoint}")))?;
+    match endpoint[scheme_end..].find('/') {
+        Some(offset) => {
+            let split = scheme_end + offset;
+            Ok((endpoint[..split].to_string(), endpoint[split..].to_string()))
+        }
+        None => Ok((endpoint.to_string(), "/api/event".to_string())),
+    }
+}

--- a/crates/platform-core/src/automation/mod.rs
+++ b/crates/platform-core/src/automation/mod.rs
@@ -2,11 +2,13 @@
 //! `org.platformlambda.automation` package, increment-6 core scope; see
 //! `docs/design/platform-core-port.md` §5e).
 
+pub mod event_api;
 pub mod http_client;
 pub mod routing;
 pub mod server;
 pub mod ws_server;
 
+pub use event_api::{event_over_http, EventApiService, EVENT_API_SERVICE};
 pub use http_client::{AsyncHttpRequest, ASYNC_HTTP_REQUEST};
 pub use routing::{AssignedRoute, CorsInfo, HeaderInfo, RouteInfo, RoutingTable};
 pub use server::{server_address, start_http_server, MY_CORRELATION_ID};

--- a/crates/platform-core/src/automation/server.rs
+++ b/crates/platform-core/src/automation/server.rs
@@ -618,6 +618,11 @@ fn url_decode(text: &str) -> String {
 /// `/info/lib` and `/info/routes` are deferred (see the actuator module doc).
 const DEFAULT_REST_YAML: &str = r#"
 rest:
+  - service: "event.api.service"
+    methods: ['POST']
+    url: "/api/event"
+    timeout: 60s
+    tracing: true
   - service: "info.actuator.service"
     methods: ['GET']
     url: "/info"

--- a/crates/platform-core/tests/event_over_http.rs
+++ b/crates/platform-core/tests/event_over_http.rs
@@ -1,0 +1,276 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Increment 61 — Event over HTTP end to end: a serialized envelope crosses
+//! `POST /api/event` over a real HTTP connection, exercising the visibility
+//! boundary (403 private), RPC + async dispatch, 404, and the compact-format
+//! rejection. The `event_over_http` client is round-tripped against the same
+//! server so the two halves prove each other (a local stand-in for the
+//! cross-language interop pairing).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Once};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use platform_core::automation::http_client::AsyncHttpClientService;
+use platform_core::automation::{self, event_over_http, AsyncHttpRequest, EventApiService};
+use platform_core::{
+    overrides, resources, AppConfigReader, AppError, ComposableFunction, EventEnvelope,
+    FunctionOptions, Platform, PostOffice,
+};
+use rmpv::Value;
+
+/// A public target: echoes its body and reports the trace id it ran under.
+struct RemoteEcho;
+
+#[async_trait]
+impl ComposableFunction for RemoteEcho {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let po = PostOffice::new(&Platform::get_instance());
+        EventEnvelope::new()
+            .set_status(201)
+            .set_header("x-demo", "remote")
+            .set_body(serde_json::json!({
+                "echo": serde_json::to_value(input.body()).unwrap_or_default(),
+                "seen_trace": po.my_trace_id(),
+            }))
+    }
+}
+
+async fn server() -> (u16, Platform) {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        resources::prepend_resource_root("tests/resources");
+        let holding = std::env::temp_dir().join(format!("mercury-eoh-test-{}", std::process::id()));
+        overrides::set("transient.data.store", &holding.display().to_string());
+        overrides::set("rest.server.port", "0");
+        // a minimal rest.yaml; /api/event arrives via the default-endpoint merge
+        overrides::set("yaml.rest.automation", "classpath:/event-rest.yaml");
+        let _ = AppConfigReader::get_instance();
+    });
+    let platform = Platform::new();
+    // the event service + a PUBLIC target and a PRIVATE one
+    platform
+        .register_private(
+            automation::EVENT_API_SERVICE,
+            Arc::new(EventApiService::new(&platform)),
+            10,
+        )
+        .unwrap();
+    platform
+        .register("v1.remote.echo", Arc::new(RemoteEcho), 4)
+        .unwrap();
+    platform
+        .register_private("v1.secret", Arc::new(RemoteEcho), 1)
+        .unwrap();
+    // the event-over-http CLIENT posts through async.http.request — the
+    // lifecycle registers it normally; this test boots the server directly
+    platform
+        .register_with_options(
+            automation::ASYNC_HTTP_REQUEST,
+            Arc::new(AsyncHttpClientService),
+            10,
+            FunctionOptions {
+                interceptor: true,
+                private: true,
+                ..FunctionOptions::default()
+            },
+        )
+        .unwrap();
+    let addr = automation::start_http_server(&platform).await.unwrap();
+    (addr.port(), platform)
+}
+
+/// POST raw bytes to `/api/event` and return (http_status, response body bytes).
+async fn post_event(port: u16, body: &[u8], extra: &[(&str, &str)]) -> (u16, Vec<u8>) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("connect");
+    let mut head = format!(
+        "POST /api/event HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/octet-stream\r\nContent-Length: {}\r\n",
+        body.len()
+    );
+    for (name, value) in extra {
+        head.push_str(&format!("{name}: {value}\r\n"));
+    }
+    head.push_str("Connection: close\r\n\r\n");
+    let mut request = head.into_bytes();
+    request.extend_from_slice(body);
+    stream.write_all(&request).await.expect("write");
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).await.expect("read");
+    // split head/body on the CRLFCRLF
+    let sep = raw
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .expect("http header terminator");
+    let head = String::from_utf8_lossy(&raw[..sep]).to_string();
+    let status: u16 = head
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|c| c.parse().ok())
+        .expect("status");
+    (status, raw[sep + 4..].to_vec())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn event_over_http_service_and_client() {
+    let (port, platform) = server().await;
+
+    // --- RPC to a public target: the reply envelope carries the target's
+    // status, headers, and body (the serialized envelope rides the HTTP body)
+    let request = EventEnvelope::new()
+        .set_to("v1.remote.echo")
+        .set_trace("trace-eoh", "POST /api/event")
+        .set_span_id("00f067aa0ba902b7")
+        .set_body(serde_json::json!({"ping": 1}))
+        .unwrap();
+    let (http_status, body) =
+        post_event(port, &request.to_bytes().unwrap(), &[("x-ttl", "5000")]).await;
+    assert_eq!(http_status, 200);
+    let result = EventEnvelope::from_bytes(&body).expect("decode reply envelope");
+    assert_eq!(result.status(), 201);
+    assert_eq!(result.header("x-demo"), Some("remote"));
+    let payload: serde_json::Value = result.body_as().unwrap();
+    assert_eq!(payload["echo"]["ping"], 1);
+    // the trace crossed the boundary and the target ran under it
+    assert_eq!(payload["seen_trace"], "trace-eoh");
+
+    // --- a private target is rejected 403 (the encapsulation boundary)
+    let secret = EventEnvelope::new()
+        .set_to("v1.secret")
+        .set_body("x")
+        .unwrap();
+    let (status, body) = post_event(port, &secret.to_bytes().unwrap(), &[]).await;
+    assert_eq!(status, 403);
+    let err = EventEnvelope::from_bytes(&body).unwrap();
+    assert_eq!(err.status(), 403);
+    assert!(err
+        .body_as::<String>()
+        .unwrap()
+        .contains("v1.secret is private"));
+
+    // --- an unknown route is 404
+    let missing = EventEnvelope::new()
+        .set_to("v1.nope")
+        .set_body("x")
+        .unwrap();
+    let (status, _) = post_event(port, &missing.to_bytes().unwrap(), &[]).await;
+    assert_eq!(status, 404);
+
+    // --- async (drop-n-forget) → HTTP 200 with a 202 ack envelope
+    let async_req = EventEnvelope::new()
+        .set_to("v1.remote.echo")
+        .set_body("fire")
+        .unwrap();
+    let (status, body) =
+        post_event(port, &async_req.to_bytes().unwrap(), &[("x-async", "true")]).await;
+    assert_eq!(status, 200);
+    let ack = EventEnvelope::from_bytes(&body).unwrap();
+    assert_eq!(ack.status(), 202);
+    let ack_body: serde_json::Value = ack.body_as().unwrap();
+    assert_eq!(ack_body["type"], "async");
+    assert_eq!(ack_body["delivered"], true);
+
+    // --- a compact (legacy) envelope is rejected 400 with a clear message
+    let compact = Value::Map(vec![
+        (Value::from("0"), Value::from("e1")),
+        (Value::from("T"), Value::from("v1.remote.echo")),
+    ]);
+    let compact_bytes = rmp_serde::to_vec_named(&compact).unwrap();
+    let (status, body) = post_event(port, &compact_bytes, &[]).await;
+    assert_eq!(status, 400);
+    assert!(EventEnvelope::from_bytes(&body)
+        .unwrap()
+        .body_as::<String>()
+        .unwrap()
+        .contains("compact format not supported"));
+
+    // --- the client half round-trips against the same server (a local
+    // stand-in for cross-language interop): RPC + async
+    let po = PostOffice::new(&platform);
+    let endpoint = format!("http://127.0.0.1:{port}/api/event");
+    let via_client = event_over_http(
+        &po,
+        &endpoint,
+        EventEnvelope::new()
+            .set_to("v1.remote.echo")
+            .set_body(serde_json::json!({"ping": 2}))
+            .unwrap(),
+        Duration::from_secs(5),
+        true,
+    )
+    .await
+    .expect("client RPC");
+    assert_eq!(via_client.status(), 201);
+    let client_payload: serde_json::Value = via_client.body_as().unwrap();
+    assert_eq!(client_payload["echo"]["ping"], 2);
+
+    let via_client_async = event_over_http(
+        &po,
+        &endpoint,
+        EventEnvelope::new()
+            .set_to("v1.remote.echo")
+            .set_body("fire")
+            .unwrap(),
+        Duration::from_secs(5),
+        false,
+    )
+    .await
+    .expect("client async");
+    assert_eq!(via_client_async.status(), 202);
+
+    // the private-target 403 surfaces through the client too
+    let client_403 = event_over_http(
+        &po,
+        &endpoint,
+        EventEnvelope::new()
+            .set_to("v1.secret")
+            .set_body("x")
+            .unwrap(),
+        Duration::from_secs(5),
+        true,
+    )
+    .await
+    .expect("client 403 is a normal envelope, not a transport error");
+    assert_eq!(client_403.status(), 403);
+}
+
+/// The service must not be reachable AS a remote target (it is private) — a
+/// defense-in-depth check on the visibility gate.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn event_service_itself_is_private() {
+    let (port, _platform) = server().await;
+    let recursive = EventEnvelope::new()
+        .set_to(automation::EVENT_API_SERVICE)
+        .set_body("x")
+        .unwrap();
+    let (status, _) = post_event(port, &recursive.to_bytes().unwrap(), &[]).await;
+    assert_eq!(
+        status, 403,
+        "the event service must reject itself as a target"
+    );
+    // silence the unused import when only this test builds
+    let _ = AsyncHttpRequest::new();
+}

--- a/crates/platform-core/tests/resources/event-rest.yaml
+++ b/crates/platform-core/tests/resources/event-rest.yaml
@@ -1,0 +1,5 @@
+rest:
+  - service: "no.op"
+    methods: ['GET']
+    url: "/api/placeholder"
+    timeout: 10s

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -77,6 +77,7 @@
 | 58 | F2 resolution (maintainer: NORMALIZE) — Nil map entries strip deterministically on every hop incl. the in-process fast path; the load-dependent null visibility is gone | 2026-07-21 | — | 231 |
 | 59 | Event over HTTP phase 2, increment 1 — standard envelope wire-format conformance: body absent-as-nil default, round_trip field, unset-field omission; Java golden vectors decode + round-trip | 2026-07-21 | — | 233 |
 | 60 | Event over HTTP phase 2, increment 2 — private functions, both Java paths: `#[preload]` private-by-default with `is_private = false` opt-out + `register_private` API + `is_private()` query; engine internals registered private | 2026-07-21 | — | 233 |
+| 61 | Event over HTTP phase 2, increment 3 — /api/event service + client: RPC/async dispatch, 403 private gate, 404/400/408, compact rejection, trace propagation (x-trace-id + traceparent); ships in default rest.yaml | 2026-07-21 | — | 235 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1673,6 +1674,38 @@ BOTH declaration paths per the maintainer's directive:
   gain the attribute row (and macros-reference's stale "duplicate route fails at
   startup" claim corrected to the increment-55 reload semantics). Workspace 233 tests /
   clippy 0 / fmt.
+
+---
+
+## Increment 61 — Event over HTTP phase 2 / 3: the /api/event service + client (2026-07-21)
+
+The feature comes together — Java `EventApiService` + the `EventEmitter` event-over-http
+client, ported (`automation/event_api.rs`):
+
+- **Service** (`POST /api/event`, registered PRIVATE, in the default rest.yaml via
+  `merge_default_endpoints` — the maintainer's directive): decodes the posted standard
+  envelope, enforces the visibility boundary (**403** for a private target — a remote
+  caller can never reach engine internals or an unpublished function), and dispatches —
+  async (`x-async: true`) is drop-n-forget with a 202 ack, otherwise RPC up to `x-ttl` ms
+  mirroring the target's reply. 404 (unknown route), 400 (missing `to`), 408 (RPC
+  timeout), and a clear 400 for a legacy compact envelope (v1 is standard-only). Every
+  response body is itself a serialized envelope, so the caller reads success and failure
+  the same way.
+- **Client** (`event_over_http`): POSTs a serialized envelope to a peer, returns the reply
+  (or the 202 ack for async). Trace context propagates via `x-trace-id` + W3C
+  `traceparent`, so a trace continues across the boundary and the remote spans parent onto
+  the caller's — one distributed trace across instances and languages.
+- **Test** (`event_over_http.rs`): a real HTTP round trip through `/api/event` —
+  RPC (status/headers/body + trace crossing), 403 private, 404, async 202 ack, compact
+  rejection, the service rejecting ITSELF as a target, and the `event_over_http` client
+  round-tripped against the same server (a local stand-in for the cross-language pairing).
+- **Docs:** new `event-over-http.md` guide (nav under Layer 1); two now-stale port notes
+  corrected (actuators + rest-automation had said `/api/event` was unported). Workspace
+  235 tests / clippy 0 / fmt; docs strict-build green.
+- **Next: the live cross-language interop pairing with the Java session** — composable-example
+  (:8100) / lambda-example (:8085) both directions, RPC + async, 404/403/408 + trace
+  continuity (the Java session offered to pair). The interop target must be
+  `is_private = false`.
 
 ---
 

--- a/docs/guides/actuators-and-http-client.md
+++ b/docs/guides/actuators-and-http-client.md
@@ -20,10 +20,11 @@ GET /livenessprobe
 ```
 
 !!! note "Rust port"
-    Three Java defaults are not ported: **`/info/lib`** (Java lists JAR dependencies from the
-    archive manifest — a Rust binary has no runtime dependency manifest), **`/info/routes`**
-    (the route listing), and **`POST /api/event`** (the Event-over-HTTP protocol). XML actuator
-    responses are also not supported — actuators answer in JSON.
+    Two Java defaults are not ported: **`/info/lib`** (Java lists JAR dependencies from the
+    archive manifest — a Rust binary has no runtime dependency manifest) and **`/info/routes`**
+    (the route listing). XML actuator responses are also not supported — actuators answer in
+    JSON. **`POST /api/event` (Event over HTTP) IS ported** (increment 61) and ships in the
+    default rest.yaml — see [Event over HTTP](event-over-http.md).
 
 #### `GET /info`
 

--- a/docs/guides/event-over-http.md
+++ b/docs/guides/event-over-http.md
@@ -1,0 +1,91 @@
+# Event over HTTP
+
+**Event over HTTP** lets a function in one application instance call a function in
+*another* instance — the same route-name + `EventEnvelope` contract you use locally,
+carried across the network. It is the only cross-instance coupling in the platform, and it
+is **opt-in by design**: an instance is a closed world unless a developer deliberately
+publishes a function to it.
+
+Everything on this page describes this repository's engine
+(`crates/platform-core/src/automation/event_api.rs`); the wire format is shared verbatim
+with the Java engine (see [EventEnvelope wire format](event-envelope-reference.md)), so a
+Rust instance and a Java instance interoperate without adaptation.
+
+## The encapsulation boundary
+
+Every function is reachable **inside** its instance — by REST automation, flows, and
+graphs — but nothing crosses the instance boundary unless you expose it:
+
+```rust
+// private (the default) — in-instance only, exactly like Java @PreLoad
+#[preload(route = "v1.internal.worker")]
+struct InternalWorker;
+
+// public — callable from another instance over /api/event
+#[preload(route = "v1.public.api", is_private = false)]
+struct PublicApi;
+```
+
+The programmatic pair is `platform.register_private(...)` (private) versus plain
+`platform.register(...)` (public). Private is the default for `#[preload]` — the same
+posture as Java `@PreLoad`, whose `isPrivate` defaults to `true`. A remote call to a
+private function is rejected with **403**; engine internals (the actuators, the telemetry
+sink, the no-op function, the async HTTP client, the event service itself) are all private,
+so they can never be reached from outside.
+
+## The endpoint
+
+`POST /api/event` ships in the default `rest.yaml` — every application with
+`rest.automation: true` exposes it with no configuration (your own `rest.yaml` entry for
+that URL wins if you want to change its timeout, attach authentication, or add CORS).
+
+| Request element | Meaning |
+|---|---|
+| Body | the serialized request `EventEnvelope` (standard wire format), `content-type: application/octet-stream` |
+| `x-ttl` header | RPC timeout in milliseconds (minimum 1000) |
+| `x-async: true` header | drop-n-forget: deliver and acknowledge, do not wait for a reply |
+
+The service decodes the envelope, checks its `to` route, and dispatches:
+
+| Outcome | Response |
+|---|---|
+| RPC to a public route | HTTP 200; body = the target's reply envelope (its own status inside) |
+| Async to a public route | HTTP 200; body = a 202 acknowledgement envelope (`type: async, delivered: true`) |
+| `to` missing | HTTP 400, "Missing routing path" |
+| Route not found | HTTP 404, "Route {to} not found" |
+| Route is private | HTTP 403, "{to} is private" |
+| RPC timeout | HTTP 408 with the error message |
+
+In every case the HTTP response body is itself a serialized envelope, so the caller reads
+the outcome the same way regardless of success or failure.
+
+## Calling another instance
+
+The `event_over_http` client posts a serialized envelope to a peer and returns the reply
+envelope (or, for an async call, the 202 acknowledgement):
+
+```rust
+use platform_core::automation::event_over_http;
+use std::time::Duration;
+
+let reply = event_over_http(
+    &po,
+    "http://peer-host:8100/api/event",
+    EventEnvelope::new()
+        .set_to("v1.public.api")
+        .set_body(request_payload)?,
+    Duration::from_secs(5),
+    true, // rpc = true; false for drop-n-forget
+).await?;
+```
+
+Trace context propagates automatically: the client sets `x-trace-id` and the W3C
+`traceparent` header from the envelope's trace, so a trace started in one instance
+continues in the other and the remote function's spans parent onto the caller's span — a
+single distributed trace across the boundary (and across languages).
+
+!!! note "Port note"
+    The v1 service accepts the **standard** wire format only. A legacy Java *compact* envelope
+    (single-character keys) is rejected with a clear 400; Java 4.10+ defaults to standard, so
+    this only surfaces with an old or misconfigured peer. The Java engine's per-format response
+    mirroring is therefore unnecessary here — replies are always standard.

--- a/docs/guides/rest-automation.md
+++ b/docs/guides/rest-automation.md
@@ -409,14 +409,15 @@ the client instead. `path` and `service` are mandatory when a filter is configur
 
 ## Built-in endpoints
 
-When `rest.yaml` does not claim their URLs, four actuator endpoints are added automatically:
-`/info`, `/env`, `/health` and `/livenessprobe` — your own entry for one of these URLs always
-wins, which is how you attach `authentication`, CORS, or a different timeout to them. See
-[Actuators & HTTP Client](actuators-and-http-client.md).
+When `rest.yaml` does not claim their URLs, five endpoints are added automatically: the four
+actuators `/info`, `/env`, `/health`, `/livenessprobe`, and **`POST /api/event`** (Event over
+HTTP). Your own entry for one of these URLs always wins, which is how you attach
+`authentication`, CORS, or a different timeout to them. See
+[Actuators & HTTP Client](actuators-and-http-client.md) and
+[Event over HTTP](event-over-http.md).
 
 !!! note "Rust port"
-    The Java engine also provides `POST /api/event` (Event-over-HTTP), `/info/lib`, and
-    `/info/routes` as defaults. None of these are ported yet — see the
+    Two Java defaults remain unported — `/info/lib` and `/info/routes` — see the
     [actuator port notes](actuators-and-http-client.md#actuator-endpoints).
 
 ## See also

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-235034)
+- **last_session:** 2026-07-22 | agent: Claude Code (2026-07-22-000658)
 - **last_review:** 2026-07-21 | through 2026-07-21-214043
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -70,7 +70,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Rust layer by layer, foundation → UI (platform-core, then event-script, then active
   knowledge graph), preserving the Java project's behavior. The Java repo is the canonical
   spec (map, don't mirror).
-  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-21 | uses: 71 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-22 | uses: 72 | tier: active | origin: 2026-07-15-215538.md -->
 ## Conventions
 
 > Established with the first code (increment 1, 2026-07-15); enforced from the first commit.
@@ -94,7 +94,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   2026-07-16): annotated functions + `platform_core::auto_start_main!();` with the app's
   `resources/` beside its `Cargo.toml` — never cargo examples inside a library crate.
   Event-script and knowledge-graph demos land as sibling `examples/<name>/` crates.
-  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-21 | uses: 70 | tier: active | origin: 2026-07-15-224707.md -->
+  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-22 | uses: 71 | tier: active | origin: 2026-07-15-224707.md -->
 
 ## Open Threads
 
@@ -497,7 +497,18 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   round_trip field, unset-field omission; the five Java golden vectors (copied verbatim)
   decode + round-trip; encoder contract locked (fresh envelope = id + headers only).
   Compact (legacy) format deliberately NOT decoded — v1 standard-only, 400 on compact
-  peers. **Increment 2 DONE 2026-07-21 (increment 60): private functions, both Java paths** —
+  peers. **Increment 3 DONE 2026-07-21 (increment 61): /api/event service + client** — Java
+  EventApiService + EventEmitter client ported (`automation/event_api.rs`): service
+  registered PRIVATE + in the default rest.yaml (merge_default_endpoints), 403 private
+  gate / 404 / 400 / 408, async 202 ack vs RPC mirror, compact-envelope rejection (v1
+  standard-only), trace propagation via x-trace-id + traceparent; `event_over_http`
+  client returns the reply/ack envelope. E2E test = real HTTP round trip (all paths +
+  service-rejects-itself + client round-trip). New `event-over-http.md` guide; two stale
+  "not ported" notes corrected. Workspace 235/clippy 0/fmt. **ONLY REMAINING: the live
+  cross-language interop pairing with the Java session (composable-example :8100 /
+  lambda-example :8085, both directions, RPC + async, 404/403/408 + trace continuity;
+  interop target = is_private = false).** Earlier: **Increment 2 (increment 60): private
+  functions, both Java paths** —
   `#[preload]` is PRIVATE BY DEFAULT with `is_private = false` opt-out (mirrors Java
   `@PreLoad isPrivate() default true` — a deliberate posture: engine internals become
   private automatically), `register_private` API + `is_private()` query, engine internals
@@ -506,8 +517,11 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   /api/event service + client (x-ttl/x-async semantics, 403 via is_private, trace
   propagation via x-trace-id + traceparent) + live interop pairing with the Java session
   (both directions, RPC + async, 404/403/408 + trace continuity; the interop target
-  function must be declared `is_private = false`).** → serves: vision-mercury
-  <!-- id: ot-event-over-http | created: 2026-07-21 | last_used: 2026-07-21 | uses: 2 | tier: working | origin: 2026-07-21-233234.md -->
+  function must be declared `is_private = false`). MAINTAINER DIRECTIVES: private-by-
+  default = the encapsulation boundary is the app instance (functions cross it only via
+  deliberate is_private = false exposure); the /api/event endpoint ships in the DEFAULT
+  rest.yaml (merge_default_endpoints, like the actuators — zero user configuration).** → serves: vision-mercury
+  <!-- id: ot-event-over-http | created: 2026-07-21 | last_used: 2026-07-22 | uses: 3 | tier: working | origin: 2026-07-21-233234.md -->
 
 - [ ] **(knowledge-harvest) Harvest the canonical vision/specs from mercury-composable (Java).**
   **Gate satisfied 2026-07-15** — the maintainer added `~/sandbox/mercury-composable` and

--- a/memory/sessions/2026-07-22-000658.md
+++ b/memory/sessions/2026-07-22-000658.md
@@ -1,0 +1,42 @@
+# Session (2026-07-22T00:06:58.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Increment 61 — Event over HTTP phase 2 / increment 3: the `/api/event` service +
+client**, completing the feature's Rust implementation (Java EventApiService +
+EventEmitter event-over-http client, ported into `automation/event_api.rs`).
+
+- **Service** (`POST /api/event`): registered PRIVATE (reached only through the REST
+  boundary, never a remote target — a self-target test proves it) and added to the
+  default rest.yaml via `merge_default_endpoints` (maintainer directive). Decodes the
+  standard envelope, enforces the 403 private gate (the encapsulation boundary), and
+  dispatches: async `x-async:true` → drop-n-forget + 202 ack; RPC → forward up to
+  `x-ttl` (min 1000ms) and mirror the target's reply. 404/400/408 + a clear 400 for a
+  legacy compact envelope (v1 standard-only). Every response body is a serialized
+  envelope, so success and failure read the same way.
+- **Client** `event_over_http`: POSTs the serialized envelope to a peer, returns the
+  reply (or 202 ack). Trace context propagates via x-trace-id + W3C traceparent so
+  distributed traces chain across the boundary.
+- **E2E test** (`event_over_http.rs`): real HTTP round trip — RPC (status/headers/body +
+  trace crossing verified: the remote function ran under the sender's trace id), 403
+  private, 404, async ack, compact rejection, service-rejects-itself, AND the client half
+  round-tripped against the same server (local stand-in for the cross-language pairing).
+  Needed a minimal test rest.yaml + manual async.http.request registration (the harness
+  boots start_http_server directly, not the full lifecycle).
+- **Docs:** new `event-over-http.md` guide (Layer 1 nav); the two now-stale port notes
+  (actuators + rest-automation claimed /api/event unported) corrected; docs strict-build
+  green. Workspace 235 / clippy 0 / fmt. INCREMENTS.md §61.
+
+**ONLY REMAINING in ot-event-over-http: the live cross-language interop pairing with the
+Java session** (composable-example :8100 / lambda-example :8085, both directions, RPC +
+async, 404/403/408 + trace continuity; the Java session offered to pair). The Rust side
+is ready.
+
+## Memory References
+
+- referenced: ot-event-over-http (increment 3 → DONE; only live interop remains),
+  port-bottom-up-faithful, conventions-rust-baseline
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
       - Write Your First Function: guides/event-driven/write-your-first-function.md
       - Function Execution: guides/event-driven/function-execution.md
       - REST Automation: guides/rest-automation.md
+      - Event over HTTP: guides/event-over-http.md
       - Function AI Agent Guide: guides/event-driven/ai-agent-guide.md
   - "Layer 2 — Event Script":
       - Overview: guides/event-script/index.md


### PR DESCRIPTION
## What

Event over HTTP phase 2, increment 3 — the feature's Rust implementation, porting Java
`EventApiService` + the `EventEmitter` event-over-http client
(`automation/event_api.rs`):

- **Service (`POST /api/event`):** registered **private** (reached only through the REST
  boundary, never a remote target) and added to the default `rest.yaml`, so every app
  with `rest.automation` on exposes it with no configuration. It decodes the posted
  standard envelope, enforces the **403** private-target gate (a remote caller can never
  reach engine internals or an unpublished function), and dispatches — `x-async: true`
  is drop-n-forget with a 202 ack, otherwise RPC up to `x-ttl` ms mirroring the target's
  reply. 404 / 400 / 408, plus a clear 400 for a legacy compact envelope (v1 is
  standard-only). Every response body is itself a serialized envelope.
- **Client (`event_over_http`):** POSTs a serialized envelope to a peer, returns the
  reply (or 202 ack). Trace context propagates via `x-trace-id` + W3C `traceparent`, so
  distributed traces chain across the boundary and across languages.

## Why

This is the payload of the cross-language interop feature the Java session handed off:
with the shared wire format (increment 59) and the private-function boundary
(increment 60) in place, `/api/event` lets a function call a **public** function in
another instance — the only cross-instance coupling, opt-in by design.

Verified end to end with a real HTTP round trip: RPC (status/headers/body + trace
crossing), 403 private, 404, async ack, compact rejection, the service rejecting itself
as a target, and the client half round-tripped against the same server (a local
stand-in for the live pairing). New `event-over-http.md` guide; two now-stale port notes
corrected. Workspace 235 tests green, clippy clean, fmt applied; docs strict-build green.

Next: the live cross-language interop pairing with the Java session (composable-example
:8100 / lambda-example :8085, both directions).

Co-Authored-By: Claude Code <noreply@anthropic.com>