### PR TITLE
Event over HTTP: cross-language interop test drive fixes + declarative routing (increment 62)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,8 +383,10 @@ dependencies = [
  "async-trait",
  "log",
  "platform-core",
+ "rmpv",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/platform-core/src/automation/event_api.rs
+++ b/crates/platform-core/src/automation/event_api.rs
@@ -205,7 +205,13 @@ pub async fn event_over_http(
     let http_event = EventEnvelope::new()
         .set_to(ASYNC_HTTP_REQUEST)
         .set_raw_body(http.to_value());
-    let response = po.request(http_event, timeout).await?;
+    // the local wait gets a small grace over the remote TTL (Java parity:
+    // EventEmitter's inner deadline is timeout + 100ms) so a peer that spends
+    // its whole TTL still replies in-band — its 408 envelope must win the
+    // race against the local abort, never lose it
+    let response = po
+        .request(http_event, timeout + Duration::from_millis(100))
+        .await?;
     // the response body is the serialized reply envelope (octet-stream →
     // binary); anything else is a transport-level failure
     match response.body() {

--- a/crates/platform-core/src/automation/event_api.rs
+++ b/crates/platform-core/src/automation/event_api.rs
@@ -30,6 +30,7 @@
 //! drop-n-forget with a 202 ack; otherwise RPC up to `x-ttl` ms.
 
 use std::collections::HashMap;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -40,14 +41,33 @@ use crate::envelope::EventEnvelope;
 use crate::function::{AppError, ComposableFunction};
 use crate::platform::Platform;
 use crate::post_office::PostOffice;
+use crate::util::app_config_reader::AppConfigReader;
+use crate::util::config_reader::ConfigReader;
+use crate::util::multi_level_map::ConfigValue;
 use crate::util::w3c_trace;
 
 /// Route of the event-over-http service (Java `EventApiService.EVENT_API_SERVICE`).
 pub const EVENT_API_SERVICE: &str = "event.api.service";
 
+/// Envelope header marking an event that already crossed an Event-over-HTTP
+/// hop (Java `EventEmitter.X_EVENT_API`) — the recursion guard: the send and
+/// request hooks never re-forward an event carrying it, so a declaratively
+/// routed event crosses the wire exactly once. Visible to the receiving
+/// function like any other envelope header.
+pub const X_EVENT_API: &str = "x-event-api";
+
 const OCTET_STREAM: &str = "application/octet-stream";
 const X_TTL: &str = "x-ttl";
 const X_ASYNC: &str = "x-async";
+
+/// Application key naming the declarative routing map
+/// (Java `EventEmitter.EVENT_OVER_HTTP_YAML`).
+const EVENT_OVER_HTTP_YAML: &str = "yaml.event.over.http";
+const DEFAULT_EVENT_OVER_HTTP_YAML: &str = "classpath:/event-over-http.yaml";
+
+/// Fixed forward timeout for the send-path (fire-and-forget / callback) hook
+/// (Java `EventEmitter.ASYNC_EVENT_HTTP_TIMEOUT` = 60s).
+const ASYNC_EVENT_HTTP_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// The `/api/event` service (Java `EventApiService`). Registered PRIVATE — it
 /// is reached only through the REST boundary, never as a remote target.
@@ -178,6 +198,30 @@ pub async fn event_over_http(
     timeout: Duration,
     rpc: bool,
 ) -> Result<EventEnvelope, AppError> {
+    static NO_HEADERS: OnceLock<HashMap<String, String>> = OnceLock::new();
+    event_over_http_with_headers(
+        po,
+        endpoint,
+        event,
+        timeout,
+        rpc,
+        NO_HEADERS.get_or_init(HashMap::new),
+    )
+    .await
+}
+
+/// [`event_over_http`] with additional per-call HTTP headers — the carrier of
+/// the per-target security headers (e.g. `authorization`) declared in
+/// `yaml.event.over.http` (Java `EventEmitter.asyncRequest(event, timeout,
+/// headers, endpoint, rpc)`).
+pub async fn event_over_http_with_headers(
+    po: &PostOffice,
+    endpoint: &str,
+    event: EventEnvelope,
+    timeout: Duration,
+    rpc: bool,
+    security_headers: &HashMap<String, String>,
+) -> Result<EventEnvelope, AppError> {
     let (host, path) = split_endpoint(endpoint)?;
     let trace_id = event.trace_id().map(str::to_string);
     let span_id = event.span_id().map(str::to_string);
@@ -191,6 +235,11 @@ pub async fn event_over_http(
         .set_body(Value::Binary(payload));
     if !rpc {
         http = http.set_header(X_ASYNC, "true");
+    }
+    // per-target security headers ride the HTTP call; the framework headers
+    // above stay authoritative on a name clash (first match wins on read)
+    for (key, value) in security_headers {
+        http = http.set_header(key, value);
     }
     // trace propagation (Java sets both headers so the receiver chains onto
     // this span as its parent)
@@ -208,9 +257,11 @@ pub async fn event_over_http(
     // the local wait gets a small grace over the remote TTL (Java parity:
     // EventEmitter's inner deadline is timeout + 100ms) so a peer that spends
     // its whole TTL still replies in-band — its 408 envelope must win the
-    // race against the local abort, never lose it
+    // race against the local abort, never lose it. This internal RPC bypasses
+    // the declarative hook (request_direct) — the HTTP client leg of a
+    // forward must never consult the registry itself.
     let response = po
-        .request(http_event, timeout + Duration::from_millis(100))
+        .request_direct(http_event, timeout + Duration::from_millis(100))
         .await?;
     // the response body is the serialized reply envelope (octet-stream →
     // binary); anything else is a transport-level failure
@@ -236,4 +287,187 @@ fn split_endpoint(endpoint: &str) -> Result<(String, String), AppError> {
         }
         None => Ok((endpoint.to_string(), "/api/event".to_string())),
     }
+}
+
+// ---- declarative Event over HTTP (Java `yaml.event.over.http`) ----
+
+/// One declarative routing entry: the peer's `/api/event` URL plus optional
+/// per-target security headers (Java `EventEmitter.eventHttpTargets` +
+/// `eventHttpHeaders`, folded into one struct).
+#[derive(Debug)]
+pub struct EventHttpTarget {
+    /// The peer endpoint, e.g. `http://127.0.0.1:8085/api/event`.
+    pub target: String,
+    /// HTTP headers added to every forwarded call (e.g. `authorization`).
+    pub headers: HashMap<String, String>,
+}
+
+/// The route → target map, loaded once on first use (Java loads it in the
+/// `EventEmitter` constructor; the Rust port has no such singleton, so the
+/// registry initializes lazily from the same configuration).
+fn event_http_registry() -> &'static HashMap<String, EventHttpTarget> {
+    static REGISTRY: OnceLock<HashMap<String, EventHttpTarget>> = OnceLock::new();
+    REGISTRY.get_or_init(load_event_http_routes)
+}
+
+/// Declarative Event-over-HTTP lookup (Java `EventEmitter.getEventHttpTarget`
+/// and `getEventHttpHeaders`): the configured target for a route, with any
+/// `@instance` suffix stripped for the lookup. `None` = the route is local.
+pub fn get_event_http_target(route: &str) -> Option<&'static EventHttpTarget> {
+    let base = match route.find('@') {
+        Some(at) => &route[..at],
+        None => route,
+    };
+    event_http_registry().get(base)
+}
+
+/// Load the `event.http[]` entries from the file named by
+/// `yaml.event.over.http` (default `classpath:/event-over-http.yaml`).
+/// An absent file simply disables the feature; `${...}` references in the
+/// values (environment variables, base configuration keys) resolve at load
+/// time (Java `EventEmitter.loadHttpRoutes`).
+fn load_event_http_routes() -> HashMap<String, EventHttpTarget> {
+    let mut targets = HashMap::new();
+    let explicit = AppConfigReader::get_instance().get_property(EVENT_OVER_HTTP_YAML);
+    let path = explicit
+        .clone()
+        .unwrap_or_else(|| DEFAULT_EVENT_OVER_HTTP_YAML.to_string());
+    let reader = match ConfigReader::load(&path) {
+        Ok(reader) => reader,
+        Err(e) => {
+            // only an explicitly configured file is worth an error — the
+            // default location is optional by design
+            if explicit.is_some() {
+                log::error!("Unable to load event-over-http config - {e}");
+            }
+            return targets;
+        }
+    };
+    let Some(ConfigValue::List(entries)) = reader.get("event.http") else {
+        log::error!(
+            "Invalid config {path} - the event.http section should be a list of route and target"
+        );
+        return targets;
+    };
+    for i in 0..entries.len() {
+        let route = reader
+            .get_property(&format!("event.http[{i}].route"))
+            .unwrap_or_default();
+        let target = reader
+            .get_property(&format!("event.http[{i}].target"))
+            .unwrap_or_default();
+        if route.is_empty() || target.is_empty() {
+            continue;
+        }
+        if crate::platform::validate_route(&route).is_err() {
+            log::error!("Invalid Event over HTTP config entry - check route {route}");
+            continue;
+        }
+        if split_endpoint(&target).is_err() {
+            log::error!("Invalid Event over HTTP config entry - check target {target}");
+            continue;
+        }
+        let mut headers = HashMap::new();
+        if let Some(ConfigValue::Map(map)) = reader.get(&format!("event.http[{i}].headers")) {
+            for key in map.keys() {
+                if let Some(value) = reader.get_property(&format!("event.http[{i}].headers.{key}"))
+                {
+                    headers.insert(key.clone(), value);
+                }
+            }
+        }
+        log::info!(
+            "Event-over-HTTP {route} -> {target} with {} header{}",
+            headers.len(),
+            if headers.len() == 1 { "" } else { "s" }
+        );
+        targets.insert(route, EventHttpTarget { target, headers });
+    }
+    log::info!(
+        "Total {} event-over-http target{} configured",
+        targets.len(),
+        if targets.len() == 1 { "" } else { "s" }
+    );
+    targets
+}
+
+/// The send-path forward (Java `EventEmitter.sendWithEventHttp`): an event
+/// whose route is declaratively mapped crosses to the peer instead of the
+/// local bus. With a `reply_to` it is a **callback**: the reply address is
+/// withheld from the wire, the forward runs as RPC, and the peer's response
+/// is delivered to the original `reply_to` locally (restoring `from`, trace,
+/// and the business correlation-id). Without one it is **async**: forwarded
+/// drop-n-forget, expecting the peer's 202 ack. Both run detached — like
+/// Java, `send` returns as soon as the forward is scheduled.
+pub(crate) fn send_with_event_http(
+    platform: &Platform,
+    event: EventEnvelope,
+    to: &str,
+    entry: &'static EventHttpTarget,
+) -> Result<(), AppError> {
+    let callback = event.reply_to().map(str::to_string);
+    let event_api_type = if callback.is_some() {
+        "callback"
+    } else {
+        "async"
+    };
+    let trace_id = event.trace_id().map(str::to_string);
+    let trace_path = event.trace_path().map(str::to_string);
+    let cid = event.correlation_id().map(str::to_string);
+    let forward = event
+        .clear_reply_to()
+        .set_header(X_EVENT_API, event_api_type);
+    let platform = platform.clone();
+    let to = to.to_string();
+    tokio::spawn(async move {
+        let po = PostOffice::new(&platform);
+        let outcome = event_over_http_with_headers(
+            &po,
+            &entry.target,
+            forward,
+            ASYNC_EVENT_HTTP_TIMEOUT,
+            callback.is_some(),
+            &entry.headers,
+        )
+        .await;
+        match outcome {
+            Ok(reply) => {
+                if let Some(callback) = callback {
+                    // deliver the peer's response to the original reply_to
+                    // locally, restoring sender, trace, and correlation-id
+                    let mut response = reply.set_to(&callback).clear_reply_to().set_from(&to);
+                    if let (Some(id), Some(path)) = (&trace_id, &trace_path) {
+                        response = response.set_trace(id, path);
+                    }
+                    if let Some(cid) = &cid {
+                        response = response.set_correlation_id(cid);
+                    }
+                    if let Err(e) = po.send(response).await {
+                        log::error!(
+                            "Error in sending callback event {to} from {} to {callback} - {}",
+                            entry.target,
+                            e.message()
+                        );
+                    }
+                } else if reply.status() != 202 {
+                    log::error!(
+                        "Error in sending async event {to} to {} - status={}, error={}",
+                        entry.target,
+                        reply.status(),
+                        reply
+                            .body_as::<String>()
+                            .unwrap_or_else(|_| format!("{}", reply.body()))
+                    );
+                }
+            }
+            Err(e) => {
+                log::error!(
+                    "Error in sending event {to} to {} - {}",
+                    entry.target,
+                    e.message()
+                );
+            }
+        }
+    });
+    Ok(())
 }

--- a/crates/platform-core/src/automation/http_client.rs
+++ b/crates/platform-core/src/automation/http_client.rs
@@ -310,10 +310,14 @@ impl AsyncHttpRequest {
         &self.body
     }
 
+    /// Java `AsyncHttpRequest.getTimeoutSeconds()`: the x-ttl header is in
+    /// milliseconds and a fractional second must round UP, never down
+    /// (1,500 ms is a 2-second budget, not 1) — otherwise the wire-level
+    /// read timeout fires before a peer that spends its whole TTL replies.
     pub fn timeout_seconds(&self) -> u64 {
         self.header("x-ttl")
             .and_then(|v| v.parse::<u64>().ok())
-            .map(|ms| (ms.max(1000)) / 1000)
+            .map(|ms| ms.max(1).div_ceil(1000))
             .unwrap_or(DEFAULT_TTL_SECONDS)
     }
 
@@ -506,8 +510,12 @@ async fn process_request(
     let http_request = builder
         .body(Full::new(Bytes::from(body_bytes)))
         .map_err(|e| AppError::new(400, format!("Invalid HTTP request - {e}")))?;
-    // per-request response timeout (the x-ttl header, default 30s)
-    let ttl = Duration::from_secs(request.timeout_seconds());
+    // per-request response timeout (the x-ttl header, default 30s) with one
+    // extra second of wire-level grace so a peer that spends its whole TTL
+    // and replies AT the deadline is still readable; the caller's own RPC
+    // timeout, not this read timeout, governs the user-visible deadline
+    // (Java parity: AsyncHttpClient responseTimeout = getTimeoutSeconds() + 1)
+    let ttl = Duration::from_secs(request.timeout_seconds() + 1);
     let http_response = tokio::time::timeout(ttl, sender.send_request(http_request))
         .await
         .map_err(|_| AppError::new(408, format!("Timeout for {} ms", ttl.as_millis())))?

--- a/crates/platform-core/src/automation/mod.rs
+++ b/crates/platform-core/src/automation/mod.rs
@@ -8,7 +8,10 @@ pub mod routing;
 pub mod server;
 pub mod ws_server;
 
-pub use event_api::{event_over_http, EventApiService, EVENT_API_SERVICE};
+pub use event_api::{
+    event_over_http, event_over_http_with_headers, get_event_http_target, EventApiService,
+    EventHttpTarget, EVENT_API_SERVICE, X_EVENT_API,
+};
 pub use http_client::{AsyncHttpRequest, ASYNC_HTTP_REQUEST};
 pub use routing::{AssignedRoute, CorsInfo, HeaderInfo, RouteInfo, RoutingTable};
 pub use server::{server_address, start_http_server, MY_CORRELATION_ID};

--- a/crates/platform-core/src/envelope.rs
+++ b/crates/platform-core/src/envelope.rs
@@ -127,6 +127,14 @@ impl EventEnvelope {
         self
     }
 
+    /// Remove the reply-to address (Java `setReplyTo(null)`) — used when an
+    /// event is re-targeted, e.g. the declarative Event-over-HTTP forward
+    /// nulls the local callback route before the envelope crosses the wire.
+    pub fn clear_reply_to(mut self) -> Self {
+        self.reply_to = None;
+        self
+    }
+
     pub fn set_correlation_id(mut self, cid: &str) -> Self {
         self.cid = Some(cid.to_string());
         self

--- a/crates/platform-core/src/platform.rs
+++ b/crates/platform-core/src/platform.rs
@@ -406,8 +406,9 @@ fn dispatch_mailbox_size() -> usize {
 
 /// Validate a route name — port of Java `Utility.validServiceName` plus the
 /// at-least-one-dot rule: lowercase alphanumeric with `.` `-` `_`, no leading/
-/// trailing/consecutive dots.
-fn validate_route(route: &str) -> Result<(), AppError> {
+/// trailing/consecutive dots. Crate-visible so the declarative
+/// Event-over-HTTP config loader applies the same rule (Java parity).
+pub(crate) fn validate_route(route: &str) -> Result<(), AppError> {
     let valid_chars = !route.is_empty()
         && route.bytes().all(|b| {
             b.is_ascii_lowercase() || b.is_ascii_digit() || matches!(b, b'.' | b'-' | b'_')

--- a/crates/platform-core/src/post_office.rs
+++ b/crates/platform-core/src/post_office.rs
@@ -27,6 +27,7 @@
 
 use std::time::Duration;
 
+use crate::automation::event_api;
 use crate::envelope::EventEnvelope;
 use crate::function::AppError;
 use crate::platform::Platform;
@@ -103,11 +104,22 @@ impl PostOffice {
     /// trace automatically: the outbound event carries the current trace
     /// id/path, this function's span id (the receiver's parent span), the
     /// sender route, and the business correlation-id when the event has none.
+    ///
+    /// A route declared in `yaml.event.over.http` forwards transparently to
+    /// the peer's `/api/event` instead of the local bus (Java
+    /// `EventEmitter.send` declarative hook) — user code cannot tell a remote
+    /// route from a local one. The `x-event-api` envelope header marks an
+    /// event that already crossed the wire, so it is never re-forwarded.
     pub async fn send(&self, event: EventEnvelope) -> Result<(), AppError> {
         let event = apply_current_trace(event);
         let Some(route) = event.to().map(str::to_string) else {
             return Err(AppError::new(400, "Missing routing path ('to')"));
         };
+        if event.header(event_api::X_EVENT_API).is_none() {
+            if let Some(entry) = event_api::get_event_http_target(&route) {
+                return event_api::send_with_event_http(&self.platform, event, &route, entry);
+            }
+        }
         self.platform.deliver(&route, event).await
     }
 
@@ -131,7 +143,11 @@ impl PostOffice {
                 .expect("timer registry")
                 .remove(&id_for_task);
             if let Some(route) = event.to().map(str::to_string) {
-                if let Err(e) = platform.deliver(&route, event).await {
+                // deliver through send() so a scheduled event honors the
+                // declarative Event-over-HTTP hook exactly like a direct one
+                // (the timer task has no trace bracket, so the trace context
+                // captured above at schedule time is untouched)
+                if let Err(e) = PostOffice::new(&platform).send(event).await {
                     log::warn!(
                         "Unable to deliver scheduled event to {route} - {}",
                         e.message()
@@ -219,6 +235,11 @@ impl PostOffice {
 
     /// RPC (Java `po.request(event, timeout)`): deliver the event and await the
     /// reply through a temporary inbox. Timeout → status **408**.
+    ///
+    /// A route declared in `yaml.event.over.http` forwards transparently as an
+    /// Event-over-HTTP RPC and returns the peer's reply (Java
+    /// `EventEmitter.asyncRequest`/`eRequest` declarative hook); the
+    /// `x-event-api` recursion guard applies as in [`send`](Self::send).
     pub async fn request(
         &self,
         event: EventEnvelope,
@@ -227,6 +248,32 @@ impl PostOffice {
         // propagate the trace context first, so a business correlation-id
         // riding the current trace wins over a minted one
         let event = apply_current_trace(event);
+        if event.header(event_api::X_EVENT_API).is_none() {
+            if let Some(entry) = event.to().and_then(event_api::get_event_http_target) {
+                let forward = event.set_header(event_api::X_EVENT_API, "request");
+                return event_api::event_over_http_with_headers(
+                    self,
+                    &entry.target,
+                    forward,
+                    timeout,
+                    true,
+                    &entry.headers,
+                )
+                .await;
+            }
+        }
+        self.request_direct(event, timeout).await
+    }
+
+    /// The local inbox-based RPC without the declarative Event-over-HTTP hook
+    /// — used by the framework's own internal calls (notably the HTTP client
+    /// leg of an Event-over-HTTP forward, which must never consult the
+    /// declarative registry itself).
+    pub(crate) async fn request_direct(
+        &self,
+        event: EventEnvelope,
+        timeout: Duration,
+    ) -> Result<EventEnvelope, AppError> {
         // a lightweight one-shot inbox (Java AsyncInbox parity): one map entry,
         // no route registration — the reply bypasses the ServiceQueue machinery
         let (inbox_id, rx) = crate::inbox::open();

--- a/crates/platform-core/tests/event_http_declarative.rs
+++ b/crates/platform-core/tests/event_http_declarative.rs
@@ -1,0 +1,189 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Declarative Event over HTTP (increment 62) — the Rust twin of the Java
+//! `EventHttpTest.configTest` + `declarativeEventOverHttpTest`: routes listed
+//! in `yaml.event.over.http` forward transparently over `/api/event`, so user
+//! code with ZERO http-awareness reaches a remote function and gets its reply.
+//!
+//! Everything runs in ONE test function: the config registry is a
+//! process-wide one-shot load whose `${server.port}` reference must resolve
+//! AFTER the ephemeral test server's port is known — a single function makes
+//! that sequencing deterministic (parallel test functions each boot their own
+//! runtime-bound server, which a shared static registry cannot follow).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use platform_core::automation::http_client::AsyncHttpClientService;
+use platform_core::automation::{self, get_event_http_target, EventApiService};
+use platform_core::{
+    overrides, resources, AppConfigReader, AppError, ComposableFunction, EventEnvelope,
+    FunctionOptions, Platform, PostOffice,
+};
+use rmpv::Value;
+
+/// The remote store (Java EventHttpTest's `event.save.get` fixture): header
+/// `type=save` stores the body and replies "saved"; `type=get` replies with
+/// the stored value. Registered PUBLIC — it is the Event-over-HTTP target.
+struct SaveGet {
+    store: Mutex<Option<Value>>,
+}
+
+#[async_trait]
+impl ComposableFunction for SaveGet {
+    async fn handle_event(
+        &self,
+        headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        match headers.get("type").map(String::as_str) {
+            Some("save") => {
+                *self.store.lock().expect("store") = Some(input.body().clone());
+                EventEnvelope::new().set_body("saved")
+            }
+            Some("get") => {
+                let stored = self
+                    .store
+                    .lock()
+                    .expect("store")
+                    .clone()
+                    .unwrap_or(Value::Nil);
+                Ok(EventEnvelope::new().set_raw_body(stored))
+            }
+            _ => Err(AppError::new(400, "unknown type")),
+        }
+    }
+}
+
+/// The local callback target (Java's `blocking.event.wait`): captures the
+/// body of the event delivered to it.
+struct CaptureCallback {
+    tx: tokio::sync::mpsc::UnboundedSender<Value>,
+}
+
+#[async_trait]
+impl ComposableFunction for CaptureCallback {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let _ = self.tx.send(input.body().clone());
+        Ok(EventEnvelope::new())
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn declarative_event_over_http() {
+    resources::prepend_resource_root("tests/resources");
+    let holding = std::env::temp_dir().join(format!("mercury-eoh-decl-{}", std::process::id()));
+    overrides::set("transient.data.store", &holding.display().to_string());
+    overrides::set("rest.server.port", "0");
+    // a minimal rest.yaml; /api/event arrives via the default-endpoint merge
+    overrides::set("yaml.rest.automation", "classpath:/event-rest.yaml");
+    overrides::set("yaml.event.over.http", "classpath:/event-over-http.yaml");
+    let _ = AppConfigReader::get_instance();
+    let platform = Platform::new();
+    platform
+        .register_private(
+            automation::EVENT_API_SERVICE,
+            Arc::new(EventApiService::new(&platform)),
+            10,
+        )
+        .unwrap();
+    // the PUBLIC remote target of the declarative routes
+    platform
+        .register(
+            "event.save.get",
+            Arc::new(SaveGet {
+                store: Mutex::new(None),
+            }),
+            2,
+        )
+        .unwrap();
+    platform
+        .register_with_options(
+            automation::ASYNC_HTTP_REQUEST,
+            Arc::new(AsyncHttpClientService),
+            10,
+            FunctionOptions {
+                interceptor: true,
+                private: true,
+                ..FunctionOptions::default()
+            },
+        )
+        .unwrap();
+    let addr = automation::start_http_server(&platform).await.unwrap();
+    // the fixture's ${server.port} resolves when the registry first loads —
+    // set the port BEFORE the first declarative lookup below
+    overrides::set("server.port", &addr.port().to_string());
+
+    // ---- config load (Java EventHttpTest.configTest) ----
+    let entry = get_event_http_target("event.http.test").expect("configured route");
+    assert_eq!(
+        entry.target,
+        format!("http://127.0.0.1:{}/api/event", addr.port())
+    );
+    assert_eq!(
+        entry.headers.get("authorization").map(String::as_str),
+        Some("demo")
+    );
+    // an @instance suffix strips for the lookup (Java getEventHttpTarget)
+    assert!(get_event_http_target("event.save.get@2").is_some());
+    assert!(get_event_http_target("no.such.route").is_none());
+
+    // ---- declarative round trip (Java declarativeEventOverHttpTest):
+    // user code below is pure PostOffice — zero http-awareness ----
+    let po = PostOffice::new(&platform);
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    platform
+        .register_private("blocking.event.wait", Arc::new(CaptureCallback { tx }), 1)
+        .unwrap();
+    // send with a reply_to = the callback dance: forwarded over HTTP as RPC,
+    // the peer's response delivered locally to blocking.event.wait
+    po.send(
+        EventEnvelope::new()
+            .set_to("event.save.get")
+            .set_header("type", "save")
+            .set_reply_to("blocking.event.wait")
+            .set_body("hello")
+            .unwrap(),
+    )
+    .await
+    .expect("declarative send");
+    let callback_body = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("callback within 5s")
+        .expect("callback value");
+    assert_eq!(callback_body.as_str(), Some("saved"));
+
+    // request() to the configured route returns the peer's reply directly
+    let response = po
+        .request(
+            EventEnvelope::new()
+                .set_to("event.save.get")
+                .set_header("type", "get"),
+            Duration::from_secs(10),
+        )
+        .await
+        .expect("declarative request");
+    assert_eq!(response.body().as_str(), Some("hello"));
+}

--- a/crates/platform-core/tests/event_over_http.rs
+++ b/crates/platform-core/tests/event_over_http.rs
@@ -34,6 +34,24 @@ use platform_core::{
 };
 use rmpv::Value;
 
+/// A public target that spends more than the caller's TTL before replying —
+/// the remote peer's in-band 408 must reach the caller (see
+/// `remote_timeout_arrives_in_band`).
+struct SleepyEcho;
+
+#[async_trait]
+impl ComposableFunction for SleepyEcho {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        _input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        tokio::time::sleep(Duration::from_millis(3000)).await;
+        EventEnvelope::new().set_body("too late")
+    }
+}
+
 /// A public target: echoes its body and reports the trace id it ran under.
 struct RemoteEcho;
 
@@ -81,6 +99,9 @@ async fn server() -> (u16, Platform) {
         .unwrap();
     platform
         .register_private("v1.secret", Arc::new(RemoteEcho), 1)
+        .unwrap();
+    platform
+        .register("v1.sleepy.echo", Arc::new(SleepyEcho), 2)
         .unwrap();
     // the event-over-http CLIENT posts through async.http.request — the
     // lifecycle registers it normally; this test boots the server directly
@@ -255,6 +276,38 @@ async fn event_over_http_service_and_client() {
     .await
     .expect("client 403 is a normal envelope, not a transport error");
     assert_eq!(client_403.status(), 403);
+}
+
+/// A peer that spends more than the caller's TTL replies with its own in-band
+/// 408 envelope — and the caller must RECEIVE it, not abort locally first.
+/// Guards two deadline bugs (the Rust twin of Java's
+/// `EventHttpTest.remoteTimeoutArrivesInBand`): the wire-level read timeout
+/// must round a fractional-second x-ttl UP with grace
+/// (`AsyncHttpRequest::timeout_seconds` + the response-timeout site), and the
+/// client's local RPC wait must exceed the remote TTL (`event_over_http`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_timeout_arrives_in_band() {
+    let (port, platform) = server().await;
+    let po = PostOffice::new(&platform);
+    let endpoint = format!("http://127.0.0.1:{port}/api/event");
+    let reply = event_over_http(
+        &po,
+        &endpoint,
+        EventEnvelope::new()
+            .set_to("v1.sleepy.echo")
+            .set_body("x")
+            .unwrap(),
+        Duration::from_millis(1500),
+        true,
+    )
+    .await
+    .expect("the remote in-band 408 must arrive as a normal envelope, not a local client error");
+    assert_eq!(reply.status(), 408);
+    let message: String = reply.body_as().unwrap();
+    assert!(
+        message.contains("1500"),
+        "the 408 message should carry the remote ttl: {message}"
+    );
 }
 
 /// The service must not be reachable AS a remote target (it is private) — a

--- a/crates/platform-core/tests/resources/event-over-http.yaml
+++ b/crates/platform-core/tests/resources/event-over-http.yaml
@@ -1,0 +1,12 @@
+# Declarative Event-over-HTTP routing map (Java test fixture parity) —
+# each entry forwards a route to a peer's /api/event endpoint transparently.
+event.http:
+  - route: 'event.http.test'
+    target: 'http://127.0.0.1:${server.port}/api/event'
+    # optional security headers
+    headers:
+      authorization: 'demo'
+  - route: 'event.save.get'
+    target: 'http://127.0.0.1:${server.port}/api/event'
+    headers:
+      authorization: 'demo'

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -78,6 +78,7 @@
 | 59 | Event over HTTP phase 2, increment 1 — standard envelope wire-format conformance: body absent-as-nil default, round_trip field, unset-field omission; Java golden vectors decode + round-trip | 2026-07-21 | — | 233 |
 | 60 | Event over HTTP phase 2, increment 2 — private functions, both Java paths: `#[preload]` private-by-default with `is_private = false` opt-out + `register_private` API + `is_private()` query; engine internals registered private | 2026-07-21 | — | 233 |
 | 61 | Event over HTTP phase 2, increment 3 — /api/event service + client: RPC/async dispatch, 403 private gate, 404/400/408, compact rejection, trace propagation (x-trace-id + traceparent); ships in default rest.yaml | 2026-07-21 | — | 235 |
+| 62 | Declarative Event over HTTP (`yaml.event.over.http`) — route→target map with per-target security headers; transparent PostOffice send/request forwarding (callback dance, x-event-api recursion guard); plus the D2 ttl fix (ceil + wire grace + local-wait grace) | 2026-07-22 | — | 237 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1706,6 +1707,46 @@ client, ported (`automation/event_api.rs`):
   (:8100) / lambda-example (:8085) both directions, RPC + async, 404/403/408 + trace
   continuity (the Java session offered to pair). The interop target must be
   `is_private = false`.
+
+---
+
+## Increment 62 — Declarative Event over HTTP + the D2 timeout fix (2026-07-22)
+
+Zero code at the user-application level for Event over HTTP (the maintainer's ask): the
+Java `yaml.event.over.http` behavior, ported.
+
+- **Config** (`yaml.event.over.http`, default `classpath:/event-over-http.yaml`; absent
+  file = feature off): `event.http[]` entries map a route to a peer's `/api/event` URL
+  plus optional per-target security headers; `${...}` references resolve at load; invalid
+  routes/targets are logged and skipped (Java `EventEmitter.loadHttpRoutes`). The map
+  loads once on first use (Java loads in its `EventEmitter` singleton constructor — this
+  port has no such singleton).
+- **Transparent forwarding** (Java send/asyncRequest/eRequest hooks): a `PostOffice`
+  `request` to a mapped route forwards as an Event-over-HTTP RPC and returns the peer's
+  reply; a `send` with `reply_to` runs the callback dance (reply address withheld from
+  the wire, peer response delivered to it locally with from/trace/cid restored); a plain
+  `send` is drop-n-forget expecting the 202 ack. The `x-event-api` marker header is the
+  recursion guard — a forwarded event is never re-forwarded. `send_later` delivers
+  through `send`, so scheduled events honor the map too. The internal HTTP-client RPC leg
+  uses a new hook-free `request_direct` (defense-in-depth: the forward machinery never
+  consults the registry itself, and the async fn type stays non-recursive).
+- **D2 fix (Eric-authorized, from the live cross-language interop drive):**
+  `AsyncHttpRequest::timeout_seconds()` now rounds a fractional-second x-ttl UP (Java
+  `getTimeoutSeconds` ceiling parity; was floor — a 1500ms ttl became a 1s read timeout),
+  the response-timeout site adds 1s wire-level grace (Java `AsyncHttpClient` parity), and
+  `event_over_http` gives its local wait a 100ms grace over the remote TTL — so a peer
+  spending its whole TTL replies in-band (its 408 envelope wins the race, never loses).
+- **Tests:** `event_http_declarative.rs` (Java `EventHttpTest.configTest` +
+  `declarativeEventOverHttpTest` twins — config load incl. `@instance` stripping, then a
+  real `/api/event` round trip where user code with zero http-awareness saves and reads
+  a value on the "remote" instance, callback + request paths);
+  `remote_timeout_arrives_in_band` in `event_over_http.rs` (Java
+  `EventHttpTest.remoteTimeoutArrivesInBand` twin — sleepy target + short ttl must yield
+  the REMOTE in-band 408, not a local client error). Workspace 237 / clippy 0 / fmt.
+- **Docs:** `event-over-http.md` gains "Event over HTTP by configuration";
+  `configuration-reference.md` adds `yaml.event.over.http` (removed from the absent-keys
+  note). The D2 fix was verified live in the cross-language interop matrix (case 6: the
+  Java peer's in-band 408 now arrives through this port's client).
 
 ---
 

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -24,7 +24,7 @@ files themselves merge in the manifest order described below.
     sync-over-async/Redis, the OpenTelemetry forwarder (`otel.*`), classpath scanning
     (`web.component.scan`, `yaml.preload.override`, `modules.autostart`), threading
     (`kernel.thread.pool`, `deferred.commit.log`), event-script extras
-    (`yaml.event.over.http`, `yaml.journal`, `yaml.multicast`),
+    (`yaml.journal`, `yaml.multicast`),
     HTTP extras (`async.http.temp`, `stack.trace.transport.size`,
     `protect.info.endpoints`), and serialization extras (`snake.case.serialization`,
     `custom.content.types`, `mime.types`). If a key is not on this page, the Rust port
@@ -169,6 +169,22 @@ Connection timeout of the built-in async HTTP client (`async.http.request`). Rea
 `crates/platform-core` (automation). The per-request time-to-live is separate — it travels
 as the `x-ttl` header on the request event (default 30 seconds; see
 [Reserved Names & Headers](reserved-names-and-headers.md)).
+
+#### `yaml.event.over.http`
+
+| Type | Default |
+|---|---|
+| text (config location) | `classpath:/event-over-http.yaml` |
+
+Location of the optional **declarative Event-over-HTTP routing map**. Each `event.http[]`
+entry in the file maps a route name to a peer's `/api/event` endpoint (with optional
+per-target security headers such as `authorization`), and every `PostOffice`
+`send`/`request` to that route is then forwarded over HTTP transparently — user code
+cannot tell a remote route from a local one. An absent file simply disables the feature.
+`${...}` references (environment variables, base configuration keys) resolve inside the
+values. Read by `crates/platform-core` (automation) on first use. See the
+[Event over HTTP guide](event-over-http.md#event-over-http-by-configuration) for the file
+format and forwarding semantics.
 
 ## Tracing and observability
 

--- a/docs/guides/event-over-http.md
+++ b/docs/guides/event-over-http.md
@@ -89,3 +89,59 @@ single distributed trace across the boundary (and across languages).
     (single-character keys) is rejected with a clear 400; Java 4.10+ defaults to standard, so
     this only surfaces with an old or misconfigured peer. The Java engine's per-format response
     mirroring is therefore unnecessary here — replies are always standard.
+
+## Event over HTTP by configuration
+
+Calling the API is rarely necessary: the same forwarding can be **declared**, so that user
+code needs zero HTTP awareness — this service abstraction means an application does not
+know (or care) where its target services run. Name the routing map in your application
+configuration (this is also the default, so a `resources/event-over-http.yaml` file is
+picked up with no configuration at all):
+
+```yaml
+yaml.event.over.http: 'classpath:/event-over-http.yaml'
+```
+
+and list the remote routes in that file:
+
+```yaml
+event.http:
+  - route: 'hello.world'
+    target: 'http://127.0.0.1:8085/api/event'
+  - route: 'event.save.get'
+    target: 'http://127.0.0.1:${server.port}/api/event'
+    # optional security headers
+    headers:
+      authorization: 'demo'
+```
+
+From then on, **every `PostOffice` call to a listed route crosses to the peer
+transparently** — the calling function cannot tell a remote route from a local one:
+
+- `po.request(event, timeout)` forwards as an Event-over-HTTP RPC and returns the peer's
+  reply envelope directly.
+- `po.send(event)` with a `reply_to` runs the **callback dance**: the reply address is
+  withheld from the wire, the forward runs as RPC, and the peer's response is delivered to
+  the original `reply_to` locally — with the sender route, trace context, and business
+  correlation-id restored.
+- `po.send(event)` without a `reply_to` is forwarded **drop-n-forget**, expecting the
+  peer's 202 acknowledgement (a failure is logged, never raised).
+
+The optional per-target `headers` ride on every forwarded HTTP call — the place for an
+`authorization` credential when the peer's `/api/event` endpoint sits behind
+authentication. `${...}` references (environment variables, base configuration keys such
+as `server.port` above) resolve when the file loads. An absent file simply leaves the
+feature off.
+
+A forwarded envelope carries the `x-event-api` marker header, and an event bearing it is
+never forwarded again — the recursion guard that lets two instances declare routes toward
+each other without a loop. The receiving function sees the header like any other envelope
+header.
+
+!!! note "Port note"
+    Same semantics as the Java engine's `yaml.event.over.http`
+    (`EventEmitter.sendWithEventHttp` and the request-path hooks), including the fixed
+    60-second forward timeout on the send path — an RPC made with `po.request` uses the
+    caller's own timeout. The Java engine loads the map at startup inside its
+    `EventEmitter` singleton; this port has no such singleton, so the map loads once on
+    first use — same configuration, same behavior.

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -12,3 +12,5 @@ async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 log = "0.4"
+rmpv = "1"
+tokio = { version = "1", features = ["time"] }

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -52,6 +52,7 @@ use platform_core::{
     before_application, main_application, preload, trace, AppConfigReader, AppError,
     ComposableFunction, EntryPoint, EventEnvelope, Platform, PostOffice, TypedFunction,
 };
+use rmpv::Value;
 use serde::{Deserialize, Serialize};
 
 // ---- the composable function (Java: @PreLoad(route = "greeting.demo", instances = 10)) ----
@@ -142,6 +143,64 @@ impl ComposableFunction for GreetingApi {
             "correlation_id": po.my_correlation_id(),
         }))
     }
+}
+
+// ---- the public echo function (Java lambda-example: hello.world) ----
+
+/// Mirrors the Java lambda-example's `hello.world` echo: replies with the
+/// request body and headers plus the worker instance and this application's
+/// origin id. Declared `is_private = false` — the deliberate opt-out that
+/// publishes the route to remote callers via Event over HTTP
+/// (`POST /api/event`); every other function here keeps the private default.
+///
+/// The body is reflected as the raw MsgPack value, never through a JSON
+/// detour — JSON has no byte type, so converting would silently drop binary
+/// values from the echo (found by the cross-language interop matrix).
+///
+/// An optional integer body key `sleep_ms` delays the reply by that many
+/// milliseconds — the cross-language interop matrix uses it to exercise the
+/// RPC-timeout (408) path (e.g. `sleep_ms: 3000` against `x-ttl: 1500`).
+#[preload(route = "hello.world", instances = 10, is_private = false)]
+struct HelloWorld;
+
+#[async_trait]
+impl ComposableFunction for HelloWorld {
+    async fn handle_event(
+        &self,
+        headers: HashMap<String, String>,
+        input: EventEnvelope,
+        instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let body = input.body().clone();
+        if let Some(ms) = sleep_ms(&body) {
+            log::info!("echo #{instance} sleeping {ms} ms before replying");
+            tokio::time::sleep(Duration::from_millis(ms)).await;
+        }
+        log::info!("echo #{instance} got a request");
+        let echo_headers = Value::Map(
+            headers
+                .iter()
+                .map(|(k, v)| (Value::from(k.as_str()), Value::from(v.as_str())))
+                .collect(),
+        );
+        Ok(EventEnvelope::new().set_raw_body(Value::Map(vec![
+            (Value::from("body"), body),
+            (Value::from("headers"), echo_headers),
+            (Value::from("instance"), Value::from(instance as u64)),
+            (Value::from("origin"), Value::from(Platform::origin())),
+        ])))
+    }
+}
+
+/// The optional integer `sleep_ms` key of a map body.
+fn sleep_ms(body: &Value) -> Option<u64> {
+    let Value::Map(entries) = body else {
+        return None;
+    };
+    entries
+        .iter()
+        .find(|(k, _)| k.as_str() == Some("sleep_ms"))
+        .and_then(|(_, v)| v.as_u64())
 }
 
 // ---- the static-content request filter (increment 8) ----

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-22 | agent: Claude Code (2026-07-22-000658)
+- **last_session:** 2026-07-22 | agent: Claude Code (2026-07-22-025232)
 - **last_review:** 2026-07-21 | through 2026-07-21-214043
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -507,7 +507,47 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   "not ported" notes corrected. Workspace 235/clippy 0/fmt. **ONLY REMAINING: the live
   cross-language interop pairing with the Java session (composable-example :8100 /
   lambda-example :8085, both directions, RPC + async, 404/403/408 + trace continuity;
-  interop target = is_private = false).** Earlier: **Increment 2 (increment 60): private
+  interop target = is_private = false).** **Interop Phase A DONE 2026-07-22** (branch
+  `feature/interop-test-service`, UNCOMMITTED — maintainer review pending): hello-world
+  gains a public `hello.world` echo (`{body, headers, instance, origin}`; optional
+  `sleep_ms` body key delays the reply for the 408 case), app live detached on :8086
+  (`-Drest.server.port=8086`; 8085 reserved for the Java lambda-example), all four
+  dispatch paths smoke-verified over real HTTP with hand-rolled standard envelopes
+  (200 echo + trace context, 408 on ttl, 403 private, 404 unknown). **Phase B DONE
+  2026-07-22** (session 2026-07-22-015354): (1) echo binary bug FIXED — the JSON detour
+  dropped MsgPack-bin bodies (Nil-normalization stripped the key); echo now reflects raw
+  `rmpv::Value` (lesson: relay/echo functions must stay in the MsgPack domain);
+  (2) Rust→Java matrix vs the live Java apps: torture echo (unicode + 9007199254740993 +
+  list + BINARY), async 202 ack, in-band 404/403, and IN-BAND trace-continuity proof
+  (Java ran under the sent trace id) all PASS via the production `event_over_http`
+  client; (3) findings — `hello.world`@8085 was still private on the Java side (their
+  item), and a Rust platform-core bug found:
+  `AsyncHttpRequest::timeout_seconds()` rounded x-ttl DOWN (1500ms→1s read timeout) so a
+  peer's in-band 408 lost to the local abort (Java fixed the same bug class during the
+  drive; their in-band 408 proven at raw protocol level). **D2 fix DONE 2026-07-22
+  (Eric-authorized; session 2026-07-22-023009):** `timeout_seconds()` → ceiling division
+  (Java `getTimeoutSeconds` parity), response-timeout site +1s wire grace (Java
+  `AsyncHttpClient` parity), `event_over_http` local wait +100ms grace over x-ttl (Java
+  EventEmitter parity); regression test `remote_timeout_arrives_in_band` (the Rust twin
+  of Java's `EventHttpTest.remoteTimeoutArrivesInBand`); platform-core 162/0, clippy 0;
+  LIVE case-6 re-run vs the Java sleeper now passes through the production client
+  (in-band 408 "Timeout for 1500 ms" @1.505s). NOTE: the Phase-B task chip for this bug
+  was already started by the user — that spun-off session is redundant now.
+  **Declarative Event over HTTP DONE 2026-07-22 (increment 62, maintainer-requested —
+  "zero code at user app level"; session 2026-07-22-025232):** `yaml.event.over.http`
+  (default classpath:/event-over-http.yaml, absent = off) → route→{target, security
+  headers} registry (lazy OnceLock; `${...}` substitution; @instance stripped);
+  PostOffice send/request hooks forward transparently (request = RPC returning the peer
+  reply; send+reply_to = callback dance restoring from/trace/cid; plain send = async 202;
+  `x-event-api` recursion guard; send_later rides send); new
+  `event_over_http_with_headers`, `EventEnvelope::clear_reply_to`, hook-free
+  `request_direct` for the internal HTTP leg (breaks async type recursion +
+  defense-in-depth). Twin tests of Java EventHttpTest (config + declarative round trip);
+  workspace 237/clippy 0/fmt; docs (guide section + configuration-reference entry +
+  INCREMENTS §62; strict docs build deferred to CI — no mkdocs in env). LIVE
+  cross-language proof: zero-code po.request + callback dance reached the JAVA peer
+  (:8299) through a scratch map. Remaining:
+  Eric's review of the interop branch (platform-core fix + declarative feature). Earlier: **Increment 2 (increment 60): private
   functions, both Java paths** —
   `#[preload]` is PRIVATE BY DEFAULT with `is_private = false` opt-out (mirrors Java
   `@PreLoad isPrivate() default true` — a deliberate posture: engine internals become

--- a/memory/sessions/2026-07-22-011925.md
+++ b/memory/sessions/2026-07-22-011925.md
@@ -1,0 +1,42 @@
+# Session (2026-07-22T01:19:25.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Event over HTTP — live interop pairing, Phase A: the Rust test service is up.**
+Prepared and launched this port's side of the cross-language Event-over-HTTP test
+drive with the Java session (mercury-composable). Branch
+`feature/interop-test-service`; changes left UNCOMMITTED in the working tree for
+the maintainer's review (no platform-core production code touched).
+
+- **`examples/hello-world` gains a public `hello.world` echo** mirroring the Java
+  lambda-example's function of the same route: replies
+  `{body, headers, instance, origin}`; `is_private = false` is the deliberate
+  opt-out publishing it through `/api/event` (every other function keeps the
+  increment-60 private default — a live demonstration of the encapsulation
+  boundary). An optional integer body key `sleep_ms` delays the reply, giving the
+  interop matrix its RPC-timeout lever. New example dep: `tokio` (time feature)
+  for the async sleep.
+- **App running detached** on port **8086** (the documented `-D` runtime override;
+  8085 stays free for the Java lambda-example):
+  `nohup target/release/hello-world -Drest.server.port=8086 > /tmp/rust-hello-world.log 2>&1 &`
+  — PID recorded in the hand-off report. `/api/event` ships via
+  `merge_default_endpoints`, confirmed in the startup log.
+- **Smoke-tested with hand-rolled MsgPack standard envelopes** (no client lib):
+  RPC echo 200 (body + headers + trace context round-trip, exec_time present),
+  `sleep_ms 3000` vs `x-ttl 1500` → 408 in ~1.6s, `sleep_ms 500` within TTL → 200
+  with exec_time ≈ 502ms, private target → 403 `greeting.demo is private`,
+  unknown route → 404. All four dispatch paths verified live over real HTTP.
+
+Phase B (next, on the Java session's signal): fire the Rust→Java direction with
+`event_over_http` against the Java app at `http://127.0.0.1:8085/api/event` and
+run the full matrix both directions (headers/body integrity, status propagation,
+404/403/408, trace continuity).
+
+## Memory References
+
+- referenced: ot-event-over-http (live interop pairing — Phase A done),
+  port-bottom-up-faithful, conventions-rust-baseline
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>

--- a/memory/sessions/2026-07-22-015354.md
+++ b/memory/sessions/2026-07-22-015354.md
@@ -1,0 +1,47 @@
+# Session (2026-07-22T01:53:54.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Event over HTTP — live interop pairing, Phase B: binary echo fix + the Rust→Java
+matrix.** Continues Phase A (2026-07-22-011925) on branch `feature/interop-test-service`
+(still UNCOMMITTED — Eric reviews).
+
+- **Binary echo bug fixed (Java→Rust leg's one failure).** The hello-world `hello.world`
+  echo converted its body through `serde_json::Value` — JSON has no byte type, so a map
+  containing a MsgPack bin failed `body_as`, degraded to Nil, and the increment-58
+  Nil-normalization stripped the `body` key from the reply map entirely. Rewritten to
+  reflect the raw `rmpv::Value` verbatim (no JSON detour); `sleep_ms` now probed via a
+  small rmpv helper. Self-verified: bin + 9007199254740993 + CJK/Greek unicode all echo
+  intact; the 408 sleep path regression-checked. New example dep `rmpv` (Cargo.toml).
+  App restarted on :8086. **Durable lesson: an echo/relay function must stay in the
+  MsgPack value domain — any JSON detour silently loses binary.**
+- **Rust→Java matrix run** (scratch driver in the session scratchpad, never committed;
+  production `event_over_http` client): torture echo (unicode, 9007199254740993, list,
+  BINARY — all intact both ways), async 202 ack, in-band 404, in-band 403
+  (`distributed.tracing is private`), trace continuity proven IN-BAND (the Java function
+  reported it ran under the sent trace id `deadbeefcafe4a11babe123456789042`) — all PASS
+  against `demo.sleeper.echo`@8299.
+- **Findings for the pairing:** (1) `hello.world`@8085 answers 403 "hello.world is
+  private" — the Java lambda-example echo wasn't opted out (`isPrivate=false`); the 403
+  gate itself works perfectly through our client. (2) **Rust client bug (platform-core,
+  NOT fixed here — out of scope):** `AsyncHttpRequest::timeout_seconds()` rounds x-ttl
+  DOWN (1500ms → 1s read timeout), so the local client aborts ("Timeout for 1000 ms" at
+  1.002s) before a peer's in-band 408 arrives — the SAME bug class the Java side fixed
+  during this drive (their getTimeoutSeconds misplaced parenthesis). Java's in-band 408
+  proven at raw protocol level (HTTP 408, envelope status 408, "Timeout for 1500 ms",
+  1.56s). Also: `event_over_http` couples the local RPC wait to the same value as x-ttl —
+  needs a grace margin so remote 408s win deterministically. Follow-up task chip raised
+  for Eric.
+
+Java→Rust leg (run by the Java session against our :8086 app): 6/7 passed before the
+fix; the binary case now passes per our self-test — re-verification on their side welcome.
+
+## Memory References
+
+- referenced: ot-event-over-http (Phase B done; client ttl-rounding fix pending),
+  ot-parity-remediation (F2 Nil-normalization explained the vanishing body key),
+  port-bottom-up-faithful, conventions-rust-baseline
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>

--- a/memory/sessions/2026-07-22-023009.md
+++ b/memory/sessions/2026-07-22-023009.md
@@ -1,0 +1,45 @@
+# Session (2026-07-22T02:30:09.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Event over HTTP — interop drive, Phase C: the D2 timeout fix (Eric-authorized,
+platform-core included).** Continues Phases A/B (2026-07-22-011925 / -015354) on branch
+`feature/interop-test-service` (still UNCOMMITTED — Eric reviews). Mirrors the Java D1
+fix from the same drive.
+
+- **`AsyncHttpRequest::timeout_seconds()`** (`automation/http_client.rs`): floor →
+  **ceiling** division (`ms.max(1).div_ceil(1000)`; Java parity:
+  `getTimeoutSeconds() = Math.max(1, (ms + 999) / 1000)`) — a fractional-second x-ttl
+  rounds UP, never down (1,500 ms is a 2-second budget, not 1).
+- **Response-timeout site** (same file): `timeout_seconds() + 1` — one second of
+  wire-level grace so a peer that spends its whole TTL and replies AT the deadline is
+  still readable (Java parity: `AsyncHttpClient` responseTimeout + 1s); the caller's own
+  RPC timeout governs the user-visible deadline.
+- **`event_over_http`** (`automation/event_api.rs`): the local `po.request` wait now gets
+  `timeout + 100ms` grace over the x-ttl it sends (Java parity: EventEmitter's inner
+  deadline), so a peer's in-band 408 deterministically wins the race against the local
+  abort.
+- **Regression test** `remote_timeout_arrives_in_band` (`tests/event_over_http.rs`; the
+  Rust twin of Java's `EventHttpTest.remoteTimeoutArrivesInBand`): a public
+  `v1.sleepy.echo` (3000ms) through the real `/api/event` round trip with a 1500ms ttl
+  must yield the REMOTE in-band 408 envelope mentioning the ttl — not a local client
+  error. Pre-fix this failed as 500 "Invalid event-over-http response" at 1.0s.
+- **Green:** event_over_http suite 3/3; full platform-core 162 passed / 0 failed;
+  clippy 0 / fmt clean.
+- **LIVE verification:** hello-world rebuilt + restarted on :8086 (new PID); interop
+  case 6 vs the Java sleeper (`demo.sleeper.echo`@8299) now **PASSES through the
+  production client** — in-band 408 "Timeout for 1500 ms" at 1.505s (was: local abort
+  "Timeout for 1000 ms" at 1.002s). Full matrix otherwise unchanged-green; binary echo
+  re-smoked on the new binary.
+- Task chip `task_a32666df` (the flag raised in Phase B for this bug) could NOT be
+  withdrawn — the user already started it; **that spun-off session's work is now
+  redundant** (the fix landed here) — flagged to the coordinator.
+
+## Memory References
+
+- referenced: ot-event-over-http (D2 fix DONE; matrix fully green except Java-side
+  hello.world@8085 privacy item), port-bottom-up-faithful, conventions-rust-baseline
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>

--- a/memory/sessions/2026-07-22-025232.md
+++ b/memory/sessions/2026-07-22-025232.md
@@ -1,0 +1,57 @@
+# Session (2026-07-22T02:52:32.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Increment 62 — declarative Event over HTTP (`yaml.event.over.http`), maintainer-requested**
+("zero code at user app level for event over http"). Continues the interop-drive session
+chain (Phases A/B/C) on branch `feature/interop-test-service` (all UNCOMMITTED — Eric
+reviews). Java `EventEmitter` declarative behavior ported.
+
+- **Config** (`automation/event_api.rs`): `yaml.event.over.http` (default
+  `classpath:/event-over-http.yaml`; absent file = feature off) parses `event.http[]`
+  into a route → `EventHttpTarget {target, headers}` map with `${...}` substitution;
+  route/target validation logs-and-skips (Java loadHttpRoutes parity). Registry is a
+  lazy `OnceLock` (Java loads in the EventEmitter singleton constructor — no such
+  singleton here; parity note in the doc comment). Lookup strips `@instance`.
+- **Transparent forwarding** (`post_office.rs` hooks, Java send/asyncRequest/eRequest):
+  `request()` to a mapped route forwards as Event-over-HTTP RPC (caller's timeout) and
+  returns the peer's reply; `send()` with reply_to = the callback dance (reply address
+  withheld from the wire, forward rpc=true at the fixed 60s Java timeout, peer response
+  delivered locally with from/trace/cid restored); plain `send()` = drop-n-forget
+  expecting the 202 ack (errors logged). Recursion guard = the `x-event-api` marker
+  header, exactly Java's. `send_later` now delivers through `send()` so scheduled events
+  honor the map. New public `event_over_http_with_headers` carries per-target security
+  headers (e.g. authorization); new `EventEnvelope::clear_reply_to`
+  (Java setReplyTo(null)); `platform::validate_route` made pub(crate) for the loader.
+  **Design point:** the internal HTTP-client RPC leg uses a new hook-free
+  `PostOffice::request_direct` — breaks the async-fn type recursion AND guarantees the
+  forward machinery never consults the registry itself (defense-in-depth).
+- **Tests:** new `tests/event_http_declarative.rs` (Java EventHttpTest.configTest +
+  declarativeEventOverHttpTest twins; fixture `tests/resources/event-over-http.yaml`
+  mirrors the Java shape incl. `${server.port}`) — ONE test fn by design: the registry is
+  a process-wide one-shot load whose `${server.port}` must resolve after the ephemeral
+  port is known (comment in the file explains). Workspace 237 / clippy 0 / fmt.
+- **Docs:** `event-over-http.md` + "Event over HTTP by configuration" section (mirrors
+  the Java guide's); `configuration-reference.md` documents `yaml.event.over.http`
+  per-entry style and drops it from the absent-keys note; INCREMENTS.md §62 (also covers
+  the Phase-C D2 fix). mkdocs unavailable in this env — strict docs build deferred to CI.
+- **LIVE cross-language validation** (scratch probe, never committed): with a scratch map
+  `demo.sleeper.echo -> http://127.0.0.1:8299/api/event`, a plain `po.request` (zero
+  http-awareness) returned the JAVA peer's echo, and `po.send`+reply_to delivered the
+  Java response to the local callback — the echoed headers show `x-event-api:
+  request`/`callback` exactly like Java. hello-world rebuilt/restarted on :8086 (new PID)
+  so the live app matches the branch.
+
+Also: at Eric's direction, the branch was committed as three logical units (interop test
+service + D3 echo fix; D2 timeout fix + regression; declarative feature) and pushed to
+origin; PR What/Why text handed to Eric (he opens the PR).
+
+## Memory References
+
+- referenced: ot-event-over-http (declarative feature added to the branch),
+  port-bottom-up-faithful, conventions-rust-baseline (INCREMENTS ledger, parity notes,
+  fmt/clippy gates)
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

Three units from the live bidirectional Event-over-HTTP interop test drive with the Java
engine (mercury-composable), which finished 7/7 both directions:

- **Interop test target (examples/hello-world):** a public `hello.world` echo mirroring the
  Java lambda-example (`{body, headers, instance, origin}`, `is_private = false`, optional
  `sleep_ms` delay for the timeout case) — including the D3 fix the Java→Rust leg found:
  the echo now reflects the raw MsgPack value instead of a serde_json detour, which
  silently dropped binary body values (JSON has no byte type; the Nil-normalization pass
  then stripped the key). Lesson captured in the doc comment: relay/echo functions must
  stay in the MsgPack value domain.
- **D2 timeout fix (platform-core):** `AsyncHttpRequest::timeout_seconds()` floored the
  x-ttl (1500ms → a 1s read timeout — the exact mirror of the Java `getTimeoutSeconds()`
  bug fixed during the same drive); now ceiling division with a 1s minimum, +1s
  wire-level grace at the response-timeout site (Java `AsyncHttpClient` parity), and a
  100ms local-wait grace in `event_over_http` (Java EventEmitter parity) so a peer's
  in-band 408 deterministically wins the race. Regression test
  `remote_timeout_arrives_in_band` (twin of Java's
  `EventHttpTest.remoteTimeoutArrivesInBand`); live re-run of the blocked matrix case now
  receives the Java peer's in-band 408 "Timeout for 1500 ms" at 1.505s.
- **Declarative Event over HTTP (increment 62):** `yaml.event.over.http` (default
  `classpath:/event-over-http.yaml`; absent file = off) maps routes to peer `/api/event`
  endpoints with optional per-target security headers; every PostOffice `send`/`request`
  to a mapped route forwards transparently (request = RPC returning the peer's reply;
  send+reply_to = the callback dance restoring from/trace/cid; plain send = async 202;
  `x-event-api` recursion guard; `send_later` rides `send`). Twin tests of Java's
  `EventHttpTest` config + declarative round trip; docs (guide section,
  configuration-reference entry, INCREMENTS §62). Workspace 237 tests green.

## Why

The interop drive is the closing milestone of the Event-over-HTTP phase-2 thread: proving
the two engines exchange envelopes as one system, both directions, before the wire format
is declared done. Fixing what the drive itself surfaced (D2/D3) keeps that proof honest —
both fixes were validated live against the Java engine, not just in unit tests.

The declarative feature is maintainer-requested ("this is a powerful feature — it is zero
code at user app level for event over http"): it turns Event over HTTP from an API into a
service abstraction, so an application declares *where* a route lives in configuration and
its code never knows the difference — the same posture as the Java engine, config-file
compatible with it, and proven live cross-language (a zero-http-awareness `po.request`
and callback `send` reached the Java peer through the map).

Note for reviewers: the D2 bug was first flagged as a background task chip before the
maintainer authorized fixing it in-session; a session spun off from that chip is now
superseded by commit 230ee55b.

---
Co-Authored-By: Claude Code <noreply@anthropic.com>