### PR TITLE
Java-parity batch pre-4.10: preload route aliases, default-on log context, RPC span-lineage telemetry, Event-over-HTTP demo pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,20 @@ the design rationale in [`docs/design/`](docs/design/).
    with its own `app-log-context.yaml`, or opt out with the new `app.log.context=false`
    key. Applications already providing an `app-log-context.yaml` are unaffected.
    Plain-text logging (`log.format=text`, the default) is unaffected.
-3. **RPC telemetry records** — the caller now emits the `round_trip` trace record for
-   each traced RPC response (Java `InboxBase.recordTrace` parity), complete with span
-   lineage: `span_id` (the callee's span) and `parent_span_id` (the caller's span), so
-   trace visualizers can chain RPC round-trips into the span tree — including across
-   Event-over-HTTP hops. The RPC reply envelope itself now carries the measured
-   `round_trip` value.
+3. **RPC telemetry records — exactly one record per span.** The caller now emits the
+   `round_trip` trace record for each traced RPC response (Java `InboxBase.recordTrace`
+   parity) while the worker suppresses its own record for an RPC-served execution whose
+   reply reached the caller (Java `WorkerHandler.sendTracingInfo` gate) — so each span
+   reports once, with full lineage: `parent_span_id` (the caller's span, unconditional)
+   and `span_id` (the callee's span, adopted only from a **direct responder**; a relayed
+   reply — e.g. a flow answering on behalf of the flow-adapter route — keeps the parent
+   but omits the span, Java `spanIdFromResponder` parity). Callback-style invocations
+   keep self-recording. The callee's trace annotations now ride the reply envelope (also
+   on the Event-over-HTTP wire) and fold into the span's single record; the RPC reply
+   itself carries the measured `round_trip` value. The programmatic `event_over_http`
+   client stamps the calling function's trace context (incl. its span) onto the wire
+   envelope, so remote functions parent onto the caller's span in both the declarative
+   and the programmatic pattern.
 4. **Event-over-HTTP demo endpoints in `hello-flow`** (the structural parallel of the
    Java composable-example, now on port **8100**): `/api/event/http/demo` (declarative —
    the flow's task is the foreign route `hello.declarative`, resolved through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,43 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
+## Unreleased
+
+### Added
+
+1. **Comma-separated route aliases in `#[preload]`** — Java `@PreLoad` parity:
+   `route = "hello.world, hello.declarative"` registers the same function object under
+   every listed name with the same instance count and visibility. Empty segments are a
+   compile error.
+2. **Application log context is now on by default.** platform-core ships a built-in
+   `default-log-context.yaml` (embedded at compile time) so the structured JSON formats
+   (`log.format=json` or `compact`) stamp the standard trace context (`cid`, `traceId`,
+   `tracePath`, `spanId`, `parentSpanId`, `service`, `timestamp`) into every log line a
+   traced function emits — no setup required. An application can replace the template
+   with its own `app-log-context.yaml`, or opt out with the new `app.log.context=false`
+   key. Applications already providing an `app-log-context.yaml` are unaffected.
+   Plain-text logging (`log.format=text`, the default) is unaffected.
+3. **RPC telemetry records** — the caller now emits the `round_trip` trace record for
+   each traced RPC response (Java `InboxBase.recordTrace` parity), complete with span
+   lineage: `span_id` (the callee's span) and `parent_span_id` (the caller's span), so
+   trace visualizers can chain RPC round-trips into the span tree — including across
+   Event-over-HTTP hops. The RPC reply envelope itself now carries the measured
+   `round_trip` value.
+4. **Event-over-HTTP demo endpoints in `hello-flow`** (the structural parallel of the
+   Java composable-example, now on port **8100**): `/api/event/http/demo` (declarative —
+   the flow's task is the foreign route `hello.declarative`, resolved through
+   `event-over-http.yaml`) and `/api/event/http/programmatic` (the task passes the peer's
+   `/api/event` URL directly to the request API). The `hello-world` echo registers the
+   `hello.declarative` alias and is interchangeable with the Java lambda-example — same
+   port 8085, same routes — so the demo doubles as a cross-language interop demo with
+   zero configuration changes.
+
+### Fixed
+
+1. **A zero-traced hop no longer leaks a nested reply's span id** as its own on the
+   response envelope (Java parity: its reply carries no span).
+
+---
 ## Version 4.9.0, 7/20/2026
 
 **Graduation release — and the adoption of the canonical version line.** The version jumps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,9 @@ dependencies = [
  "event-script",
  "log",
  "platform-core",
+ "rmpv",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Rust (stable) + Cargo. Run any example:
 
 ```bash
 cargo run -p hello-world           # layer 1 — event bus + HTTP
-cargo run -p hello-flow            # layer 2 — a YAML flow over HTTP (port 8086)
+cargo run -p hello-flow            # layer 2 — a YAML flow over HTTP (port 8100)
 cargo run -p minigraph-playground  # layer 3 — the Playground; open http://127.0.0.1:8100/
 ```
 

--- a/crates/platform-core/resources/default-log-context.yaml
+++ b/crates/platform-core/resources/default-log-context.yaml
@@ -1,0 +1,18 @@
+#
+# Built-in default application log context.
+#
+# The log-context feature is ON by default using this template. It applies to the
+# structured JSON log formats (log.format=json or compact).
+#
+# To customize the context block, provide your own app-log-context.yaml in the
+# application's resources/ folder - it replaces this default entirely.
+# To turn the feature off, set app.log.context=false in the application configuration.
+#
+context:
+  cid: $cid
+  traceId: $traceId
+  tracePath: $tracePath
+  spanId: $spanId
+  parentSpanId: $parentSpanId
+  service: $service
+  timestamp: $utc

--- a/crates/platform-core/src/app_starter.rs
+++ b/crates/platform-core/src/app_starter.rs
@@ -401,16 +401,23 @@ impl AutoStart {
                 .and_then(|key| config.get_property(key))
                 .and_then(|value| value.parse::<usize>().ok())
                 .unwrap_or(entry.instances);
-            starter = starter.preload_with_options(
-                entry.route,
-                (entry.factory)(),
-                instances,
-                FunctionOptions {
-                    zero_traced: entry.zero_tracing,
-                    interceptor: entry.interceptor,
-                    private: entry.is_private,
-                },
-            );
+            // a comma-separated route value declares ALIASES: every name
+            // registers the SAME function object with the same instance
+            // count and visibility (Java AppStarter splits @PreLoad.route
+            // and registers one instance for all names)
+            let function = (entry.factory)();
+            for route in entry.route.split(',').map(str::trim) {
+                starter = starter.preload_with_options(
+                    route,
+                    function.clone(),
+                    instances,
+                    FunctionOptions {
+                        zero_traced: entry.zero_tracing,
+                        interceptor: entry.interceptor,
+                        private: entry.is_private,
+                    },
+                );
+            }
         }
         for entry in inventory::iter::<crate::registry::MainAppEntry> {
             // Java @OptionalService: skip a conditionally-run main application

--- a/crates/platform-core/src/automation/event_api.rs
+++ b/crates/platform-core/src/automation/event_api.rs
@@ -223,6 +223,14 @@ pub async fn event_over_http_with_headers(
     security_headers: &HashMap<String, String>,
 ) -> Result<EventEnvelope, AppError> {
     let (host, path) = split_endpoint(endpoint)?;
+    // stamp the calling function's trace context onto the WIRE envelope
+    // (fill-if-absent trace id/path; the caller's span unconditionally) —
+    // Java parity: the trace-aware po.request(..., endpoint, rpc) touches the
+    // event before serialization, so the remote function parents onto the
+    // caller's span. The declarative hook already applied this in request();
+    // a second application is idempotent. A PROGRAMMATIC caller passing a
+    // fresh envelope gets the same lineage automatically.
+    let event = crate::post_office::apply_current_trace(event);
     let trace_id = event.trace_id().map(str::to_string);
     let span_id = event.span_id().map(str::to_string);
     let payload = event.to_bytes()?;

--- a/crates/platform-core/src/envelope.rs
+++ b/crates/platform-core/src/envelope.rs
@@ -42,8 +42,8 @@ use crate::function::AppError;
 /// `docs/guides/event-envelope-wire-format.md` in the Java repo; golden
 /// vectors under `tests/resources/envelope-vectors/`). Encoders emit `id` and
 /// `headers` always and other fields only when set; decoders treat absent and
-/// nil identically and ignore unknown keys (Java may add `tags`,
-/// `annotations`, `stack`, `obj_type`, `exception`).
+/// nil identically and ignore unknown keys (Java may add `tags`, `stack`,
+/// `obj_type`, `exception`).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EventEnvelope {
     id: String,
@@ -75,6 +75,14 @@ pub struct EventEnvelope {
     /// format; stamped by callers that measure it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     round_trip: Option<f32>,
+    /// Trace annotations riding a REPLY envelope (Java `annotations`): a
+    /// worker attaches the function's `annotate_trace` key-values to its
+    /// response, and the RPC caller folds them into the `round_trip` trace
+    /// record (then strips them — user code never sees them). Same key on the
+    /// wire as the Java standard format, so annotations survive an
+    /// Event-over-HTTP hop in either language direction.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    annotations: HashMap<String, rmpv::Value>,
 }
 
 fn nil_value() -> rmpv::Value {
@@ -101,6 +109,7 @@ impl Default for EventEnvelope {
             body: rmpv::Value::Nil,
             exec_time: None,
             round_trip: None,
+            annotations: HashMap::new(),
         }
     }
 }
@@ -269,6 +278,18 @@ impl EventEnvelope {
         self
     }
 
+    /// Trace annotations riding this (reply) envelope (Java `getAnnotations`).
+    pub fn annotations(&self) -> &HashMap<String, rmpv::Value> {
+        &self.annotations
+    }
+
+    /// Remove all annotations (Java `clearAnnotations`) — the RPC caller
+    /// strips them after folding them into the trace record.
+    pub fn clear_annotations(mut self) -> Self {
+        self.annotations.clear();
+        self
+    }
+
     // ---- crate-internal mutators (worker bookkeeping) ----
 
     pub(crate) fn set_body_internal(&mut self, body: rmpv::Value) {
@@ -302,6 +323,14 @@ impl EventEnvelope {
 
     pub(crate) fn clear_span_id_internal(&mut self) {
         self.span_id = None;
+    }
+
+    pub(crate) fn set_annotations_internal(&mut self, annotations: HashMap<String, rmpv::Value>) {
+        self.annotations = annotations;
+    }
+
+    pub(crate) fn clear_annotations_internal(&mut self) {
+        self.annotations.clear();
     }
 
     // ---- wire format ----

--- a/crates/platform-core/src/envelope.rs
+++ b/crates/platform-core/src/envelope.rs
@@ -300,6 +300,10 @@ impl EventEnvelope {
         self.span_id = Some(span_id.to_string());
     }
 
+    pub(crate) fn clear_span_id_internal(&mut self) {
+        self.span_id = None;
+    }
+
     // ---- wire format ----
 
     /// Encode the envelope as MsgPack bytes (idiomatic serde — design D4).

--- a/crates/platform-core/src/inbox.rs
+++ b/crates/platform-core/src/inbox.rs
@@ -68,14 +68,19 @@ pub(crate) fn open() -> (String, oneshot::Receiver<EventEnvelope>) {
 }
 
 /// Deliver a reply to an inbox. A missing entry (caller timed out and closed
-/// the inbox) drops the reply silently — the correct outcome.
-pub(crate) fn deliver(id: &str, reply: EventEnvelope) {
+/// the inbox) drops the reply silently — the correct outcome. Returns whether
+/// the reply actually reached a waiting caller — the Java
+/// `ProcessStatus.isNotDelivered` signal, which reopens the worker-side
+/// telemetry record for an RPC-served execution (otherwise the caller's
+/// `round_trip` record is THE record for the span and the worker stays quiet).
+pub(crate) fn deliver(id: &str, reply: EventEnvelope) -> bool {
     let sender = registry()
         .lock()
         .expect("inbox registry poisoned")
         .remove(id);
-    if let Some(sender) = sender {
-        let _ = sender.send(reply);
+    match sender {
+        Some(sender) => sender.send(reply).is_ok(),
+        None => false,
     }
 }
 

--- a/crates/platform-core/src/logging.rs
+++ b/crates/platform-core/src/logging.rs
@@ -19,11 +19,14 @@
 //! (`org.platformlambda.core.logging`).
 //!
 //! Spans tell you the causal path; application logs tell you what happened
-//! inside each step. When the optional **`app-log-context.yaml`** is present
-//! on the resource path, every structured (JSON) log line emitted inside a
-//! traced function carries a `context` block — correlation id, trace/span
-//! ids, service name, and any business key-values added via
-//! `PostOffice::update_context` — so logs and spans join up in the backend.
+//! inside each step. The log-context feature is **on by default**: the crate
+//! ships a built-in `default-log-context.yaml` (embedded at compile time)
+//! carrying the standard trace context, so every structured (JSON) log line
+//! emitted inside a traced function carries a `context` block — correlation
+//! id, trace/span ids, service name, and any business key-values added via
+//! `PostOffice::update_context` — with zero setup. An application replaces
+//! the template with its own **`app-log-context.yaml`** on the resource path,
+//! or opts out entirely with `app.log.context=false` (default `true`).
 //!
 //! The template maps an output key (your choice) to one of three forms:
 //! a reserved **`$token`** (`$cid`, `$traceId`, `$tracePath`, `$spanId`,
@@ -49,9 +52,18 @@ use crate::util::app_config_reader::AppConfigReader;
 use crate::util::config_reader::{ConfigError, ConfigReader};
 
 const CONFIG_FILE: &str = "classpath:/app-log-context.yaml";
+/// The built-in default template (Java `default-log-context.yaml`), shipped
+/// under a DISTINCT file name from the application override. Java keeps the
+/// two names apart because same-named classpath resources shadow in
+/// classloader order; this port embeds the default at compile time — the
+/// same defensive design, enforced by the compiler.
+const DEFAULT_TEMPLATE: &str = include_str!("../resources/default-log-context.yaml");
+/// Feature switch (Java `app.log.context`), default `true`.
+const FEATURE_FLAG: &str = "app.log.context";
 const CONTEXT: &str = "context";
 
-/// Parsed `app-log-context.yaml` template (Java `LogContextConfig`).
+/// Parsed log-context template (Java `LogContextConfig`) — the application's
+/// `app-log-context.yaml` when present, otherwise the built-in default.
 pub struct LogContextConfig {
     enabled: bool,
     /// output key → reserved token name (without the `$`), resolved per line
@@ -66,21 +78,36 @@ impl LogContextConfig {
     /// (Java parity).
     pub fn instance() -> &'static LogContextConfig {
         static INSTANCE: OnceLock<LogContextConfig> = OnceLock::new();
-        INSTANCE.get_or_init(|| {
-            let _ = AppConfigReader::get_instance();
-            match ConfigReader::load(CONFIG_FILE) {
-                Ok(reader) => LogContextConfig::from_reader(&reader),
-                Err(ConfigError::NotFound(_)) => {
-                    // optional config file absent — feature stays off
-                    log::debug!("Optional {CONFIG_FILE} not found - log context feature disabled");
-                    LogContextConfig::disabled()
-                }
-                Err(e) => {
-                    log::error!("Unable to load {CONFIG_FILE} - {e}");
-                    LogContextConfig::disabled()
+        INSTANCE.get_or_init(Self::load_config_file)
+    }
+
+    /// Resolve the template with the Java `LogContextConfig.loadConfigFile`
+    /// order: the `app.log.context` switch (default on) → the application's
+    /// own `app-log-context.yaml` (replaces the template entirely) → the
+    /// built-in default, so the feature is on out of the box.
+    fn load_config_file() -> LogContextConfig {
+        let config = AppConfigReader::get_instance();
+        if config.get_property_or(FEATURE_FLAG, "true") == "false" {
+            log::info!("Application log context disabled by {FEATURE_FLAG}=false");
+            return LogContextConfig::disabled();
+        }
+        match ConfigReader::load(CONFIG_FILE) {
+            Ok(reader) => LogContextConfig::from_reader(&reader),
+            Err(ConfigError::NotFound(_)) => {
+                // no application override — fall back to the built-in default
+                match ConfigReader::from_yaml_text(DEFAULT_TEMPLATE) {
+                    Ok(reader) => LogContextConfig::from_reader(&reader),
+                    Err(e) => {
+                        log::warn!("Built-in default-log-context.yaml invalid - {e}");
+                        LogContextConfig::disabled()
+                    }
                 }
             }
-        })
+            Err(e) => {
+                log::error!("Unable to load {CONFIG_FILE} - {e}");
+                LogContextConfig::disabled()
+            }
+        }
     }
 
     fn disabled() -> Self {
@@ -339,5 +366,61 @@ mod tests {
         assert!(matches!(LogFormat::resolve("compact"), LogFormat::Compact));
         assert!(matches!(LogFormat::resolve("text"), LogFormat::Text));
         assert!(matches!(LogFormat::resolve("unknown"), LogFormat::Text)); // safe default
+    }
+
+    /// One sequential test for the three `load_config_file` outcomes — the
+    /// resolution reads process-global state (overrides, resource roots), so
+    /// the cases must not run as parallel tests.
+    #[test]
+    fn log_context_is_on_by_default_overridable_and_can_opt_out() {
+        // 1. DEFAULT-ON: no app-log-context.yaml on the resource path (this
+        // crate's own resources/ has none) → the built-in default template
+        // enables the feature with the standard trace-context keys
+        let config = LogContextConfig::load_config_file();
+        assert!(config.is_enabled(), "log context must be ON by default");
+        let token_keys: Vec<&str> = config.tokens.iter().map(|(k, _)| k.as_str()).collect();
+        for expected in [
+            "cid",
+            "traceId",
+            "tracePath",
+            "spanId",
+            "parentSpanId",
+            "service",
+            "timestamp",
+        ] {
+            assert!(
+                token_keys.contains(&expected),
+                "built-in template must carry '{expected}'"
+            );
+        }
+        assert!(
+            config.constants.is_empty(),
+            "built-in default has no constants"
+        );
+
+        // 2. OPT-OUT: app.log.context=false disables the feature entirely
+        crate::util::overrides::set(FEATURE_FLAG, "false");
+        let config = LogContextConfig::load_config_file();
+        crate::util::overrides::clear(FEATURE_FLAG);
+        assert!(!config.is_enabled(), "app.log.context=false must opt out");
+
+        // 3. APP FILE OVERRIDES: an app-log-context.yaml on the resource path
+        // REPLACES the built-in template entirely (no merge)
+        let dir = std::env::temp_dir().join(format!("pc-logctx-default-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("app-log-context.yaml"),
+            "context:\n  onlyKey: $service\n",
+        )
+        .unwrap();
+        crate::util::resources::prepend_resource_root(&dir);
+        let config = LogContextConfig::load_config_file();
+        assert!(config.is_enabled());
+        assert_eq!(
+            config.tokens,
+            vec![("onlyKey".to_string(), "service".to_string())],
+            "the application template must replace the built-in default entirely"
+        );
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/platform-core/src/platform.rs
+++ b/crates/platform-core/src/platform.rs
@@ -614,8 +614,12 @@ async fn worker_loop(
                 normalize_null_transport(&mut response);
                 if let Some((trace_id, trace_path, span_id)) = trace_triple {
                     response.set_trace_internal(&trace_id, &trace_path);
-                    if let Some(span_id) = span_id {
-                        response.set_span_id_internal(&span_id);
+                    match span_id {
+                        Some(span_id) => response.set_span_id_internal(&span_id),
+                        // a zero-traced hop owns no span — and must not leak
+                        // a nested reply's span as its own (Java rebuilds the
+                        // response envelope, so its reply never carries one)
+                        None => response.clear_span_id_internal(),
                     }
                 }
                 // a lightweight RPC inbox (Java AsyncInbox parity) bypasses the
@@ -660,6 +664,14 @@ fn is_zero_traced(route: &str) -> bool {
     if crate::telemetry::ZERO_TRACING_FILTER.contains(&route) || route.starts_with("inbox.") {
         return true;
     }
+    in_skip_rpc_tracing_list(route)
+}
+
+/// Whether a route is listed in `skip.rpc.tracing` (default
+/// `async.http.request`) — shared by the worker's zero-trace resolution above
+/// and the caller-side RPC `round_trip` record (Java `InboxBase.getSkipTracing`
+/// reads the same key).
+pub(crate) fn in_skip_rpc_tracing_list(route: &str) -> bool {
     AppConfigReader::get_instance()
         .get_property_or("skip.rpc.tracing", "async.http.request")
         .split([',', ' '])

--- a/crates/platform-core/src/platform.rs
+++ b/crates/platform-core/src/platform.rs
@@ -542,10 +542,20 @@ async fn worker_loop(
             break;
         };
         let started = Instant::now();
+        let mut event = event;
+        // annotations belong to REPLY envelopes only — never leak a prior
+        // hop's annotations into a function's input (Java WorkerHandler
+        // clears them on every non-inbox delivery)
+        event.clear_annotations_internal();
         let headers = event.headers().clone();
         let reply_to = event.reply_to().map(str::to_string);
         let cid = event.correlation_id().map(str::to_string);
         let event_from = event.from().map(str::to_string);
+        // the RPC marker (Java `event.getTag(RPC)`): in this port an RPC
+        // reply address is always a lightweight inbox id
+        let served_rpc = reply_to
+            .as_deref()
+            .is_some_and(|r| r.starts_with(crate::inbox::INBOX_PREFIX));
         // trace bracket (Java WorkerHandler): a traced request carries trace id
         // + path; this execution gets its own span, parented to the sender's
         // span carried on the envelope. A ZERO-TRACED route still keeps the
@@ -588,11 +598,32 @@ async fn worker_loop(
                 (!s.zero_traced).then(|| s.span_id.clone()),
             )
         });
-        // send the performance-metrics dataset to the telemetry sink — never
-        // for a zero-traced route (Java: sendTracingInfo is gated on tracing)
-        if let Some(state) = finished_state.filter(|s| !s.zero_traced) {
-            emit_telemetry(&registry, &route, event_from, &state, &result, elapsed_ms).await;
-        }
+        // trace annotations ride the REPLY (Java applyTraceContext): the RPC
+        // caller folds them into the round_trip record; a zero-traced hop
+        // attaches none (Java has no live TraceInfo there)
+        let reply_annotations: HashMap<String, rmpv::Value> = finished_state
+            .as_ref()
+            .filter(|s| !s.zero_traced)
+            .map(|s| {
+                s.annotations
+                    .iter()
+                    .filter_map(|(k, v)| {
+                        rmpv::ext::to_value(v).ok().map(|value| (k.clone(), value))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        // pre-compute the outcome for the telemetry record — the result is
+        // consumed by the reply delivery below (Java reads it from
+        // ProcessStatus after processEvent has already sent the response)
+        let outcome = match &result {
+            Ok(response) => (response.status(), !response.has_error(), None),
+            Err(e) => (e.status(), false, Some(e.message().to_string())),
+        };
+        // whether an RPC reply failed to reach its waiting caller (the Java
+        // ProcessStatus.isNotDelivered signal); an interceptor's success path
+        // attempts no delivery and is NOT a delivery failure (Java parity)
+        let mut not_delivered = false;
         match (reply_to, result) {
             // an event interceptor replies MANUALLY (Java @EventInterceptor):
             // its successful return value is ignored and no auto-reply is sent
@@ -610,6 +641,7 @@ async fn worker_loop(
                 response.set_from_internal(&route);
                 response.set_to_internal(&reply_route);
                 response.set_exec_time_internal(elapsed_ms);
+                response.set_annotations_internal(reply_annotations.clone());
                 // the reply is a bus hop too — same deterministic null strip
                 normalize_null_transport(&mut response);
                 if let Some((trace_id, trace_path, span_id)) = trace_triple {
@@ -625,7 +657,7 @@ async fn worker_loop(
                 // a lightweight RPC inbox (Java AsyncInbox parity) bypasses the
                 // route machinery entirely — complete the caller's oneshot
                 if reply_route.starts_with(crate::inbox::INBOX_PREFIX) {
-                    crate::inbox::deliver(&reply_route, response);
+                    not_delivered = !crate::inbox::deliver(&reply_route, response);
                 } else if let Some(function) = reserved_route_function(&registry, &reply_route) {
                     // replies to the reserved engine routes (task callbacks)
                     // take the same direct path as sends
@@ -652,6 +684,16 @@ async fn worker_loop(
                 );
             }
             (None, Ok(_)) => {} // fire-and-forget success: result discarded
+        }
+        // send the performance-metrics dataset to the telemetry sink — never
+        // for a zero-traced route, and never for an RPC-served execution whose
+        // reply reached the caller: the caller's round_trip record is THE
+        // record for this span (Java WorkerHandler.sendTracingInfo gate:
+        // `journaled || rpc == null || notDelivered`; journaling not ported)
+        if let Some(state) = finished_state.filter(|s| !s.zero_traced) {
+            if !served_rpc || not_delivered {
+                emit_telemetry(&registry, &route, event_from, &state, outcome, elapsed_ms).await;
+            }
         }
     }
 }
@@ -688,7 +730,7 @@ async fn emit_telemetry(
     route: &str,
     from: Option<String>,
     state: &TraceState,
-    result: &Result<EventEnvelope, AppError>,
+    outcome: (i32, bool, Option<String>),
     elapsed_ms: f32,
 ) {
     let sender = registry
@@ -699,10 +741,7 @@ async fn emit_telemetry(
     let Some(sender) = sender else {
         return; // no telemetry sink on this platform
     };
-    let (status, success, exception) = match result {
-        Ok(response) => (response.status(), !response.has_error(), None),
-        Err(e) => (e.status(), false, Some(e.message().to_string())),
-    };
+    let (status, success, exception) = outcome;
     let mut metrics = serde_json::Map::new();
     let mut put = |k: &str, v: serde_json::Value| {
         metrics.insert(k.to_string(), v);

--- a/crates/platform-core/src/post_office.rs
+++ b/crates/platform-core/src/post_office.rs
@@ -282,6 +282,11 @@ impl PostOffice {
             .correlation_id()
             .map(str::to_string)
             .unwrap_or_else(|| uuid::Uuid::new_v4().simple().to_string());
+        // capture the RPC trace identity before the send consumes the event
+        // (Java AsyncInbox constructor: to, from, traceId, tracePath, and the
+        // caller's span riding the outbound request — the callee's parent)
+        let rpc_trace = RpcTraceCapture::of(&event);
+        let begin = std::time::Instant::now();
         let event = event.set_reply_to(&inbox_id).set_correlation_id(&cid);
         if let Err(e) = self.send(event).await {
             crate::inbox::close(&inbox_id);
@@ -289,7 +294,16 @@ impl PostOffice {
         }
         let outcome = tokio::time::timeout(timeout, rx).await;
         match outcome {
-            Ok(Ok(response)) => Ok(response),
+            Ok(Ok(response)) => {
+                // the requester measures the full request/response cycle
+                // (Java AsyncInbox.saveResponse: reply.setRoundTrip(diff)),
+                // standardized to 3 decimal points like exec_time
+                let diff = begin.elapsed().as_secs_f32() * 1000.0;
+                let diff = (diff.max(0.0) * 1000.0).round() / 1000.0;
+                let response = response.set_round_trip(diff);
+                self.record_rpc_trace(&rpc_trace, &response);
+                Ok(response)
+            }
             Ok(Err(_)) => Err(AppError::new(500, "Reply channel closed unexpectedly")),
             Err(_) => {
                 crate::inbox::close(&inbox_id);
@@ -299,5 +313,150 @@ impl PostOffice {
                 ))
             }
         }
+    }
+
+    /// Emit the caller-side RPC trace record — the dataset carrying
+    /// `round_trip` — to the `distributed.tracing` sink (Java
+    /// `InboxBase.recordTrace`, invoked from `AsyncInbox.saveResponse`).
+    ///
+    /// Emitted only for a **traced** RPC (the outbound event carried a trace
+    /// id and path) whose target service is not in `skip.rpc.tracing`, and
+    /// never from inside a zero-traced bracket (a zero-traced hop emits no
+    /// telemetry; in Java its outbound events carry no trace, so no record).
+    /// Span lineage mirrors the Java fix (commit `04e5618f`): `span_id` = the
+    /// callee's own span carried on the RPC reply; `parent_span_id` = the
+    /// caller's span captured from the outbound request — so the round-trip
+    /// record chains into the span tree like any worker-emitted record.
+    ///
+    /// Parity note: Java moves the reply envelope's `annotations` into this
+    /// record. In this port annotations never ride the reply — they flow with
+    /// the callee's own worker-emitted record — so the field is absent here.
+    fn record_rpc_trace(&self, rpc: &RpcTraceCapture, reply: &EventEnvelope) {
+        let (Some(to), Some(trace_id), Some(trace_path)) =
+            (&rpc.to, &rpc.trace_id, &rpc.trace_path)
+        else {
+            return; // not a traced RPC
+        };
+        // a zero-traced hop must not emit telemetry (its trace context flows
+        // for continuity only — see the worker's trace bracket)
+        if trace::with_current(|state| state.zero_traced).unwrap_or(false) {
+            return;
+        }
+        let service = trim_origin(to).to_string();
+        if crate::platform::in_skip_rpc_tracing_list(&service) {
+            return;
+        }
+        if !self
+            .platform
+            .has_route(crate::telemetry::DISTRIBUTED_TRACING)
+        {
+            return; // no telemetry sink on this platform
+        }
+        let mut metrics = serde_json::Map::new();
+        let mut put = |k: &str, v: serde_json::Value| {
+            metrics.insert(k.to_string(), v);
+        };
+        put(
+            "origin",
+            serde_json::Value::String(Platform::origin().to_string()),
+        );
+        put("id", serde_json::Value::String(trace_id.clone()));
+        put("service", serde_json::Value::String(service));
+        if let Some(from) = &rpc.from {
+            put(
+                "from",
+                serde_json::Value::String(trim_origin(from).to_string()),
+            );
+        }
+        // span lineage of the RPC (omitted when unavailable, Java parity)
+        if let Some(span_id) = reply.span_id() {
+            put("span_id", serde_json::Value::String(span_id.to_string()));
+        }
+        if let Some(parent) = &rpc.parent_span {
+            put("parent_span_id", serde_json::Value::String(parent.clone()));
+        }
+        if let Some(exec_time) = reply.exec_time() {
+            put(
+                "exec_time",
+                serde_json::Value::from(((exec_time as f64) * 1000.0).round() / 1000.0),
+            );
+        }
+        if let Some(round_trip) = reply.round_trip() {
+            put(
+                "round_trip",
+                serde_json::Value::from(((round_trip as f64) * 1000.0).round() / 1000.0),
+            );
+        }
+        put("start", serde_json::Value::String(rpc.start.clone()));
+        put("path", serde_json::Value::String(trace_path.clone()));
+        let status = reply.status();
+        put("status", serde_json::Value::from(status));
+        if status >= 400 {
+            put("success", serde_json::Value::Bool(false));
+            // data privacy (Java parity): only a recognized plain error
+            // message is shown; any structured error body is masked
+            let message = match reply.body() {
+                rmpv::Value::String(s) => s.as_str().unwrap_or("***").to_string(),
+                _ => "***".to_string(),
+            };
+            put("exception", serde_json::Value::String(message));
+        } else {
+            put("success", serde_json::Value::Bool(true));
+        }
+        let mut dataset = serde_json::Map::new();
+        dataset.insert("trace".to_string(), serde_json::Value::Object(metrics));
+        // fire-and-forget like Java's EventEmitter.send — never delays the
+        // caller's RPC completion; delivery failures are logged only
+        let platform = self.platform.clone();
+        tokio::spawn(async move {
+            match EventEnvelope::new()
+                .set_to(crate::telemetry::DISTRIBUTED_TRACING)
+                .set_body(serde_json::Value::Object(dataset))
+            {
+                Ok(event) => {
+                    if let Err(e) = platform
+                        .deliver(crate::telemetry::DISTRIBUTED_TRACING, event)
+                        .await
+                    {
+                        log::error!("Unable to send to distributed.tracing - {}", e.message());
+                    }
+                }
+                Err(e) => log::error!("Unable to send to distributed.tracing - {}", e.message()),
+            }
+        });
+    }
+}
+
+/// The RPC trace identity captured when the request is sent (Java
+/// `AsyncInbox`'s constructor fields + `InboxMetadata`).
+struct RpcTraceCapture {
+    to: Option<String>,
+    from: Option<String>,
+    trace_id: Option<String>,
+    trace_path: Option<String>,
+    /// The caller's span riding the outbound request — the callee's parent.
+    parent_span: Option<String>,
+    /// ISO-8601 UTC time the RPC began.
+    start: String,
+}
+
+impl RpcTraceCapture {
+    fn of(event: &EventEnvelope) -> Self {
+        RpcTraceCapture {
+            to: event.to().map(str::to_string),
+            from: event.from().map(str::to_string),
+            trace_id: event.trace_id().map(str::to_string),
+            trace_path: event.trace_path().map(str::to_string),
+            parent_span: event.span_id().map(str::to_string),
+            start: trace::iso8601_utc_now(),
+        }
+    }
+}
+
+/// Trim an `@origin` suffix from a route (Java `InboxBase.trimOrigin`).
+fn trim_origin(route: &str) -> &str {
+    match route.find('@') {
+        Some(at) => &route[..at],
+        None => route,
     }
 }

--- a/crates/platform-core/src/post_office.rs
+++ b/crates/platform-core/src/post_office.rs
@@ -25,6 +25,7 @@
 //! timeout (→ status **408** on expiry). Fork-n-join and `send_later` arrive
 //! in later increments.
 
+use std::collections::HashMap;
 use std::time::Duration;
 
 use crate::automation::event_api;
@@ -40,8 +41,10 @@ use crate::trace;
 /// so the receiver knows its parent span — except inside a zero-traced hop,
 /// which owns no span (Java: no live TraceInfo there); `from` and the
 /// business correlation-id follow the request when absent.
-/// No-op outside a trace bracket.
-fn apply_current_trace(mut event: EventEnvelope) -> EventEnvelope {
+/// No-op outside a trace bracket. Crate-visible so the programmatic
+/// Event-over-HTTP client stamps the wire envelope the same way (Java's
+/// trace-aware `po.request(..., endpoint, rpc)` touches the event first).
+pub(crate) fn apply_current_trace(mut event: EventEnvelope) -> EventEnvelope {
     let snapshot = trace::with_current(|state| {
         (
             state.route.clone(),
@@ -301,7 +304,11 @@ impl PostOffice {
                 let diff = begin.elapsed().as_secs_f32() * 1000.0;
                 let diff = (diff.max(0.0) * 1000.0).round() / 1000.0;
                 let response = response.set_round_trip(diff);
-                self.record_rpc_trace(&rpc_trace, &response);
+                // the reply's annotations belong to the trace record, never
+                // to the caller (Java saveResponse: fold + clearAnnotations)
+                let annotations = response.annotations().clone();
+                let response = response.clear_annotations();
+                self.record_rpc_trace(&rpc_trace, &response, annotations);
                 Ok(response)
             }
             Ok(Err(_)) => Err(AppError::new(500, "Reply channel closed unexpectedly")),
@@ -318,30 +325,32 @@ impl PostOffice {
     /// Emit the caller-side RPC trace record — the dataset carrying
     /// `round_trip` — to the `distributed.tracing` sink (Java
     /// `InboxBase.recordTrace`, invoked from `AsyncInbox.saveResponse`).
+    /// For an RPC-served execution this is **the single record for the span**:
+    /// the worker suppresses its own record when the reply reaches the caller
+    /// (Java `WorkerHandler.sendTracingInfo` gate), so exec_time, round_trip,
+    /// span lineage and the callee's annotations all report here, once.
     ///
     /// Emitted only for a **traced** RPC (the outbound event carried a trace
-    /// id and path) whose target service is not in `skip.rpc.tracing`, and
-    /// never from inside a zero-traced bracket (a zero-traced hop emits no
-    /// telemetry; in Java its outbound events carry no trace, so no record).
-    /// Span lineage mirrors the Java fix (commit `04e5618f`): `span_id` = the
-    /// callee's own span carried on the RPC reply; `parent_span_id` = the
-    /// caller's span captured from the outbound request — so the round-trip
-    /// record chains into the span tree like any worker-emitted record.
-    ///
-    /// Parity note: Java moves the reply envelope's `annotations` into this
-    /// record. In this port annotations never ride the reply — they flow with
-    /// the callee's own worker-emitted record — so the field is absent here.
-    fn record_rpc_trace(&self, rpc: &RpcTraceCapture, reply: &EventEnvelope) {
+    /// id and path) whose target service is not in `skip.rpc.tracing`.
+    /// Span lineage mirrors the Java fixes (commits `04e5618f` + `140640d8`):
+    /// `parent_span_id` = the caller's span captured from the outbound
+    /// request, unconditionally; `span_id` = the callee's own span carried on
+    /// the reply, adopted **only from a direct responder** (the reply's `from`
+    /// equals the requested route — Java `InboxBase.spanIdFromResponder`). A
+    /// RELAYED reply (e.g. a flow answering on behalf of the manager route)
+    /// carries the span of a different function that reports its own record —
+    /// adopting it would misattribute and duplicate that span.
+    fn record_rpc_trace(
+        &self,
+        rpc: &RpcTraceCapture,
+        reply: &EventEnvelope,
+        annotations: HashMap<String, rmpv::Value>,
+    ) {
         let (Some(to), Some(trace_id), Some(trace_path)) =
             (&rpc.to, &rpc.trace_id, &rpc.trace_path)
         else {
             return; // not a traced RPC
         };
-        // a zero-traced hop must not emit telemetry (its trace context flows
-        // for continuity only — see the worker's trace bracket)
-        if trace::with_current(|state| state.zero_traced).unwrap_or(false) {
-            return;
-        }
         let service = trim_origin(to).to_string();
         if crate::platform::in_skip_rpc_tracing_list(&service) {
             return;
@@ -368,8 +377,10 @@ impl PostOffice {
                 serde_json::Value::String(trim_origin(from).to_string()),
             );
         }
-        // span lineage of the RPC (omitted when unavailable, Java parity)
-        if let Some(span_id) = reply.span_id() {
+        // span lineage of the RPC (omitted when unavailable, Java parity):
+        // the reply's span id counts only when it comes from the DIRECT
+        // responder (Java spanIdFromResponder); the parent is unconditional
+        if let Some(span_id) = span_id_from_responder(to, reply) {
             put("span_id", serde_json::Value::String(span_id.to_string()));
         }
         if let Some(parent) = &rpc.parent_span {
@@ -405,6 +416,17 @@ impl PostOffice {
         }
         let mut dataset = serde_json::Map::new();
         dataset.insert("trace".to_string(), serde_json::Value::Object(metrics));
+        // the callee's annotations, carried on the reply, report with THIS
+        // record — the callee's own record was suppressed (Java recordTrace)
+        if !annotations.is_empty() {
+            let folded: serde_json::Map<String, serde_json::Value> = annotations
+                .into_iter()
+                .filter_map(|(k, v)| serde_json::to_value(&v).ok().map(|value| (k, value)))
+                .collect();
+            if !folded.is_empty() {
+                dataset.insert("annotations".to_string(), serde_json::Value::Object(folded));
+            }
+        }
         // fire-and-forget like Java's EventEmitter.send — never delays the
         // caller's RPC completion; delivery failures are logged only
         let platform = self.platform.clone();
@@ -458,5 +480,17 @@ fn trim_origin(route: &str) -> &str {
     match route.find('@') {
         Some(at) => &route[..at],
         None => route,
+    }
+}
+
+/// The reply's span id, adopted only when the reply comes from the DIRECT
+/// responder — its `from` equals the requested route (Java
+/// `InboxBase.spanIdFromResponder`, commit `140640d8`). A relayed reply
+/// (another function answering on behalf of the requested route) carries a
+/// span that its own record already reports.
+fn span_id_from_responder<'a>(to: &str, reply: &'a EventEnvelope) -> Option<&'a str> {
+    match reply.from() {
+        Some(from) if trim_origin(to) == from => reply.span_id(),
+        _ => None,
     }
 }

--- a/crates/platform-core/src/util/config_reader.rs
+++ b/crates/platform-core/src/util/config_reader.rs
@@ -84,6 +84,18 @@ impl ConfigReader {
         Ok(reader)
     }
 
+    /// Build a reader from in-memory YAML text and resolve references — used
+    /// for **embedded** built-in templates (e.g. `default-log-context.yaml`),
+    /// the Rust analog of a library-jar classpath resource. The `resources/`
+    /// roots are application-owned in this port, so a library default ships
+    /// compiled-in via `include_str!` instead of shadowing a file name.
+    pub fn from_yaml_text(text: &str) -> Result<Self, ConfigError> {
+        let mut reader = ConfigReader::default();
+        reader.load_yaml_text(text)?;
+        reader.resolve_references();
+        Ok(reader)
+    }
+
     /// Build a reader from an existing nested map and resolve references
     /// (Java `load(Map)`).
     pub fn from_map(map: BTreeMap<String, ConfigValue>) -> Self {

--- a/crates/platform-core/tests/annotations.rs
+++ b/crates/platform-core/tests/annotations.rs
@@ -139,6 +139,31 @@ impl ComposableFunction for AnnoPublicEcho {
     }
 }
 
+/// Comma-separated route ALIASES (Java `@PreLoad(route = "a.b, c.d")`): the
+/// same function object registers under every name with the same instance
+/// count and visibility. The counter proves both routes reach this handler.
+#[preload(
+    route = "anno.alias.one, anno.alias.two",
+    instances = 3,
+    is_private = false
+)]
+struct AliasedEcho;
+
+static ALIAS_CALLS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+#[async_trait]
+impl ComposableFunction for AliasedEcho {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        ALIAS_CALLS.fetch_add(1, Ordering::SeqCst);
+        Ok(EventEnvelope::new().set_raw_body(input.body().clone()))
+    }
+}
+
 /// The interceptor flag (Java @PreLoad + @EventInterceptor): manual reply
 /// through the raw envelope's reply_to/cid; no auto-reply on success.
 #[preload(route = "anno.interceptor")]
@@ -405,4 +430,32 @@ async fn annotation_macros_end_to_end() {
         .await
         .expect("interceptor manual reply");
     assert_eq!(reply.body_as::<String>().expect("manual reply"), "manual");
+
+    // comma-separated route aliases (Java @PreLoad(route = "a.b, c.d")):
+    // both names registered, same instance count, same (public) visibility
+    assert!(platform.has_route("anno.alias.one"));
+    assert!(platform.has_route("anno.alias.two"));
+    assert_eq!(platform.instances("anno.alias.one"), Some(3));
+    assert_eq!(platform.instances("anno.alias.two"), Some(3));
+    assert_eq!(platform.is_private("anno.alias.one"), Some(false));
+    assert_eq!(platform.is_private("anno.alias.two"), Some(false));
+    // both aliases are callable and reach the SAME handler
+    for alias in ["anno.alias.one", "anno.alias.two"] {
+        let reply = po
+            .request(
+                EventEnvelope::new()
+                    .set_to(alias)
+                    .set_body(alias)
+                    .expect("body"),
+                Duration::from_secs(2),
+            )
+            .await
+            .expect("alias rpc");
+        assert_eq!(reply.body_as::<String>().expect("alias reply"), alias);
+    }
+    assert_eq!(
+        ALIAS_CALLS.load(Ordering::SeqCst),
+        2,
+        "one shared handler must have served both aliases"
+    );
 }

--- a/crates/platform-core/tests/telemetry.rs
+++ b/crates/platform-core/tests/telemetry.rs
@@ -178,15 +178,22 @@ async fn traced_request_produces_span_lineage_across_two_hops() {
     // the response carries the trace context back (applyTraceContext parity)
     assert_eq!(response.trace_id(), Some(trace_id.as_str()));
     assert!(response.span_id().is_some());
-    // two spans arrive: one per traced hop
-    let all = wait_for_datasets(&datasets, 2).await;
+    // four datasets arrive: one WORKER record per traced hop plus one
+    // caller-side RPC record (round_trip) per RPC — the test's request for
+    // v1.first.hop and the first hop's nested request for v1.second.hop
+    let all = wait_for_datasets(&datasets, 4).await;
+    // a worker record has no round_trip; an RPC record always does
     let first = all
         .iter()
-        .find(|d| trace_of(d)["service"] == "v1.first.hop")
+        .find(|d| {
+            trace_of(d)["service"] == "v1.first.hop" && !trace_of(d).contains_key("round_trip")
+        })
         .expect("first hop span");
     let second = all
         .iter()
-        .find(|d| trace_of(d)["service"] == "v1.second.hop")
+        .find(|d| {
+            trace_of(d)["service"] == "v1.second.hop" && !trace_of(d).contains_key("round_trip")
+        })
         .expect("second hop span");
     // same trace, OTel-shaped ids
     assert_eq!(trace_of(first)["id"], serde_json::json!(trace_id));
@@ -213,6 +220,31 @@ async fn traced_request_produces_span_lineage_across_two_hops() {
     // business correlation-id propagated to BOTH hops
     assert_eq!(cid_a.lock().unwrap().as_deref(), Some("order-42"));
     assert_eq!(cid_b.lock().unwrap().as_deref(), Some("order-42"));
+    // the caller-side RPC record for the nested hop (Java InboxBase.recordTrace)
+    // chains like a worker record: span_id = the callee's own span (from the
+    // reply), parent_span_id = the caller's span (from the outbound request)
+    let second_rpc = all
+        .iter()
+        .find(|d| {
+            trace_of(d)["service"] == "v1.second.hop" && trace_of(d).contains_key("round_trip")
+        })
+        .expect("second hop RPC record");
+    assert_eq!(
+        trace_of(second_rpc)["span_id"],
+        trace_of(second)["span_id"],
+        "RPC record must carry the callee's own span"
+    );
+    assert_eq!(
+        trace_of(second_rpc)["parent_span_id"].as_str().unwrap(),
+        first_span,
+        "RPC record must chain onto the caller's span"
+    );
+    assert_eq!(
+        trace_of(second_rpc)["from"],
+        serde_json::json!("v1.first.hop")
+    );
+    assert_eq!(trace_of(second_rpc)["success"], serde_json::json!(true));
+    assert!(trace_of(second_rpc)["round_trip"].is_number());
 }
 
 #[tokio::test]
@@ -428,15 +460,40 @@ async fn zero_traced_route_preserves_trace_continuity() {
     assert_eq!(recorded[0].0.as_deref(), Some("trace-through-zero"));
     assert_eq!(recorded[0].1.as_deref(), Some("GET /zero"));
     assert_eq!(recorded[0].2, None, "zero-traced hop must not mint a span");
-    // exactly ONE telemetry dataset: the recorder's own execution — the
-    // zero-traced relay emitted none
-    let all = wait_for_datasets(&datasets, 1).await;
+    // exactly TWO telemetry datasets: the recorder's own worker record plus
+    // the TEST's caller-side RPC record about the relay (Java parity: the
+    // caller's inbox records a traced RPC whatever the target's tracing
+    // posture). The zero-traced relay itself emitted NOTHING — no worker
+    // record, and its nested RPC record is suppressed by the zero-traced
+    // bracket (its outbound events carry no span; in Java they carry no
+    // trace at all, so no inbox record either).
+    let all = wait_for_datasets(&datasets, 2).await;
     tokio::time::sleep(Duration::from_millis(100)).await;
     let all_after = datasets.lock().expect("capture mutex").clone();
     assert_eq!(all_after.len(), all.len(), "no late datasets expected");
-    assert!(all_after
+    let worker_records: Vec<_> = all_after
         .iter()
-        .all(|d| trace_of(d)["service"] == "v1.trace.recorder"));
+        .filter(|d| !trace_of(d).contains_key("round_trip"))
+        .collect();
+    assert_eq!(worker_records.len(), 1, "only the recorder emits a span");
+    assert_eq!(
+        trace_of(worker_records[0])["service"],
+        serde_json::json!("v1.trace.recorder")
+    );
+    // the RPC record about the zero-traced relay carries NO span_id — the
+    // relay owns no span, so its reply carries none
+    let rpc_record = all_after
+        .iter()
+        .find(|d| trace_of(d).contains_key("round_trip"))
+        .expect("the test caller's RPC record");
+    assert_eq!(
+        trace_of(rpc_record)["service"],
+        serde_json::json!("v1.zero.relay")
+    );
+    assert!(
+        !trace_of(rpc_record).contains_key("span_id"),
+        "a zero-traced callee contributes no span to the RPC record"
+    );
 }
 
 /// A function that schedules a delayed send and returns immediately — the
@@ -578,4 +635,97 @@ async fn explicit_trace_identity_survives_ambient_bracket() {
     // the sender's span still rides the event (Java: span is stamped
     // unconditionally so the receiver knows its parent)
     assert!(recorded[0].2.is_some());
+}
+
+// ---- RPC telemetry span lineage (Java PostOfficeTest.rpcTelemetryCarriesSpanLineage) ----
+
+/// Regression twin of the Java fix (commit `04e5618f`): the RPC trace record
+/// (the one carrying `round_trip`) must chain like a worker-emitted record —
+/// `span_id` is the callee's own span (carried on the RPC reply) and
+/// `parent_span_id` is the caller's span (carried on the outbound request).
+/// A traced parent function makes a nested RPC to a leaf; the leaf's RPC
+/// record must carry both fields, with `parent_span_id` equal to the parent
+/// function's own span.
+#[tokio::test]
+async fn rpc_telemetry_carries_span_lineage() {
+    setup_config();
+    let (platform, datasets) = capture_platform();
+    struct Leaf;
+    #[async_trait]
+    impl ComposableFunction for Leaf {
+        async fn handle_event(
+            &self,
+            _h: HashMap<String, String>,
+            _i: EventEnvelope,
+            _n: usize,
+        ) -> Result<EventEnvelope, AppError> {
+            EventEnvelope::new().set_body("ok")
+        }
+    }
+    platform
+        .register("span.lineage.leaf", Arc::new(Leaf), 1)
+        .unwrap();
+    platform
+        .register(
+            "span.lineage.parent",
+            Arc::new(Hop {
+                platform: platform.clone(),
+                next: Some("span.lineage.leaf"),
+                seen_cid: Arc::new(Mutex::new(None)),
+                annotate: None,
+            }),
+            1,
+        )
+        .unwrap();
+    let po = PostOffice::new(&platform);
+    let trace_id = trace::new_trace_id();
+    let response = po
+        .request(
+            EventEnvelope::new()
+                .set_to("span.lineage.parent")
+                .set_trace(&trace_id, "GET /api/span/lineage")
+                .set_body("start")
+                .unwrap(),
+            Duration::from_secs(8),
+        )
+        .await
+        .unwrap();
+    // the reply itself now reports the measured round trip (Java parity)
+    assert!(response.round_trip().is_some());
+    // worker records: parent + leaf; RPC records: parent (by the test) + leaf
+    // (by the parent function) = four datasets
+    let all = wait_for_datasets(&datasets, 4).await;
+    let leaf_rpc = all
+        .iter()
+        .find(|d| {
+            trace_of(d)["service"] == "span.lineage.leaf" && trace_of(d).contains_key("round_trip")
+        })
+        .expect("the RPC trace record for the leaf must arrive");
+    let parent_worker = all
+        .iter()
+        .find(|d| {
+            trace_of(d)["service"] == "span.lineage.parent"
+                && !trace_of(d).contains_key("round_trip")
+        })
+        .expect("the parent's worker record must arrive");
+    let leaf = trace_of(leaf_rpc);
+    assert_eq!(leaf["id"], serde_json::json!(trace_id));
+    assert!(
+        leaf["span_id"].is_string(),
+        "the RPC record carries the callee's own span"
+    );
+    assert!(
+        leaf["parent_span_id"].is_string(),
+        "the RPC record chains onto the caller's span"
+    );
+    assert_eq!(
+        leaf["parent_span_id"],
+        trace_of(parent_worker)["span_id"],
+        "the leaf's parent is the parent function's own span"
+    );
+    assert_eq!(leaf["from"], serde_json::json!("span.lineage.parent"));
+    assert!(leaf["round_trip"].is_number());
+    assert!(leaf["exec_time"].is_number());
+    assert_eq!(leaf["path"], serde_json::json!("GET /api/span/lineage"));
+    assert_eq!(leaf["success"], serde_json::json!(true));
 }

--- a/crates/platform-core/tests/telemetry.rs
+++ b/crates/platform-core/tests/telemetry.rs
@@ -178,24 +178,25 @@ async fn traced_request_produces_span_lineage_across_two_hops() {
     // the response carries the trace context back (applyTraceContext parity)
     assert_eq!(response.trace_id(), Some(trace_id.as_str()));
     assert!(response.span_id().is_some());
-    // four datasets arrive: one WORKER record per traced hop plus one
-    // caller-side RPC record (round_trip) per RPC — the test's request for
-    // v1.first.hop and the first hop's nested request for v1.second.hop
-    let all = wait_for_datasets(&datasets, 4).await;
-    // a worker record has no round_trip; an RPC record always does
+    // EXACTLY ONE record per span (Java WorkerHandler suppression): both hops
+    // are RPC-served, so each span's single record is the caller-side RPC
+    // record carrying round_trip — the test's request for v1.first.hop and
+    // the first hop's nested request for v1.second.hop
+    let _ = wait_for_datasets(&datasets, 2).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let all = datasets.lock().expect("capture mutex").clone();
+    assert_eq!(all.len(), 2, "one record per span, no worker duplicates");
+    assert!(all.iter().all(|d| trace_of(d).contains_key("round_trip")));
     let first = all
         .iter()
-        .find(|d| {
-            trace_of(d)["service"] == "v1.first.hop" && !trace_of(d).contains_key("round_trip")
-        })
-        .expect("first hop span");
+        .find(|d| trace_of(d)["service"] == "v1.first.hop")
+        .expect("first hop record");
     let second = all
         .iter()
-        .find(|d| {
-            trace_of(d)["service"] == "v1.second.hop" && !trace_of(d).contains_key("round_trip")
-        })
-        .expect("second hop span");
-    // same trace, OTel-shaped ids
+        .find(|d| trace_of(d)["service"] == "v1.second.hop")
+        .expect("second hop record");
+    // same trace, OTel-shaped ids; span_id is each callee's OWN span,
+    // adopted from the direct responder's reply (spanIdFromResponder)
     assert_eq!(trace_of(first)["id"], serde_json::json!(trace_id));
     assert_eq!(trace_of(second)["id"], serde_json::json!(trace_id));
     let first_span = trace_of(first)["span_id"].as_str().unwrap();
@@ -205,46 +206,28 @@ async fn traced_request_produces_span_lineage_across_two_hops() {
         trace_of(second)["parent_span_id"].as_str().unwrap(),
         first_span
     );
-    // the second hop's caller is recorded
+    // spans stay unique across the trace (Java SpanPropagationTest invariant)
+    assert_ne!(trace_of(second)["span_id"], trace_of(first)["span_id"]);
+    // the second hop's caller is recorded; the test itself has no route
     assert_eq!(trace_of(second)["from"], serde_json::json!("v1.first.hop"));
+    assert!(!trace_of(first).contains_key("from"));
     // timing + success + path present
     assert!(trace_of(first)["exec_time"].is_number());
+    assert!(trace_of(first)["round_trip"].is_number());
     assert_eq!(trace_of(first)["success"], serde_json::json!(true));
     assert_eq!(trace_of(first)["path"], serde_json::json!("GET /api/first"));
     assert!(trace_of(first)["start"].as_str().unwrap().ends_with('Z'));
-    // annotations flow with the first hop's span
+    // annotations ride the reply envelope and fold into the span's single
+    // record (Java: applyTraceContext -> inbox recordTrace); the caller's
+    // returned envelope no longer carries them
     assert_eq!(
         first["annotations"]["business.step"],
         serde_json::json!("checkout")
     );
+    assert!(response.annotations().is_empty());
     // business correlation-id propagated to BOTH hops
     assert_eq!(cid_a.lock().unwrap().as_deref(), Some("order-42"));
     assert_eq!(cid_b.lock().unwrap().as_deref(), Some("order-42"));
-    // the caller-side RPC record for the nested hop (Java InboxBase.recordTrace)
-    // chains like a worker record: span_id = the callee's own span (from the
-    // reply), parent_span_id = the caller's span (from the outbound request)
-    let second_rpc = all
-        .iter()
-        .find(|d| {
-            trace_of(d)["service"] == "v1.second.hop" && trace_of(d).contains_key("round_trip")
-        })
-        .expect("second hop RPC record");
-    assert_eq!(
-        trace_of(second_rpc)["span_id"],
-        trace_of(second)["span_id"],
-        "RPC record must carry the callee's own span"
-    );
-    assert_eq!(
-        trace_of(second_rpc)["parent_span_id"].as_str().unwrap(),
-        first_span,
-        "RPC record must chain onto the caller's span"
-    );
-    assert_eq!(
-        trace_of(second_rpc)["from"],
-        serde_json::json!("v1.first.hop")
-    );
-    assert_eq!(trace_of(second_rpc)["success"], serde_json::json!(true));
-    assert!(trace_of(second_rpc)["round_trip"].is_number());
 }
 
 #[tokio::test]
@@ -460,38 +443,41 @@ async fn zero_traced_route_preserves_trace_continuity() {
     assert_eq!(recorded[0].0.as_deref(), Some("trace-through-zero"));
     assert_eq!(recorded[0].1.as_deref(), Some("GET /zero"));
     assert_eq!(recorded[0].2, None, "zero-traced hop must not mint a span");
-    // exactly TWO telemetry datasets: the recorder's own worker record plus
-    // the TEST's caller-side RPC record about the relay (Java parity: the
-    // caller's inbox records a traced RPC whatever the target's tracing
-    // posture). The zero-traced relay itself emitted NOTHING — no worker
-    // record, and its nested RPC record is suppressed by the zero-traced
-    // bracket (its outbound events carry no span; in Java they carry no
-    // trace at all, so no inbox record either).
-    let all = wait_for_datasets(&datasets, 2).await;
+    // exactly TWO telemetry datasets, both caller-side RPC records (one per
+    // span — Java parity): the RELAY's nested request records the recorder's
+    // span (the trace context flows through a zero-traced hop, so its
+    // outbound events are traced and its inbox records like any other), and
+    // the TEST's request records the relay. NO worker records: both
+    // executions were RPC-served, and the zero-traced relay never emits its
+    // own telemetry anyway.
+    let _ = wait_for_datasets(&datasets, 2).await;
     tokio::time::sleep(Duration::from_millis(100)).await;
-    let all_after = datasets.lock().expect("capture mutex").clone();
-    assert_eq!(all_after.len(), all.len(), "no late datasets expected");
-    let worker_records: Vec<_> = all_after
+    let all = datasets.lock().expect("capture mutex").clone();
+    assert_eq!(all.len(), 2, "one record per span, no late datasets");
+    assert!(all.iter().all(|d| trace_of(d).contains_key("round_trip")));
+    // the recorder's single record: its own span, adopted from the direct
+    // responder's reply; NO parent — the zero-traced relay owns no span
+    let recorder = all
         .iter()
-        .filter(|d| !trace_of(d).contains_key("round_trip"))
-        .collect();
-    assert_eq!(worker_records.len(), 1, "only the recorder emits a span");
-    assert_eq!(
-        trace_of(worker_records[0])["service"],
-        serde_json::json!("v1.trace.recorder")
+        .find(|d| trace_of(d)["service"] == "v1.trace.recorder")
+        .expect("the relay's RPC record about the recorder");
+    assert!(trace_of(recorder)["span_id"].is_string());
+    assert!(
+        !trace_of(recorder).contains_key("parent_span_id"),
+        "a zero-traced caller contributes no parent span"
     );
-    // the RPC record about the zero-traced relay carries NO span_id — the
-    // relay owns no span, so its reply carries none
-    let rpc_record = all_after
-        .iter()
-        .find(|d| trace_of(d).contains_key("round_trip"))
-        .expect("the test caller's RPC record");
     assert_eq!(
-        trace_of(rpc_record)["service"],
+        trace_of(recorder)["from"],
         serde_json::json!("v1.zero.relay")
     );
+    // the relay's single record carries NO span_id — the relay owns no span,
+    // so its reply carries none for the responder gate to adopt
+    let relay = all
+        .iter()
+        .find(|d| trace_of(d)["service"] == "v1.zero.relay")
+        .expect("the test caller's RPC record about the relay");
     assert!(
-        !trace_of(rpc_record).contains_key("span_id"),
+        !trace_of(relay).contains_key("span_id"),
         "a zero-traced callee contributes no span to the RPC record"
     );
 }
@@ -692,22 +678,25 @@ async fn rpc_telemetry_carries_span_lineage() {
         .unwrap();
     // the reply itself now reports the measured round trip (Java parity)
     assert!(response.round_trip().is_some());
-    // worker records: parent + leaf; RPC records: parent (by the test) + leaf
-    // (by the parent function) = four datasets
-    let all = wait_for_datasets(&datasets, 4).await;
+    // exactly one record per span (worker records suppressed for delivered
+    // RPCs): the parent's record by the test, the leaf's by the parent
+    let _ = wait_for_datasets(&datasets, 2).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let all = datasets.lock().expect("capture mutex").clone();
+    assert_eq!(all.len(), 2, "one record per span");
     let leaf_rpc = all
         .iter()
         .find(|d| {
             trace_of(d)["service"] == "span.lineage.leaf" && trace_of(d).contains_key("round_trip")
         })
         .expect("the RPC trace record for the leaf must arrive");
-    let parent_worker = all
+    let parent_rpc = all
         .iter()
         .find(|d| {
             trace_of(d)["service"] == "span.lineage.parent"
-                && !trace_of(d).contains_key("round_trip")
+                && trace_of(d).contains_key("round_trip")
         })
-        .expect("the parent's worker record must arrive");
+        .expect("the parent's RPC record must arrive");
     let leaf = trace_of(leaf_rpc);
     assert_eq!(leaf["id"], serde_json::json!(trace_id));
     assert!(
@@ -720,12 +709,121 @@ async fn rpc_telemetry_carries_span_lineage() {
     );
     assert_eq!(
         leaf["parent_span_id"],
-        trace_of(parent_worker)["span_id"],
+        trace_of(parent_rpc)["span_id"],
         "the leaf's parent is the parent function's own span"
+    );
+    assert_ne!(
+        leaf["span_id"],
+        trace_of(parent_rpc)["span_id"],
+        "spans stay unique across the trace"
     );
     assert_eq!(leaf["from"], serde_json::json!("span.lineage.parent"));
     assert!(leaf["round_trip"].is_number());
     assert!(leaf["exec_time"].is_number());
     assert_eq!(leaf["path"], serde_json::json!("GET /api/span/lineage"));
     assert_eq!(leaf["success"], serde_json::json!(true));
+}
+
+/// Regression twin of Java commit `140640d8` (`InboxBase.spanIdFromResponder`,
+/// caught by the flow engine's SpanPropagationTest): a RELAYED reply — one
+/// answered on behalf of the requested route by a different function — must
+/// NOT donate its span id to the caller's `round_trip` record. That span
+/// belongs to a function that reports its own record; adopting it would
+/// misattribute and duplicate it. `parent_span_id` stays unconditional.
+#[tokio::test]
+async fn relayed_reply_does_not_donate_its_span_to_the_rpc_record() {
+    setup_config();
+    let (platform, datasets) = capture_platform();
+    struct Responder;
+    #[async_trait]
+    impl ComposableFunction for Responder {
+        async fn handle_event(
+            &self,
+            _h: HashMap<String, String>,
+            _i: EventEnvelope,
+            _n: usize,
+        ) -> Result<EventEnvelope, AppError> {
+            EventEnvelope::new().set_body("real answer")
+        }
+    }
+    /// An event interceptor that relays the responder's reply verbatim to the
+    /// original caller — the relayed reply's `from` names the responder, not
+    /// the route the caller requested (the flow-engine reply shape).
+    struct RelayInterceptor {
+        platform: Platform,
+    }
+    #[async_trait]
+    impl ComposableFunction for RelayInterceptor {
+        async fn handle_event(
+            &self,
+            _h: HashMap<String, String>,
+            input: EventEnvelope,
+            _n: usize,
+        ) -> Result<EventEnvelope, AppError> {
+            let po = PostOffice::new(&self.platform);
+            let nested = po
+                .request(
+                    EventEnvelope::new()
+                        .set_to("relay.actual.responder")
+                        .set_body("x")?,
+                    Duration::from_secs(2),
+                )
+                .await?;
+            if let (Some(reply_to), Some(cid)) = (input.reply_to(), input.correlation_id()) {
+                // relay: keep the nested reply's `from` (the responder)
+                let relayed = nested.set_to(reply_to).set_correlation_id(cid);
+                po.send(relayed).await?;
+            }
+            EventEnvelope::new().set_body("ignored by the worker")
+        }
+    }
+    platform
+        .register("relay.actual.responder", Arc::new(Responder), 1)
+        .unwrap();
+    platform
+        .register_with_options(
+            "relay.entry",
+            Arc::new(RelayInterceptor {
+                platform: platform.clone(),
+            }),
+            1,
+            platform_core::FunctionOptions {
+                interceptor: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let po = PostOffice::new(&platform);
+    let response = po
+        .request(
+            EventEnvelope::new()
+                .set_to("relay.entry")
+                .set_trace(&trace::new_trace_id(), "GET /relay")
+                .set_body("go")
+                .unwrap(),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.body_as::<String>().unwrap(), "real answer");
+    // two RPC records: the responder's (by the interceptor) and the relay
+    // entry's (by the test); no worker records
+    let _ = wait_for_datasets(&datasets, 2).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let all = datasets.lock().expect("capture mutex").clone();
+    assert_eq!(all.len(), 2, "one record per span");
+    let responder = all
+        .iter()
+        .find(|d| trace_of(d)["service"] == "relay.actual.responder")
+        .expect("the responder's record");
+    let entry = all
+        .iter()
+        .find(|d| trace_of(d)["service"] == "relay.entry")
+        .expect("the relay entry's record");
+    // the responder's span reports exactly once — on its own record
+    assert!(trace_of(responder)["span_id"].is_string());
+    assert!(
+        !trace_of(entry).contains_key("span_id"),
+        "a relayed reply must not donate its span to the caller's record"
+    );
 }

--- a/crates/platform-macros/src/lib.rs
+++ b/crates/platform-macros/src/lib.rs
@@ -63,7 +63,11 @@ use syn::{parse_macro_input, ItemStruct, LitInt, LitStr};
 /// composable function at startup.
 ///
 /// Parameters:
-/// - `route = "my.function.route"` (required)
+/// - `route = "my.function.route"` (required). A **comma-separated list**
+///   registers the same function under several route names (aliases) with the
+///   same instance count and visibility — the Java
+///   `@PreLoad(route = "hello.world, hello.declarative")` behavior. Each name
+///   is whitespace-trimmed; an empty segment is a compile error.
 /// - `instances = N` (default 1)
 /// - `env_instances = "config.key"` — read the instance count from application
 ///   configuration at startup, falling back to `instances` (Java `envInstances`)
@@ -130,6 +134,13 @@ pub fn preload(args: TokenStream, input: TokenStream) -> TokenStream {
             .to_compile_error()
             .into();
     };
+    // a comma-separated route list declares ALIASES (Java @PreLoad parity);
+    // validate the list shape at compile time — empty segments are an error
+    if let Err(message) = validate_route_list(&route.value()) {
+        return syn::Error::new_spanned(&route, message)
+            .to_compile_error()
+            .into();
+    }
     // consume stacked marker attributes (Java annotation stacking)
     zero_tracing |= strip_marker(&mut item, "zero_tracing");
     interceptor |= strip_marker(&mut item, "event_interceptor");
@@ -389,5 +400,49 @@ fn optional_service_expr(cond: &Option<LitStr>) -> proc_macro2::TokenStream {
     match cond {
         Some(c) => quote!(::core::option::Option::Some(#c)),
         None => quote!(::core::option::Option::None),
+    }
+}
+
+/// Validate a `#[preload]` route value: one route name, or a comma-separated
+/// list of route names (aliases — Java `@PreLoad(route = "a.b, c.d")`). Each
+/// segment is whitespace-trimmed; an **empty segment** (leading/trailing/
+/// doubled comma, or a blank value) is rejected here at compile time.
+/// Route-name *shape* (lowercase, at least one dot) stays a startup-time
+/// check in `Platform::register`, exactly as for a single route.
+fn validate_route_list(route: &str) -> Result<(), String> {
+    let segments: Vec<&str> = route.split(',').map(str::trim).collect();
+    if segments.iter().any(|segment| segment.is_empty()) {
+        return Err(format!(
+            "invalid #[preload] route list '{route}' - each comma-separated \
+             route name must be non-empty"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_route_list;
+
+    #[test]
+    fn single_route_is_valid() {
+        assert!(validate_route_list("hello.world").is_ok());
+    }
+
+    #[test]
+    fn comma_separated_aliases_are_valid_with_or_without_spaces() {
+        assert!(validate_route_list("hello.world, hello.declarative").is_ok());
+        assert!(validate_route_list("hello.world,hello.declarative").is_ok());
+        assert!(validate_route_list("a.b , c.d ,  e.f").is_ok());
+    }
+
+    #[test]
+    fn empty_segments_are_rejected() {
+        assert!(validate_route_list("").is_err());
+        assert!(validate_route_list("   ").is_err());
+        assert!(validate_route_list("hello.world,").is_err());
+        assert!(validate_route_list(",hello.world").is_err());
+        assert!(validate_route_list("hello.world,,hello.declarative").is_err());
+        assert!(validate_route_list("hello.world, ,hello.declarative").is_err());
     }
 }

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -79,6 +79,7 @@
 | 60 | Event over HTTP phase 2, increment 2 — private functions, both Java paths: `#[preload]` private-by-default with `is_private = false` opt-out + `register_private` API + `is_private()` query; engine internals registered private | 2026-07-21 | — | 233 |
 | 61 | Event over HTTP phase 2, increment 3 — /api/event service + client: RPC/async dispatch, 403 private gate, 404/400/408, compact rejection, trace propagation (x-trace-id + traceparent); ships in default rest.yaml | 2026-07-21 | — | 235 |
 | 62 | Declarative Event over HTTP (`yaml.event.over.http`) — route→target map with per-target security headers; transparent PostOffice send/request forwarding (callback dance, x-event-api recursion guard); plus the D2 ttl fix (ceil + wire grace + local-wait grace) | 2026-07-22 | — | 237 |
+| 63 | Java-parity batch pre-4.10: `#[preload]` route aliases, app-log-context ON by default (built-in `default-log-context.yaml` + `app.log.context` switch), caller-side RPC `round_trip` telemetry record with span lineage, Event-over-HTTP demo endpoints in hello-flow (declarative + programmatic; port 8086→8100) | 2026-07-23 | — | 243 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1747,6 +1748,58 @@ Java `yaml.event.over.http` behavior, ported.
   `configuration-reference.md` adds `yaml.event.over.http` (removed from the absent-keys
   note). The D2 fix was verified live in the cross-language interop matrix (case 6: the
   Java peer's in-band 408 now arrives through this port's client).
+
+---
+
+## Increment 63 — Java-parity batch before the 4.10 line (2026-07-23)
+
+Six maintainer-requested feature-gap fixes so both engines enter the next release in
+lock-step (Java references: mercury-composable commits `9f9050e1` log-context default-on,
+`04e5618f` RPC span lineage, `ca3fb4a7`/`ffb45ff1` interop demo pair).
+
+- **`#[preload]` route aliases**: `route = "hello.world, hello.declarative"` registers
+  the SAME function object under every comma-separated name with the same instance count
+  and visibility (Java `AppStarter` splits `@PreLoad.route` and registers one instance
+  for all names). The macro validates the list at compile time — an empty segment is a
+  compile error; route-name shape stays a startup check as before.
+- **Application log context ON by default** (Java `LogContextConfig.loadConfigFile`
+  order): the `app.log.context` switch (default `true`) → the application's own
+  `app-log-context.yaml` (replaces the template entirely) → the built-in
+  `default-log-context.yaml` carrying the standard seven-token trace context. The
+  built-in ships under a DISTINCT file name embedded via `include_str!` — the Rust
+  mirror of Java's same-named-resource-shadowing defense (`ConfigReader::from_yaml_text`
+  added for embedded templates). json/compact formats only; `text` unaffected.
+- **Caller-side RPC `round_trip` telemetry record** (Java `InboxBase.recordTrace` — this
+  port previously emitted NO record on RPC completion, a wider gap than the Java bug):
+  `PostOffice::request_direct` now records a traced RPC's completion to
+  `distributed.tracing` with **span lineage** exactly per the Java fix — `span_id` = the
+  callee's span from the reply, `parent_span_id` = the caller's span captured from the
+  outbound request. Gated like Java: traced events only, `skip.rpc.tracing` honored
+  (shared helper with the worker's zero-trace resolution), plus never from inside a
+  zero-traced bracket (in Java such events carry no trace at all). The reply envelope
+  now carries `set_round_trip` (Java `saveResponse` parity). Companion fix: a
+  zero-traced hop clears a nested reply's span id from its response instead of leaking
+  it (Java rebuilds the response envelope, so its reply never carries one).
+  Regression `rpc_telemetry_carries_span_lineage` (the Java
+  `PostOfficeTest.rpcTelemetryCarriesSpanLineage` twin) + strengthened lineage/zero-trace
+  tests.
+- **Event-over-HTTP demo endpoints in hello-flow** (now port **8100**, the structural
+  parallel of the Java composable-example): `/api/event/http/demo` (declarative — flow
+  task = the foreign alias route `hello.declarative` via `event-over-http.yaml` +
+  `peer.demo.host`/`peer.demo.port`) and `/api/event/http/programmatic` (flow task
+  `v1.event.over.http.rpc` passes the peer's `/api/event` URL directly to
+  `event_over_http`). Callee = the hello-world echo, now registered as
+  `hello.world, hello.declarative` — drop-in interchangeable with the Java
+  lambda-example (same port 8085, same routes): the cross-language demo needs zero
+  config changes. Loopback e2e test (`examples/hello-flow/tests/event_over_http_demo.rs`,
+  the Java `EventOverHttpDemoTest` twin): peer.demo.* points back at the test server, so
+  both patterns cross a REAL HTTP hop onto mock public echoes in-process.
+- **Docs:** observability + configuration-reference (log context default-on,
+  `app.log.context`), macros-reference + event-driven AI guide (alias syntax),
+  event-over-http.md (zero-code demo walk-through, the programmatic twin, cross-language
+  interop section — structurally mirrors the Java guide), hello-flow/hello-world READMEs,
+  port sweep 8086→8100 across guides. CHANGELOG "Unreleased" section.
+- Workspace 243 / clippy 0 / fmt.
 
 ---
 

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -79,7 +79,7 @@
 | 60 | Event over HTTP phase 2, increment 2 — private functions, both Java paths: `#[preload]` private-by-default with `is_private = false` opt-out + `register_private` API + `is_private()` query; engine internals registered private | 2026-07-21 | — | 233 |
 | 61 | Event over HTTP phase 2, increment 3 — /api/event service + client: RPC/async dispatch, 403 private gate, 404/400/408, compact rejection, trace propagation (x-trace-id + traceparent); ships in default rest.yaml | 2026-07-21 | — | 235 |
 | 62 | Declarative Event over HTTP (`yaml.event.over.http`) — route→target map with per-target security headers; transparent PostOffice send/request forwarding (callback dance, x-event-api recursion guard); plus the D2 ttl fix (ceil + wire grace + local-wait grace) | 2026-07-22 | — | 237 |
-| 63 | Java-parity batch pre-4.10: `#[preload]` route aliases, app-log-context ON by default (built-in `default-log-context.yaml` + `app.log.context` switch), caller-side RPC `round_trip` telemetry record with span lineage, Event-over-HTTP demo endpoints in hello-flow (declarative + programmatic; port 8086→8100) | 2026-07-23 | — | 243 |
+| 63 | Java-parity batch pre-4.10: `#[preload]` route aliases, app-log-context ON by default (built-in `default-log-context.yaml` + `app.log.context` switch), caller-side RPC `round_trip` telemetry record with span lineage, Event-over-HTTP demo endpoints in hello-flow (declarative + programmatic; port 8086→8100) | 2026-07-23 | — | 244 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1769,20 +1769,39 @@ lock-step (Java references: mercury-composable commits `9f9050e1` log-context de
   built-in ships under a DISTINCT file name embedded via `include_str!` — the Rust
   mirror of Java's same-named-resource-shadowing defense (`ConfigReader::from_yaml_text`
   added for embedded templates). json/compact formats only; `text` unaffected.
-- **Caller-side RPC `round_trip` telemetry record** (Java `InboxBase.recordTrace` — this
-  port previously emitted NO record on RPC completion, a wider gap than the Java bug):
-  `PostOffice::request_direct` now records a traced RPC's completion to
-  `distributed.tracing` with **span lineage** exactly per the Java fix — `span_id` = the
-  callee's span from the reply, `parent_span_id` = the caller's span captured from the
-  outbound request. Gated like Java: traced events only, `skip.rpc.tracing` honored
-  (shared helper with the worker's zero-trace resolution), plus never from inside a
-  zero-traced bracket (in Java such events carry no trace at all). The reply envelope
-  now carries `set_round_trip` (Java `saveResponse` parity). Companion fix: a
-  zero-traced hop clears a nested reply's span id from its response instead of leaking
-  it (Java rebuilds the response envelope, so its reply never carries one).
-  Regression `rpc_telemetry_carries_span_lineage` (the Java
-  `PostOfficeTest.rpcTelemetryCarriesSpanLineage` twin) + strengthened lineage/zero-trace
-  tests.
+- **Caller-side RPC `round_trip` telemetry record — exactly one record per span** (Java
+  `InboxBase.recordTrace` — this port previously emitted NO record on RPC completion, a
+  wider gap than the Java bug): `PostOffice::request_direct` now records a traced RPC's
+  completion to `distributed.tracing`, and the worker **suppresses its own record** for
+  an RPC-served execution whose reply reached the caller (the Java
+  `WorkerHandler.sendTracingInfo` gate `journaled || rpc == null || notDelivered`;
+  journaling not ported — the RPC marker in this port is an `inbox.` reply address, and
+  `inbox::deliver` now reports delivery). Callback-style dispatch (a route `reply_to`,
+  e.g. Event Script tasks) keeps self-recording. **Span lineage** per the Java fixes
+  (04e5618f + 140640d8): `parent_span_id` = the caller's span from the outbound request,
+  unconditional; `span_id` = the callee's span from the reply, adopted **only from a
+  direct responder** (`span_id_from_responder`: the reply's `from` equals the requested
+  route) — a relayed reply (flow answering on behalf of the adapter route) keeps the
+  parent but omits the span it does not own. **Annotations now ride the reply envelope**
+  (new wire-compatible `annotations` field, also crossing Event-over-HTTP): the worker
+  attaches the function's `annotate_trace` values to its response and the caller folds
+  them into the span's single record, then strips them (Java
+  applyTraceContext/saveResponse). The programmatic `event_over_http` client stamps the
+  calling function's trace context (incl. its span) onto the wire envelope
+  (`apply_current_trace`, Java touch parity) so remote functions parent onto the
+  caller's span in BOTH patterns. Gated like Java: traced events only,
+  `skip.rpc.tracing` honored (shared helper with the worker's zero-trace resolution).
+  The reply envelope carries `set_round_trip` (Java `saveResponse` parity). Companion
+  fix: a zero-traced hop clears a nested reply's span id from its response instead of
+  leaking it (Java rebuilds the response envelope, so its reply never carries one).
+  Regressions: `rpc_telemetry_carries_span_lineage` (the Java
+  `PostOfficeTest.rpcTelemetryCarriesSpanLineage` twin),
+  `relayed_reply_does_not_donate_its_span_to_the_rpc_record` (the Java
+  `SpanPropagationTest` unique-span invariant), + rewritten lineage/zero-trace tests
+  asserting one-record-per-span. Live two-app acceptance drive (hello-flow →
+  hello-world, both patterns) verified at span level: no duplicate spans, no foreign
+  span ids on round_trip records, callee records parent onto the caller's task span in
+  both patterns.
 - **Event-over-HTTP demo endpoints in hello-flow** (now port **8100**, the structural
   parallel of the Java composable-example): `/api/event/http/demo` (declarative — flow
   task = the foreign alias route `hello.declarative` via `event-over-http.yaml` +
@@ -1799,7 +1818,7 @@ lock-step (Java references: mercury-composable commits `9f9050e1` log-context de
   event-over-http.md (zero-code demo walk-through, the programmatic twin, cross-language
   interop section — structurally mirrors the Java guide), hello-flow/hello-world READMEs,
   port sweep 8086→8100 across guides. CHANGELOG "Unreleased" section.
-- Workspace 243 / clippy 0 / fmt.
+- Workspace 244 / clippy 0 / fmt.
 
 ---
 

--- a/docs/guides/api-overview.md
+++ b/docs/guides/api-overview.md
@@ -257,7 +257,7 @@ po.annotate_trace("customer_tier", "gold")
 
 Attaches business context to the **application log** stream (Java `updateContext`): the
 key-value appears in the `context` block of every subsequent structured log line of this
-request (requires the optional `app-log-context.yaml`; see the
+request (the log context is on by default — see the
 [Configuration Reference](configuration-reference.md)). A null value removes the key. The
 reserved context keys (`cid`, `traceId`, `tracePath`, `spanId`, `parentSpanId`, `service`,
 `utc`) are rejected with status 400; outside a trace the call is a silent no-op.

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -244,7 +244,7 @@ flow file is compiled and validated at startup, before the HTTP server accepts a
 The flow YAML syntax is **identical to the Java engine's**, so flow files port unchanged —
 see the [flow grammar](event-script/flow-grammar.md) and the
 [syntax reference](event-script/syntax.md). The runnable example is `hello-flow`
-(port **8086**) in [Getting Started](getting-started.md).
+(port **8100**) in [Getting Started](getting-started.md).
 
 ## The knowledge graph stands on top of both
 

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -234,8 +234,21 @@ dispatch).
 
 Application log output format: `text` is a plain console line; `json` pretty-prints each
 record; `compact` emits single-line jsonl records (no CR/LF within a record). Both JSON
-forms carry the application log context block when `app-log-context.yaml` is present. Read
-by `crates/platform-core` (logging). Switch at launch with `-Dlog.format=json`.
+forms carry the application log context block (on by default — see `app.log.context`).
+Read by `crates/platform-core` (logging). Switch at launch with `-Dlog.format=json`.
+
+#### `app.log.context`
+
+| Type | Default |
+|---|---|
+| boolean | `true` |
+
+Turns the [application log context](observability.md#the-application-log-context) on or
+off. When on (the default), the structured JSON formats (`log.format=json` or `compact`)
+stamp a `context` block — correlation id, trace/span ids, service name — into every log
+line a traced function emits, using the built-in `default-log-context.yaml` template.
+Provide your own `app-log-context.yaml` on the resource path to replace the template, or
+set this key to `false` to opt out. Read by `crates/platform-core` (logging).
 
 #### `log.level`
 
@@ -253,14 +266,15 @@ by `crates/platform-core` (logging).
 
 | Type | Default |
 |---|---|
-| resource file | absent (feature off) |
+| resource file | absent (the built-in `default-log-context.yaml` applies) |
 
-When present on the resource path, every structured (JSON) log line emitted inside a traced
-function carries a `context` block. Its `context:` section maps an output key of your
-choice to a reserved `$token` (`$cid`, `$traceId`, `$tracePath`, `$spanId`,
-`$parentSpanId`, `$service`, `$utc` — resolved live per line), a `${ENV:default}`
-substitution (resolved once at load), or a literal. Keys that resolve to nothing are
-omitted. Business key-values added with `PostOffice::update_context` join the same block.
+Replaces the built-in log-context template entirely. Its `context:` section maps an
+output key of your choice to a reserved `$token` (`$cid`, `$traceId`, `$tracePath`,
+`$spanId`, `$parentSpanId`, `$service`, `$utc` — resolved live per line), a
+`${ENV:default}` substitution (resolved once at load), or a literal. Keys that resolve to
+nothing are omitted. Business key-values added with `PostOffice::update_context` join the
+same block. When this file is absent, the built-in default template (the seven standard
+trace-context keys) applies — see `app.log.context` above to switch the feature off.
 Read by `crates/platform-core` (logging).
 
 ## Actuators and health

--- a/docs/guides/event-driven/ai-agent-guide.md
+++ b/docs/guides/event-driven/ai-agent-guide.md
@@ -61,7 +61,7 @@ struct MyFunction;
 
 | Parameter | Type | Default | Notes |
 |:---|:---|:---|:---|
-| `route` | string | **required** | Unique; one route per struct. Dot-separated lowercase convention (`v1.my.function`). |
+| `route` | string | **required** | Unique. Dot-separated lowercase convention (`v1.my.function`). A comma-separated list registers the same function under several route names (aliases) with the same instances/visibility — Java parity: `route = "hello.world, hello.declarative"`. Empty segments are a compile error. |
 | `instances` | int | `1` | Concurrent workers. Production services typically use 10–100. |
 | `env_instances` | string | — | A key in the application configuration to read the worker count from at startup (the value may itself use `${SOME_ENV:default}` syntax); falls back to `instances`. |
 | `typed` | flag | off | The struct implements `TypedFunction<I, O>` instead of `ComposableFunction`; the engine bridges it with a `TypedAdapter`. |
@@ -69,7 +69,7 @@ struct MyFunction;
 | `interceptor` | flag | off | Event-interceptor mode: the function sees the raw incoming `EventEnvelope` and the engine does **not** auto-reply on success (failures still route to the caller). Also stackable as `#[event_interceptor]`. |
 | `is_private` | bool | `true` | Preloaded functions are **private by default** (in-instance only — Java `@PreLoad` parity); set `is_private = false` to make the function callable from another application instance through Event over HTTP. Everything inside the instance (REST automation, flows, graphs) reaches private functions normally. Programmatic pair: `platform.register_private(...)`; plain `register(...)` = public. |
 
-*(The Java engine's `isPrivate`, `inputPojoClass`, `customSerializer`, and
+*(The Java engine's `inputPojoClass`, `customSerializer`, and
 `inputStrategy`/`outputStrategy` parameters have no Rust equivalent — everything is process-local,
 and serde handles typing; see [Serialization](#serialization).)*
 
@@ -374,7 +374,7 @@ rest:
 
 ```bash
 # 4. Test (rest.server.port from resources/application.yml)
-curl -s -X POST http://127.0.0.1:8086/api/greeting \
+curl -s -X POST http://127.0.0.1:8100/api/greeting \
      -H "content-type: application/json" \
      -d '{"name": "Mercury"}'
 # → {"greeting": "Hello, Mercury!"}

--- a/docs/guides/event-over-http.md
+++ b/docs/guides/event-over-http.md
@@ -145,3 +145,190 @@ header.
     caller's own timeout. The Java engine loads the map at startup inside its
     `EventEmitter` singleton; this port has no such singleton, so the map loads once on
     first use — same configuration, same behavior.
+
+## Zero-code demo: hello-flow to hello-world
+
+The two example applications ship with a working declarative demo. The `hello-flow`
+example (port 8100) has a REST endpoint wired to an Event Script flow whose only task is
+the route `hello.declarative` — a route that does **not** exist in hello-flow. The
+`event-over-http.yaml` configuration tells the system where that route lives, and the
+platform makes the Event-over-HTTP call automatically. There is no orchestration or HTTP
+client code anywhere: the caller side is a flow definition plus two configuration entries,
+and the callee side is an ordinary public function.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as curl
+    participant C as hello-flow (8100)
+    participant L as hello-world (8085)
+    U->>C: POST /api/event/http/demo
+    Note over C: flow task "hello.declarative"<br/>route is not local — resolved<br/>via event-over-http.yaml
+    C->>L: POST /api/event<br/>(MsgPack envelope + trace context)
+    Note over L: hello.declarative echo<br/>(alias of hello.world)
+    L-->>C: result (body, headers, instance, origin)
+    C-->>U: HTTP 200 (JSON)
+```
+
+The moving parts:
+
+**Callee — hello-world (port 8085).** The `HelloWorld` echo function is public and
+registers two route names (a comma-separated alias list); the second exists for this demo:
+
+```rust
+#[preload(
+    route = "hello.world, hello.declarative",
+    instances = 10,
+    is_private = false
+)]
+struct HelloWorld;
+```
+
+**Caller — hello-flow (port 8100).** In `application.yml`, the declarative routing file is
+named and the peer address is externalized:
+
+```yaml
+yaml.event.over.http: 'classpath:/event-over-http.yaml'
+peer.demo.host: '127.0.0.1'
+peer.demo.port: 8085
+```
+
+`event-over-http.yaml` maps the foreign route to the peer's Event API endpoint:
+
+```yaml
+event.http:
+  - route: 'hello.declarative'
+    target: 'http://${peer.demo.host:127.0.0.1}:${peer.demo.port}/api/event'
+```
+
+and the REST endpoint `GET/POST /api/event/http/demo` (see `rest.yaml`) runs the flow
+`event-over-http-demo` whose task simply names the route:
+
+```yaml
+tasks:
+  - name: 'event-over-http-demo'
+    input:
+      - 'input.header -> header'
+      - 'input.body -> *'
+    process: 'hello.declarative'
+    output:
+      - 'text(application/json) -> output.header.content-type'
+      - 'result -> output.body'
+    description: 'Make an Event-over-Http call using the event-over-http.yaml configuration'
+    execution: end
+```
+
+### Step by step
+
+1. Start the callee in one terminal:
+
+    ```shell
+    cargo run -p hello-world
+    ```
+
+2. Start the caller in a second terminal:
+
+    ```shell
+    cargo run -p hello-flow
+    ```
+
+3. Hit the demo endpoint:
+
+    ```shell
+    curl -s -X POST -H "content-type: application/json" \
+         -d '{"hello": "world"}' http://127.0.0.1:8100/api/event/http/demo
+    ```
+
+4. The hello-world echo replies through the same path in reverse — the response arrives as
+   regular JSON:
+
+    ```json
+    {
+      "body": { "hello": "world" },
+      "headers": {
+        "x-event-api": "callback",
+        "x-flow-id": "event-over-http-demo",
+        "...": "..."
+      },
+      "instance": 4,
+      "origin": "5a309e1934c64ba0a7502062ec4dc393"
+    }
+    ```
+
+    The `origin` identifies the application instance that actually executed the function —
+    the hello-world app, not the app you called. The `x-event-api` header is the
+    recursion-guard marker stamped on the forwarded envelope; its presence tells you the
+    event crossed the wire declaratively.
+
+5. Look at both applications' logs: the trace context propagated across the HTTP hop
+   automatically. Both apps log telemetry under the **same trace id**, the
+   `hello.declarative` RPC record carries `span_id` and `parent_span_id` chaining it onto
+   the caller's flow, and — with the default-on
+   [application log context](observability.md#the-application-log-context) — every
+   structured log line on both sides is stamped with that trace id.
+
+### The programmatic twin
+
+The hello-flow example has a second endpoint, `/api/event/http/programmatic`, that reaches
+the **same peer function** through the programmatic pattern. Its flow task
+(`v1.event.over.http.rpc` in `examples/hello-flow/src/main.rs`) builds the peer's Event
+API endpoint URL from the same `peer.demo.host` / `peer.demo.port` properties and passes
+it directly to the request API — so `hello.world` needs **no entry** in
+`event-over-http.yaml`:
+
+```rust
+let endpoint = format!("http://{host}:{port}/api/event");
+let request = EventEnvelope::new().set_to("hello.world").set_raw_body(input.body().clone());
+let response = event_over_http(&po, &endpoint, request, Duration::from_secs(10), true).await?;
+```
+
+```shell
+curl -s -X POST -H "content-type: application/json" \
+     -d '{"hello": "world"}' http://127.0.0.1:8100/api/event/http/programmatic
+```
+
+The response has the same echo shape, and the trace continues across the hop the same way.
+This is why the echo function registers **two route names**: the programmatic endpoint
+calls the primary route `hello.world`, the declarative endpoint calls the alias
+`hello.declarative`. Choose declarative when the target address is deployment
+configuration (the usual case); choose programmatic when the code must compute or vary
+the target at runtime.
+
+!!! note "Port note"
+    Against the **Java** callee (lambda-example), the echoed headers also include Java's
+    worker-injected `my_route` header — `hello.world` for the programmatic call,
+    `hello.declarative` for the declarative one — directly naming the route that served
+    it. The Rust worker does not inject `my_route`; with the Rust callee, tell the
+    patterns apart by the endpoint you called or by the declarative marker
+    `x-event-api: callback` in the echoed headers.
+
+### Same demo, different language
+
+The canonical [Java implementation](https://github.com/Accenture/mercury-composable)
+ships counterpart examples: **lambda-example** is the parallel of hello-world (same port
+8085, same public `hello.world` / `hello.declarative` echo), and **composable-example**
+is the parallel of hello-flow (same port 8100, same two demo endpoints). That makes the
+demo above a cross-language demo with **zero changes**:
+
+1. Stop the Rust hello-world.
+2. Build and start the Java lambda-example from a clone of the Java repository
+   (`x.y.z` is the current version in its root `pom.xml`):
+
+    ```shell
+    cd examples/lambda-example
+    mvn clean package
+    java -jar target/lambda-example-x.y.z.jar
+    ```
+
+3. Run the same `curl` commands again — both demo endpoints now call Java.
+
+The response has the same shape — only the `origin` now identifies the Java application.
+The hello-flow example neither knows nor cares which language serves the route: it
+addresses a route name, the envelope travels in the language-neutral
+[standard wire format](event-envelope-reference.md), and the trace context continues
+across the language boundary.
+
+The mirror direction works the same way: the Java composable-example (port 8100) declares
+`hello.declarative` in its own `event-over-http.yaml` and can call the Rust hello-world —
+or the Java lambda-example — interchangeably. Point `peer.demo.host` / `peer.demo.port`
+at any peer that exposes the routes.

--- a/docs/guides/event-script/index.md
+++ b/docs/guides/event-script/index.md
@@ -168,7 +168,7 @@ the adapter reshapes the HTTP request into the flow's input dataset (`input.quer
 
 ```bash
 cargo run -p hello-flow
-curl 'http://127.0.0.1:8086/api/hello/eric?lang=fr'
+curl 'http://127.0.0.1:8100/api/hello/eric?lang=fr'
 ```
 
 ```json

--- a/docs/guides/event-script/syntax.md
+++ b/docs/guides/event-script/syntax.md
@@ -158,10 +158,10 @@ including ones from a library crate the app depends on — registers itself at s
 To test your new REST endpoint, flow configuration and function, please point your browser to
 
 ```text
-http://127.0.0.1:8086/api/greetings/my_name
+http://127.0.0.1:8100/api/greetings/my_name
 ```
 
-(8086 is `examples/hello-flow`'s `rest.server.port`; use your application's port.)
+(8100 is `examples/hello-flow`'s `rest.server.port`; use your application's port.)
 You can replace "my_name" with your first name to see the response to the browser.
 
 ## Flow configuration syntax

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -120,7 +120,7 @@ a static-content filter) is in
 
 ```bash
 cargo run -p hello-flow
-curl -s http://127.0.0.1:8086/api/hello/eric
+curl -s http://127.0.0.1:8100/api/hello/eric
 ```
 
 The endpoint binds to a **flow** instead of a function (`flow: 'hello-flow'` in its

--- a/docs/guides/macros-reference.md
+++ b/docs/guides/macros-reference.md
@@ -27,7 +27,7 @@ Registers a composable function at startup and binds it to a route — the Java
 
 | Parameter | Meaning |
 |---|---|
-| `route = "..."` | **Required.** The function's route name (lowercase, at least one dot). |
+| `route = "..."` | **Required.** The function's route name (lowercase, at least one dot). A **comma-separated list** registers the same function object under several route names (aliases) with the same instance count and visibility — the Java `@PreLoad(route = "hello.world, hello.declarative")` behavior. Names are whitespace-trimmed; an empty segment is a compile error. |
 | `instances = N` | Worker count, default `1`. |
 | `env_instances = "config.key"` | Read the worker count from application configuration at startup; the literal `instances` is the fallback. |
 | `typed` | The struct implements `TypedFunction<I, O>` instead of `ComposableFunction`. |
@@ -71,6 +71,20 @@ configured value when the key is set:
     instances = 2
 )]
 struct UntypedEcho;
+```
+
+A comma-separated `route` registers **aliases** — one function object serving several
+route names. The `hello-world` example publishes its echo under two names because the
+Event-over-HTTP demo calls it through two different patterns (see the
+[Event over HTTP guide](event-over-http.md)):
+
+```rust
+#[preload(
+    route = "hello.world, hello.declarative",
+    instances = 10,
+    is_private = false
+)]
+struct HelloWorld;
 ```
 
 An invalid route name fails the application at startup (a duplicate route RELOADS the

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -5,8 +5,8 @@ functions, flows, and graph nodes that never call each other directly. Observabi
 therefore not optional — it is the only way to see the causal path a request actually took.
 mercury answers this with a built-in distributed-tracing engine whose trace and span ids
 follow the **W3C Trace Context / OpenTelemetry** format, a real-time telemetry stream, and
-an opt-in log context that joins application logs to their spans. Everything on this page
-is verified against this repository's source and the running `hello-world` example.
+a default-on log context that joins application logs to their spans. Everything on this
+page is verified against this repository's source and the running `hello-world` example.
 
 ## Two ids, two concerns
 
@@ -112,10 +112,13 @@ present, your `annotations`:
 `status`, `success`, `exception`
 :   HTTP-style status code, a boolean verdict, and — only on failure — the error message.
 
-!!! note "Rust port"
-    The Java dataset additionally records a `round_trip` metric. The Rust port does not —
-    the requester reads the equivalent from the reply envelope's `exec_time`. Everything
-    else in the dataset shape is Java parity.
+A traced **RPC** produces a second record from the caller's side when the reply arrives —
+same shape, plus a `round_trip` metric (the full request/response cycle in milliseconds;
+the reply envelope carries the same value). Its span lineage chains like the worker's
+record: `span_id` is the callee's own span (carried on the reply) and `parent_span_id` is
+the caller's span — including across an Event-over-HTTP hop, which is what stitches a
+remote function's record into the calling application's span tree. Routes listed in
+`skip.rpc.tracing` (default `async.http.request`) are excluded (Java parity).
 
 By default the dataset is **logged** — that is the real-time telemetry stream. This is a
 real record from a `hello-world` run (`log.format: json`), emitted by `distributed.tracing`
@@ -216,11 +219,22 @@ log level comes from `log.level` (default `info`); a `RUST_LOG` environment vari
 ## The application log context
 
 Spans tell you the causal path; application logs tell you what happened inside each step.
-The log-context feature closes the gap: when an optional **`app-log-context.yaml`** is
-present on the resource path, every structured log line carries a `context` block —
-correlation id, trace/span ids, service name, and your own key-values — so you can pivot
-from a span in your backend straight to the log lines that belong to it. From
-`examples/hello-world/resources/app-log-context.yaml`:
+The log-context feature closes the gap: every structured log line carries a `context`
+block — correlation id, trace/span ids, service name, and your own key-values — so you
+can pivot from a span in your backend straight to the log lines that belong to it.
+
+The feature is **on by default**: platform-core ships a built-in
+`default-log-context.yaml` (embedded at compile time) that emits the standard trace
+context (`cid`, `traceId`, `tracePath`, `spanId`, `parentSpanId`, `service`,
+`timestamp`) on every structured log line. You can adjust it in two ways:
+
+- **Customize** — provide your own `app-log-context.yaml` on the resource path
+  (`resources/`); it replaces the built-in template entirely.
+- **Opt out** — set `app.log.context: false` in the application configuration.
+
+A custom template looks like this — from
+`examples/hello-world/resources/app-log-context.yaml`, which extends the standard set
+with two custom keys:
 
 ```yaml
 context:
@@ -283,7 +297,7 @@ the span join up in the backend, with the `user` key added by `update_context`:
 - Trace-bound context keys appear only on lines emitted **inside** a traced function
   execution; framework boot logs and work `tokio::spawn`ed from inside a function carry
   only the trace-independent keys — the same boundary the distributed trace has.
-- Feature off (no `app-log-context.yaml`) costs one boolean check per log line.
+- Feature off (`app.log.context: false`) costs one boolean check per log line.
 - The `text` format never renders a context block, whatever the configuration.
 
 ## See also

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -112,13 +112,20 @@ present, your `annotations`:
 `status`, `success`, `exception`
 :   HTTP-style status code, a boolean verdict, and — only on failure — the error message.
 
-A traced **RPC** produces a second record from the caller's side when the reply arrives —
-same shape, plus a `round_trip` metric (the full request/response cycle in milliseconds;
-the reply envelope carries the same value). Its span lineage chains like the worker's
-record: `span_id` is the callee's own span (carried on the reply) and `parent_span_id` is
-the caller's span — including across an Event-over-HTTP hop, which is what stitches a
-remote function's record into the calling application's span tree. Routes listed in
-`skip.rpc.tracing` (default `async.http.request`) are excluded (Java parity).
+**Exactly one record per span.** For an **RPC-served** execution the worker suppresses
+its own record when the reply reaches the caller, and the caller emits the span's single
+record when the reply arrives — same shape, plus a `round_trip` metric (the full
+request/response cycle in milliseconds; the reply envelope carries the same value) and
+the callee's `annotations`, which ride the reply envelope. Its span lineage chains like
+a worker-emitted record: `parent_span_id` is the caller's span, and `span_id` is the
+callee's own span — adopted only from a **direct responder** (the reply's `from` equals
+the requested route); a relayed reply (e.g. a flow answering on behalf of the
+flow-adapter route) keeps the parent but omits `span_id`, because the relaying
+function's span is reported by its own record. This works across an Event-over-HTTP hop
+too, which is what stitches a remote function's record into the calling application's
+span tree. **Callback**-style invocations (a `reply_to` that is a route, not an RPC
+inbox — e.g. Event Script task dispatch) keep self-recording from the worker. Routes
+listed in `skip.rpc.tracing` (default `async.http.request`) are excluded (Java parity).
 
 By default the dataset is **logged** — that is the real-time telemetry stream. This is a
 real record from a `hello-world` run (`log.format: json`), emitted by `distributed.tracing`

--- a/examples/hello-flow/Cargo.toml
+++ b/examples/hello-flow/Cargo.toml
@@ -12,3 +12,7 @@ event-script = { path = "../../crates/event-script" }
 async-trait = "0.1"
 serde_json = "1"
 log = "0.4"
+
+[dev-dependencies]
+rmpv = { version = "1", features = ["with-serde"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util"] }

--- a/examples/hello-flow/README.md
+++ b/examples/hello-flow/README.md
@@ -2,7 +2,7 @@
 
 Composable orchestration: the transaction lives in
 `resources/flows/hello-flow.yml` — a **flow** that routes by language and
-composes a greeting. The two Rust functions never call each other and never
+composes a greeting. The Rust functions never call each other and never
 see HTTP; the flow engine choreographs them by route name, and `rest.yaml`
 binds the endpoint to the flow with one line:
 
@@ -17,6 +17,11 @@ manager, task executor, HTTP adapter, resilience handler, 42 built-in
 plugins) through the same annotation inventory that collects the app's own
 functions — `main()` is still one line.
 
+This example is the structural parallel of the Java **composable-example**
+(same port **8100**, same demo endpoints) — it also ships the two
+[Event-over-HTTP demo endpoints](#the-event-over-http-demo-both-patterns)
+below.
+
 ## Run it
 
 ```bash
@@ -24,9 +29,9 @@ cargo run -p hello-flow
 ```
 
 The startup log shows the layered boot: the plugin loader (sequence 3) → the
-flow compiler (sequence 5, `Event scripts deployed: 1`) → preloaded functions
-→ REST automation on port **8086** → the main application announcing
-`Flows ready: ["hello-flow"]`.
+flow compiler (sequence 5, `Event scripts deployed: 3`) → preloaded functions
+→ REST automation on port **8100** → the main application announcing
+`Flows ready: [...]`.
 
 ## Test drive
 
@@ -34,10 +39,10 @@ flow compiler (sequence 5, `Event scripts deployed: 1`) → preloaded functions
 greeting path:
 
 ```bash
-curl 'http://127.0.0.1:8086/api/hello/eric?lang=fr'
+curl 'http://127.0.0.1:8100/api/hello/eric?lang=fr'
 # {"cid":"...","handled_by_instance":N,"message":"Bonjour, eric!","served_by":"hello-flow"}
 
-curl 'http://127.0.0.1:8086/api/hello/eric?lang=en'
+curl 'http://127.0.0.1:8100/api/hello/eric?lang=en'
 # {"cid":"...","message":"Hello, eric!",...}
 ```
 
@@ -46,7 +51,7 @@ becomes the flow's `model.cid`, which the flow maps into the greeting
 function's input; the response proves the id survived the whole transaction:
 
 ```bash
-curl -H 'X-Correlation-Id: order-777' 'http://127.0.0.1:8086/api/hello/eric?lang=en'
+curl -H 'X-Correlation-Id: order-777' 'http://127.0.0.1:8100/api/hello/eric?lang=en'
 # {"cid":"order-777", ...}
 ```
 
@@ -59,19 +64,60 @@ and its timing).
 everything below:
 
 ```bash
-curl 'http://127.0.0.1:8086/'          # or open it in a browser
+curl 'http://127.0.0.1:8100/'          # or open it in a browser
 ```
 
 **Actuators** — `/health` runs the sample `flow.engine.health` dependency,
 which reports on the flow engine itself (healthy while flows are deployed):
 
 ```bash
-curl 'http://127.0.0.1:8086/info'
-curl 'http://127.0.0.1:8086/env'       # the properties selected in application.yml
-curl 'http://127.0.0.1:8086/health'
-# {"dependency":[{"message":"flow engine is running with 1 flow deployed",...}],"status":"UP"}
-curl 'http://127.0.0.1:8086/livenessprobe'
+curl 'http://127.0.0.1:8100/info'
+curl 'http://127.0.0.1:8100/env'       # the properties selected in application.yml
+curl 'http://127.0.0.1:8100/health'
+# {"dependency":[{"message":"flow engine is running with 3 flows deployed",...}],"status":"UP"}
+curl 'http://127.0.0.1:8100/livenessprobe'
 ```
+
+## The Event-over-HTTP demo (both patterns)
+
+Two endpoints call the **same peer function** in another application through
+the two Event-over-HTTP patterns. The callee is the `hello-world` example —
+or, interchangeably, the Java `lambda-example`: both listen on port **8085**
+and register the same public echo under two route names
+(`hello.world, hello.declarative`). Start the callee in another terminal:
+
+```bash
+cargo run -p hello-world      # or the Java lambda-example — same port, same routes
+```
+
+**Declarative** (zero code — the target address is deployment configuration):
+the flow's task is the foreign route `hello.declarative`, which does not
+exist here; `resources/event-over-http.yaml` resolves it to the peer's
+`/api/event` endpoint and the call crosses the wire automatically.
+
+```bash
+curl -s -X POST -H 'content-type: application/json' \
+     -d '{"hello":"world"}' http://127.0.0.1:8100/api/event/http/demo
+```
+
+**Programmatic** (the code computes the target at runtime): the flow's task
+`v1.event.over.http.rpc` builds the peer's URL from `peer.demo.host` /
+`peer.demo.port` and passes it directly to the request API — so its target
+route `hello.world` needs **no** entry in `event-over-http.yaml`.
+
+```bash
+curl -s -X POST -H 'content-type: application/json' \
+     -d '{"hello":"world"}' http://127.0.0.1:8100/api/event/http/programmatic
+```
+
+Both replies echo the body, headers, worker instance and the **callee's**
+`origin` id — proof the function ran in the other application. Watch the
+`distributed.tracing` records on both terminals: one continuous trace, with
+the callee's span chained onto the caller's task span across the HTTP hop.
+Point `peer.demo.host`/`peer.demo.port` at any peer that exposes the routes —
+the Java and Rust callees are drop-in replacements for each other, which is
+the point of the demo. The full walk-through (including the cross-language
+angle) is in the docs site's *Event over HTTP* guide.
 
 ## Change the transaction without touching code
 
@@ -85,9 +131,13 @@ orchestration is configuration.
 
 | File | Role |
 |---|---|
-| `src/main.rs` | two composable functions + the one-line main |
+| `src/main.rs` | the composable functions + the one-line main |
 | `resources/flows/hello-flow.yml` | **the transaction** (decision + 2 end tasks) |
+| `resources/flows/event-over-http-demo.yml` | the declarative Event-over-HTTP demo flow |
+| `resources/flows/event-over-http-programmatic.yml` | the programmatic Event-over-HTTP demo flow |
+| `resources/event-over-http.yaml` | the declarative route → peer mapping |
 | `resources/flows.yaml` | which flows to compile at startup |
-| `resources/rest.yaml` | the endpoint → flow binding |
-| `resources/application.yml` | app name, port, health dependency, /env selections |
+| `resources/rest.yaml` | the endpoint → flow bindings |
+| `resources/application.yml` | app name, port, peer address, health dependency |
 | `resources/public/index.html` | the static landing page |
+| `tests/event_over_http_demo.rs` | loopback e2e test of both demo endpoints |

--- a/examples/hello-flow/resources/application.yml
+++ b/examples/hello-flow/resources/application.yml
@@ -1,11 +1,19 @@
 # hello-flow example — event-script (layer 2) riding platform-core (layer 1).
+# The structural parallel of the Java composable-example (same port 8100).
 application.name: hello-flow
 
 # REST automation serves rest.yaml; the flow engine loads flows.yaml — both
 # by their default locations in this resources/ folder.
 rest.automation: true
-rest.server.port: 8086
+rest.server.port: 8100
 
 info.app.description: 'mercury hello-flow example (event-script)'
 show.application.properties: 'application.name, rest.server.port'
 mandatory.health.dependencies: 'flow.engine.health'
+
+# Event-over-HTTP demo peer (the callee of both demo endpoints): the Rust
+# hello-world example or the Java lambda-example — both serve port 8085 with
+# the same public routes, so they are interchangeable.
+yaml.event.over.http: 'classpath:/event-over-http.yaml'
+peer.demo.host: '127.0.0.1'
+peer.demo.port: 8085

--- a/examples/hello-flow/resources/event-over-http.yaml
+++ b/examples/hello-flow/resources/event-over-http.yaml
@@ -1,0 +1,8 @@
+# Declarative Event-over-HTTP routing (the caller side of the demo): the
+# foreign route below does NOT exist in this application — every PostOffice
+# call to it forwards transparently to the peer's /api/event endpoint.
+# Compare with the programmatic demo endpoint, whose task passes the peer's
+# URL directly to the request API and therefore needs no entry here.
+event.http:
+  - route: 'hello.declarative'
+    target: 'http://${peer.demo.host:127.0.0.1}:${peer.demo.port}/api/event'

--- a/examples/hello-flow/resources/flows.yaml
+++ b/examples/hello-flow/resources/flows.yaml
@@ -1,4 +1,6 @@
 flows:
   - 'hello-flow.yml'
+  - 'event-over-http-demo.yml'
+  - 'event-over-http-programmatic.yml'
 
 location: 'classpath:/flows/'

--- a/examples/hello-flow/resources/flows/event-over-http-demo.yml
+++ b/examples/hello-flow/resources/flows/event-over-http-demo.yml
@@ -1,0 +1,36 @@
+#
+# The DECLARATIVE Event-over-HTTP demo: the task below names the route
+# 'hello.declarative', which does not exist in this application — the
+# event-over-http.yaml configuration resolves it to the peer's /api/event
+# endpoint and the call crosses the wire automatically. Zero orchestration
+# or HTTP client code.
+#
+flow:
+  id: 'event-over-http-demo'
+  description: 'Demonstrate Event-over-Http protocol using declarative means'
+  ttl: 10s
+  exception: 'v1.hello.exception'
+
+first.task: 'event-over-http-demo'
+
+tasks:
+  - name: 'event-over-http-demo'
+    input:
+      - 'input.header -> header'
+      - 'input.body -> *'
+    process: 'hello.declarative'
+    output:
+      - 'text(application/json) -> output.header.content-type'
+      - 'result -> output.body'
+    description: 'Make an Event-over-Http call using the event-over-http.yaml configuration'
+    execution: end
+
+  - input:
+      - 'error.code -> status'
+      - 'error.message -> message'
+    process: 'v1.hello.exception'
+    output:
+      - 'result.status -> output.status'
+      - 'result -> output.body'
+    description: 'Just a demo exception handler'
+    execution: end

--- a/examples/hello-flow/resources/flows/event-over-http-programmatic.yml
+++ b/examples/hello-flow/resources/flows/event-over-http-programmatic.yml
@@ -1,0 +1,35 @@
+#
+# The PROGRAMMATIC Event-over-HTTP demo: the task is an ordinary composable
+# function (v1.event.over.http.rpc) that passes the peer's /api/event URL
+# directly to the request API — so its target route 'hello.world' needs NO
+# entry in event-over-http.yaml. Compare with event-over-http-demo.yml,
+# which reaches the same peer function declaratively via its alias route.
+#
+flow:
+  id: 'event-over-http-programmatic'
+  description: 'Demonstrate Event-over-Http protocol using programmatic means'
+  ttl: 10s
+  exception: 'v1.hello.exception'
+
+first.task: 'v1.event.over.http.rpc'
+
+tasks:
+  - input:
+      - 'input.header -> header'
+      - 'input.body -> *'
+    process: 'v1.event.over.http.rpc'
+    output:
+      - 'text(application/json) -> output.header.content-type'
+      - 'result -> output.body'
+    description: 'Make an Event-over-Http call using the PostOffice request API'
+    execution: end
+
+  - input:
+      - 'error.code -> status'
+      - 'error.message -> message'
+    process: 'v1.hello.exception'
+    output:
+      - 'result.status -> output.status'
+      - 'result -> output.body'
+    description: 'Just a demo exception handler'
+    execution: end

--- a/examples/hello-flow/resources/rest.yaml
+++ b/examples/hello-flow/resources/rest.yaml
@@ -1,4 +1,4 @@
-# One declarative endpoint bound to a FLOW (not a function): REST automation
+# Declarative endpoints bound to FLOWS (not functions): REST automation
 # injects the x-flow-id header and http.flow.adapter launches the flow.
 rest:
   - service: "http.flow.adapter"
@@ -6,4 +6,22 @@ rest:
     url: "/api/hello/{user}"
     flow: 'hello-flow'
     timeout: 10s
+    tracing: true
+
+  # Event-over-HTTP demo, DECLARATIVE pattern: the flow's task is the foreign
+  # route 'hello.declarative', resolved through event-over-http.yaml
+  - service: "http.flow.adapter"
+    methods: ['GET', 'POST']
+    url: "/api/event/http/demo"
+    flow: 'event-over-http-demo'
+    timeout: 15s
+    tracing: true
+
+  # Event-over-HTTP demo, PROGRAMMATIC pattern: the flow's task passes the
+  # peer's /api/event URL directly to the PostOffice request API
+  - service: "http.flow.adapter"
+    methods: ['GET', 'POST']
+    url: "/api/event/http/programmatic"
+    flow: 'event-over-http-programmatic'
+    timeout: 15s
     tracing: true

--- a/examples/hello-flow/src/main.rs
+++ b/examples/hello-flow/src/main.rs
@@ -15,23 +15,32 @@
 //
 
 //! The event-script taste of mercury: the transaction lives in
-//! `resources/flows/hello-flow.yml` — the two functions below are the only
-//! code, and neither knows the other exists (route-name + envelope coupling
+//! `resources/flows/hello-flow.yml` — the functions below are the only
+//! code, and none knows the others exist (route-name + envelope coupling
 //! only). Linking the `event-script` crate self-registers the flow engine
 //! through the annotation inventory; `rest.yaml` binds the endpoint to the
 //! flow with `flow: 'hello-flow'`.
 //!
+//! This example is the structural parallel of the Java `composable-example`
+//! (same port 8100, same demo endpoints). Besides the greeting flow, it
+//! ships the two **Event-over-HTTP demo endpoints** — see `README.md` and
+//! the Event over HTTP guide — whose callee is the `hello-world` example
+//! (or, interchangeably, the Java `lambda-example`) on port 8085.
+//!
 //! ```bash
 //! cargo run -p hello-flow
-//! curl 'http://127.0.0.1:8086/api/hello/eric?lang=fr'
-//! curl 'http://127.0.0.1:8086/api/hello/eric?lang=en'
+//! curl 'http://127.0.0.1:8100/api/hello/eric?lang=fr'
+//! curl 'http://127.0.0.1:8100/api/hello/eric?lang=en'
 //! ```
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use async_trait::async_trait;
+use platform_core::automation::event_over_http;
 use platform_core::{
-    main_application, preload, AppError, ComposableFunction, EntryPoint, EventEnvelope,
+    main_application, preload, AppConfigReader, AppError, ComposableFunction, EntryPoint,
+    EventEnvelope, Platform, PostOffice,
 };
 
 /// Decision task: French when `lang=fr`, English otherwise.
@@ -75,6 +84,80 @@ impl ComposableFunction for GreetingComposer {
                 "handled_by_instance": instance,
                 "served_by": "hello-flow",
             }))
+    }
+}
+
+/// The PROGRAMMATIC Event-over-HTTP demo task (the Rust twin of the Java
+/// composable-example's `EventOverHttpRpc`): calls the peer's `hello.world`
+/// function by passing the peer's Event API endpoint URL directly to the
+/// request API. Because the target address is given programmatically,
+/// `hello.world` does NOT appear in `event-over-http.yaml` — compare with
+/// `hello.declarative` (an alias of the same peer function), which is
+/// resolved through that configuration file instead. The two REST endpoints
+/// `/api/event/http/programmatic` and `/api/event/http/demo` therefore hit
+/// the same peer function through the two different patterns.
+#[preload(route = "v1.event.over.http.rpc", instances = 10)]
+struct EventOverHttpRpc;
+
+#[async_trait]
+impl ComposableFunction for EventOverHttpRpc {
+    async fn handle_event(
+        &self,
+        headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let config = AppConfigReader::get_instance();
+        let host = config.get_property_or("peer.demo.host", "127.0.0.1");
+        let port = config.get_property_or("peer.demo.port", "8085");
+        let endpoint = format!("http://{host}:{port}/api/event");
+        let mut request = EventEnvelope::new()
+            .set_to("hello.world")
+            .set_raw_body(input.body().clone());
+        for (key, value) in &headers {
+            request = request.set_header(key, value);
+        }
+        let po = PostOffice::new(&Platform::get_instance());
+        let response =
+            event_over_http(&po, &endpoint, request, Duration::from_secs(10), true).await?;
+        if response.status() != 200 {
+            // surface the remote error to the flow's exception handler
+            return Err(AppError::new(
+                response.status(),
+                response
+                    .body_as::<String>()
+                    .unwrap_or_else(|_| response.body().to_string()),
+            ));
+        }
+        Ok(EventEnvelope::new().set_raw_body(response.body().clone()))
+    }
+}
+
+/// A demo exception handler for the two Event-over-HTTP flows: formats the
+/// flow engine's error dataset (`error.code`, `error.message`) as the HTTP
+/// response (the Java composable-example's `v1.hello.exception` analog).
+#[preload(route = "v1.hello.exception")]
+struct HelloException;
+
+#[async_trait]
+impl ComposableFunction for HelloException {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let body: serde_json::Value = input.body_as().unwrap_or(serde_json::Value::Null);
+        let status = body["status"].as_i64().unwrap_or(500);
+        log::warn!(
+            "demo exception handler: status={status}, message={}",
+            body["message"]
+        );
+        EventEnvelope::new().set_body(serde_json::json!({
+            "type": "error",
+            "status": status,
+            "message": body["message"],
+        }))
     }
 }
 
@@ -125,7 +208,7 @@ struct HelloFlowApp;
 impl EntryPoint for HelloFlowApp {
     async fn start(&self, _args: &[String]) -> Result<(), AppError> {
         log::info!(
-            "Flows ready: {:?} — try: curl 'http://127.0.0.1:8086/api/hello/eric?lang=fr'",
+            "Flows ready: {:?} — try: curl 'http://127.0.0.1:8100/api/hello/eric?lang=fr'",
             event_script::flows::get_all_flows()
         );
         Ok(())

--- a/examples/hello-flow/tests/event_over_http_demo.rs
+++ b/examples/hello-flow/tests/event_over_http_demo.rs
@@ -1,0 +1,147 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! End-to-end coverage of the two Event-over-HTTP demo endpoints — the Rust
+//! twin of the Java composable-example's `EventOverHttpDemoTest`. The test
+//! points `peer.demo.host`/`peer.demo.port` back at this test server, so both
+//! patterns make a REAL HTTP hop through `/api/event` and land on the public
+//! echo functions registered below — the same wiring as the live demo against
+//! the `hello-world` example (or the Java lambda-example), but self-contained
+//! in one process. The loopback is legitimate: the declarative map is
+//! consulted before local discovery, and the inbound `/api/event` delivery
+//! carries the `x-event-api` recursion guard, so the hop still crosses the
+//! wire exactly once.
+//!
+//! One test function on purpose: the app boots ONCE per process (AutoStart is
+//! a run-once lifecycle) and the declarative registry is a process-wide
+//! one-shot load, so both endpoints are exercised in a single sequential run.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use platform_core::{
+    automation, overrides, AppError, AutoStart, ComposableFunction, EventEnvelope, Platform,
+};
+use rmpv::Value;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+// The application under test is a BIN crate (examples are standalone
+// applications, not libraries), so its annotated items are not linkable as a
+// dependency — include its source so the link-time inventory in this test
+// binary carries the app's functions, flows adapter and main application.
+#[allow(dead_code)]
+#[path = "../src/main.rs"]
+mod app;
+
+/// Stand-in for the hello-world example's public echo (`hello.world` and its
+/// alias `hello.declarative`) — body, headers, instance, origin.
+struct Echo;
+
+#[async_trait]
+impl ComposableFunction for Echo {
+    async fn handle_event(
+        &self,
+        headers: HashMap<String, String>,
+        input: EventEnvelope,
+        instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let echo_headers = Value::Map(
+            headers
+                .iter()
+                .map(|(k, v)| (Value::from(k.as_str()), Value::from(v.as_str())))
+                .collect(),
+        );
+        Ok(EventEnvelope::new().set_raw_body(Value::Map(vec![
+            (Value::from("body"), input.body().clone()),
+            (Value::from("headers"), echo_headers),
+            (Value::from("instance"), Value::from(instance as u64)),
+            (Value::from("origin"), Value::from(Platform::origin())),
+        ])))
+    }
+}
+
+/// Minimal raw HTTP/1.1 POST (no client dependency).
+async fn http_post(port: u16, path: &str, body: &str) -> (u16, String) {
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("connect");
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: localhost\r\ncontent-type: application/json\r\n\
+         accept: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(request.as_bytes()).await.expect("write");
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).await.expect("read");
+    let text = String::from_utf8_lossy(&raw).to_string();
+    let (head, payload) = text.split_once("\r\n\r\n").unwrap_or((text.as_str(), ""));
+    let status: u16 = head
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse().ok())
+        .unwrap_or_else(|| panic!("status code missing in: {text:?}"));
+    (status, payload.to_string())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn both_event_over_http_demo_endpoints_round_trip() {
+    let holding = std::env::temp_dir().join(format!("hello-flow-demo-{}", std::process::id()));
+    overrides::set("transient.data.store", &holding.display().to_string());
+    // an ephemeral port; the peer address is set to the SAME server below
+    overrides::set("rest.server.port", "0");
+    // boot the whole application: flow compiler, preloaded functions, REST
+    AutoStart::main(vec![]).await.expect("app lifecycle");
+    let port = automation::server_address().expect("server started").port();
+    // loop the demo peer back to this very server — ${peer.demo.port} in
+    // event-over-http.yaml resolves when the declarative registry first
+    // loads, which happens on the first mapped PostOffice call below
+    overrides::set("peer.demo.host", "127.0.0.1");
+    overrides::set("peer.demo.port", &port.to_string());
+    // the public echo functions the live demo finds in the hello-world app
+    let platform = Platform::get_instance();
+    platform.register("hello.world", Arc::new(Echo), 5).unwrap();
+    platform
+        .register("hello.declarative", Arc::new(Echo), 5)
+        .unwrap();
+
+    // PROGRAMMATIC pattern: flow task passes the peer URL to the request API
+    let (status, body) = http_post(
+        port,
+        "/api/event/http/programmatic",
+        "{\"hello\":\"world\"}",
+    )
+    .await;
+    assert_eq!(status, 200, "programmatic demo body: {body}");
+    let response: serde_json::Value = serde_json::from_str(&body).expect("json");
+    assert_eq!(response["body"]["hello"], serde_json::json!("world"));
+    assert_eq!(response["origin"], serde_json::json!(Platform::origin()));
+
+    // DECLARATIVE pattern: flow task names the foreign route, resolved
+    // through event-over-http.yaml — zero code
+    let (status, body) = http_post(port, "/api/event/http/demo", "{\"hello\":\"world\"}").await;
+    assert_eq!(status, 200, "declarative demo body: {body}");
+    let response: serde_json::Value = serde_json::from_str(&body).expect("json");
+    assert_eq!(response["body"]["hello"], serde_json::json!("world"));
+    assert_eq!(response["origin"], serde_json::json!(Platform::origin()));
+    // the declarative hop is marked by the recursion-guard header; the
+    // programmatic hop carries no marker — the wire crossed exactly once
+    assert_eq!(
+        response["headers"]["x-event-api"],
+        serde_json::json!("callback")
+    );
+}

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -80,6 +80,14 @@ curl -s -o /dev/null -w '%{http_code}\n' -H "If-None-Match: $ETAG" \
 Or just open <http://127.0.0.1:8085/> in a browser and refresh — the second
 load revalidates with 304.
 
+**The Event-over-HTTP interop target** — the app publishes a public echo
+function under two route names (`hello.world, hello.declarative` — a
+comma-separated alias list, one shared handler). It is the standing callee
+of the `hello-flow` example's two Event-over-HTTP demo endpoints, and the
+drop-in counterpart of the Java `lambda-example` (same port 8085, same
+routes) — so the demo doubles as a cross-language interop demo. See the
+hello-flow README and the docs site's *Event over HTTP* guide.
+
 Stop with Ctrl-C (graceful shutdown cleans the elastic store).
 
 ## Where things live

--- a/examples/hello-world/resources/app-log-context.yaml
+++ b/examples/hello-world/resources/app-log-context.yaml
@@ -1,5 +1,9 @@
-# Optional application log context (increment 5): when this file is present,
-# every structured (JSON) log line emitted inside a traced function carries a
+# Application log context override: the feature is ON by default with the
+# platform's built-in default-log-context.yaml (the standard trace context).
+# Providing this file REPLACES that template entirely — this example adds two
+# custom keys on top of the standard set. Opt out with app.log.context=false.
+#
+# Every structured (JSON) log line emitted inside a traced function carries a
 # "context" block, so logs and spans join up in the observability backend.
 #
 # left side  = output key (your choice)

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -153,6 +153,17 @@ impl ComposableFunction for GreetingApi {
 /// publishes the route to remote callers via Event over HTTP
 /// (`POST /api/event`); every other function here keeps the private default.
 ///
+/// The function registers TWO route names (a comma-separated alias list,
+/// Java `@PreLoad` parity) because it is the standing Event-over-HTTP
+/// interop target of the demo pair: the Rust `hello-flow` example (or the
+/// Java `composable-example`) calls `hello.world` through the PROGRAMMATIC
+/// pattern (the caller passes this app's `/api/event` URL to the request
+/// API) and `hello.declarative` through the DECLARATIVE pattern (the route
+/// is resolved via the caller's `event-over-http.yaml`). Both examples run
+/// on port 8085 with the same route names, so the Java and Rust callees are
+/// drop-in replacements for each other — that interchangeability is the
+/// point of the demo.
+///
 /// The body is reflected as the raw MsgPack value, never through a JSON
 /// detour — JSON has no byte type, so converting would silently drop binary
 /// values from the echo (found by the cross-language interop matrix).
@@ -160,7 +171,11 @@ impl ComposableFunction for GreetingApi {
 /// An optional integer body key `sleep_ms` delays the reply by that many
 /// milliseconds — the cross-language interop matrix uses it to exercise the
 /// RPC-timeout (408) path (e.g. `sleep_ms: 3000` against `x-ttl: 1500`).
-#[preload(route = "hello.world", instances = 10, is_private = false)]
+#[preload(
+    route = "hello.world, hello.declarative",
+    instances = 10,
+    is_private = false
+)]
 struct HelloWorld;
 
 #[async_trait]

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-22 | agent: Claude Code (2026-07-22-025232)
+- **last_session:** 2026-07-23 | agent: Claude Code (2026-07-23-005048)
 - **last_review:** 2026-07-21 | through 2026-07-21-214043
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -560,7 +560,22 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   function must be declared `is_private = false`). MAINTAINER DIRECTIVES: private-by-
   default = the encapsulation boundary is the app instance (functions cross it only via
   deliberate is_private = false exposure); the /api/event endpoint ships in the DEFAULT
-  rest.yaml (merge_default_endpoints, like the actuators — zero user configuration).** → serves: vision-mercury
+  rest.yaml (merge_default_endpoints, like the actuators — zero user configuration).**
+  **UPDATE 2026-07-22/23: increments 59–62 MERGED as PR #166 (merge `e36e5dc5`). Increment
+  63 (Java-parity batch pre-4.10) IMPLEMENTED on branch `feature/parity-log-context-aliases`
+  (3 commits `9dd64126`/`91347823`/`98644826`, NOT pushed — Eric pushes/opens the PR):
+  `#[preload]` comma-separated route aliases; app-log-context ON by default (built-in
+  `default-log-context.yaml` via include_str! + `app.log.context` switch — Java 9f9050e1
+  mirror); caller-side RPC `round_trip` record with span lineage (Java 04e5618f mirror —
+  the port previously emitted NO RPC record at all; companion fix: a zero-traced hop no
+  longer leaks a nested reply's span); hello-flow 8086→8100 + the two Event-over-HTTP demo
+  endpoints (declarative `/api/event/http/demo` + programmatic
+  `/api/event/http/programmatic`, loopback e2e + live two-app cross-app span-tree
+  verification); docs walk-through mirrors the Java guide. Workspace 243/clippy 0/fmt.
+  Follow-up candidates: port Java's worker-injected `my_route` header (docs claim scoped
+  honestly meanwhile); the Java demo flows' `output.body.content-type` mapping looks like
+  a typo (flagged to Eric). See session 2026-07-23-005048.**
+  → serves: vision-mercury
   <!-- id: ot-event-over-http | created: 2026-07-21 | last_used: 2026-07-22 | uses: 3 | tier: working | origin: 2026-07-21-233234.md -->
 
 - [ ] **(knowledge-harvest) Harvest the canonical vision/specs from mercury-composable (Java).**

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.9.0**: tracks the canonical mercury-composable line (Java 4.9.0 released the same day — one version, two languages).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-23 | agent: Claude Code (2026-07-23-005048)
+- **last_session:** 2026-07-23 | agent: Claude Code (2026-07-23-013514)
 - **last_review:** 2026-07-21 | through 2026-07-21-214043
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -574,7 +574,16 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   verification); docs walk-through mirrors the Java guide. Workspace 243/clippy 0/fmt.
   Follow-up candidates: port Java's worker-injected `my_route` header (docs claim scoped
   honestly meanwhile); the Java demo flows' `output.body.content-type` mapping looks like
-  a typo (flagged to Eric). See session 2026-07-23-005048.**
+  a typo (flagged to Eric). See session 2026-07-23-005048. **TELEMETRY FIX ROUND
+  2026-07-23 (commit `8328d720`, same branch — Eric's interop drives on PR #167 surfaced
+  three findings, all fixed + span-level acceptance PASSED): I1 exactly ONE record per
+  span (worker suppresses its record for a delivered RPC — Java sendTracingInfo gate;
+  RPC marker = inbox reply address; annotations now ride the reply envelope, a new
+  wire-compatible field, and fold into the caller's record); I2 round_trip span_id only
+  from a DIRECT responder (reply.from == requested route — Java spanIdFromResponder
+  140640d8; relayed flow replies keep parent, omit span); I3 programmatic
+  event_over_http stamps the caller's trace/span on the wire envelope (apply_current_
+  trace at client entry). Workspace 244/clippy 0/fmt. See session 2026-07-23-013514.**
   → serves: vision-mercury
   <!-- id: ot-event-over-http | created: 2026-07-21 | last_used: 2026-07-22 | uses: 3 | tier: working | origin: 2026-07-21-233234.md -->
 

--- a/memory/sessions/2026-07-23-005048.md
+++ b/memory/sessions/2026-07-23-005048.md
@@ -1,0 +1,89 @@
+# Session (2026-07-23T00:51:49.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Increment 63 — Java-parity batch before the 4.10 line** (Eric's request: seven
+feature-gap fixes so the Rust port matches the Java repo pre-release). Branch
+`feature/parity-log-context-aliases`, three logical commits (`9dd64126` platform-core,
+`91347823` examples, `98644826` docs). NOT pushed — Eric pushes/opens the PR. Java
+references: mercury-composable `9f9050e1` (log-context default-on), `04e5618f` (RPC span
+lineage), `ca3fb4a7`/`78b6b252`/`ffb45ff1` (interop demo pair + docs).
+
+1. **`#[preload]` route aliases** — `route = "a.b, c.d"` registers the SAME function
+   object (one `Arc`, cloned per name) under every comma-separated name with the same
+   instances/visibility; macro rejects empty segments at compile time
+   (`validate_route_list` + unit tests); `AutoStart::main` splits (Java
+   `AppStarter.registerFunctionWithRoutes` parity). Runtime test in `annotations.rs`
+   (both aliases callable, one shared handler, same instances/privacy).
+2. **App-log-context ON by default** — Java `loadConfigFile` order: `app.log.context`
+   switch (default true) → app's own `app-log-context.yaml` (replaces entirely) →
+   built-in `default-log-context.yaml` (7 standard trace tokens). Built-in ships as
+   `crates/platform-core/resources/default-log-context.yaml` embedded via `include_str!`
+   — the Rust mirror of Java's distinct-filename defense (classpath shadowing);
+   new `ConfigReader::from_yaml_text` for embedded templates. hello-world's override
+   file keeps working (comment updated to "replaces the default"). Unit test covers
+   default-on / opt-out / app-file-override sequentially (global state).
+3. **RPC telemetry (Item 3 finding: gap WIDER than Java's)** — the Rust port emitted NO
+   caller-side `round_trip` record at all (the lightweight oneshot inbox had no
+   telemetry). Implemented Java `InboxBase.recordTrace` in
+   `PostOffice::request_direct`: traced RPCs record to `distributed.tracing` with
+   **span lineage per the Java fix** (`span_id` = callee's span from the reply,
+   `parent_span_id` = caller's span from the outbound request), honoring
+   `skip.rpc.tracing` (helper shared with the worker's zero-trace resolution) and
+   suppressed inside a zero-traced bracket (Java-equivalent: such events carry no trace).
+   Reply envelope now carries `set_round_trip` (Java `saveResponse`). **Companion fix
+   found by the tests:** a zero-traced relay returning a nested reply leaked the inner
+   span id on its response — the worker now clears it (Java rebuilds the response
+   envelope, so no leak is possible there). Regression
+   `rpc_telemetry_carries_span_lineage` (Java `rpcTelemetryCarriesSpanLineage` twin).
+4. **Demo endpoints (items 4+7)** — hello-flow (now **port 8100**, composable-example
+   parallel): `/api/event/http/demo` (declarative — foreign route `hello.declarative`
+   via `event-over-http.yaml` + `peer.demo.host`/`peer.demo.port`) and
+   `/api/event/http/programmatic` (task `v1.event.over.http.rpc` passes the peer URL to
+   `event_over_http` — Java `EventOverHttpRpc` twin; + `v1.hello.exception` handler).
+   hello-world echo = `hello.world, hello.declarative` public aliases; drop-in
+   interchangeable with the Java lambda-example (8085). Loopback e2e test
+   (`EventOverHttpDemoTest` twin) — peer.demo.* points at the test server; the app is a
+   bin crate, so the test links the app source via `#[path] mod app` to reach the
+   annotation inventory. **Live two-app verification passed**: both endpoints returned
+   the callee's origin; one continuous cross-app span tree (callee round_trip records
+   chained span_id/parent_span_id onto the caller's task spans across the HTTP hop).
+5. **Port sweep 8086→8100** across README/guides (INCREMENTS history left intact; the
+   ledger gains §63 instead). NOTE: hello-flow now shares port 8100 with
+   minigraph-playground (run one at a time) — same family-collision as Java's
+   lambda-example/minigraph-playground both on 8085.
+6. **Docs** — observability (default-on log context; replaced the stale "no round_trip
+   in this port" note with the RPC-record contract), configuration-reference
+   (`app.log.context`), macros-reference + event-driven AI guide (alias syntax; removed
+   stale "isPrivate has no Rust equivalent"), event-over-http.md (zero-code demo
+   walk-through + programmatic twin + cross-language section, mirroring the Java
+   guide's structure), both example READMEs, CHANGELOG "Unreleased", INCREMENTS §63.
+
+**Deliberate divergences (documented, not silent):** (a) the RPC record omits
+`annotations` (they never ride the reply in this port — they flow with the callee's
+worker record); (b) the demo flows map `text(application/json) ->
+output.header.content-type` — the JAVA demo flows write `output.body.content-type`,
+which looks like a typo there (harmless: `result -> output.body` overwrites it) —
+flagged to Eric; (c) Java's worker-injected `my_route` header is NOT ported, so the
+docs' pattern-identification note is scoped honestly (Java callee: `my_route`; Rust
+callee: endpoint or the `x-event-api: callback` marker) — my_route injection is a
+possible future parity item.
+
+**Verification:** workspace 243 tests green (was 237), clippy 0 warnings, fmt clean;
+live two-app demo smoke test on 8085/8100 with trace-log inspection.
+
+## Memory References
+
+- referenced: port-bottom-up-faithful, conventions-rust-baseline (INCREMENTS ledger,
+  parity notes, fmt/clippy gates), ot-event-over-http (demo endpoints extend the
+  increment-59–62 arc)
+
+**[review-overdue]** This session is the 11th since the 2026-07-21 review
+(`review_every: 10`). Deliberately NOT run here: the sweep touches memory files
+repo-wide and this work sits on an unpushed feature branch — mixing housekeeping into
+the feature PR invites merge noise. Run the REVIEW.md ritual as its own commit (on
+main, after this branch lands, or before — maintainer's call).
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>

--- a/memory/sessions/2026-07-23-013514.md
+++ b/memory/sessions/2026-07-23-013514.md
@@ -1,0 +1,58 @@
+# Session (2026-07-23T01:35:27.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Increment 63 follow-up — one telemetry record per span** (three findings from Eric's
+live bidirectional interop drives on PR #167; same branch
+`feature/parity-log-context-aliases`, commit `8328d720`, NOT pushed — Eric gates). Java
+references: `WorkerHandler.sendTracingInfo` gate, commit `140640d8`
+(`InboxBase.spanIdFromResponder`).
+
+- **I1 (callee double-emit):** the worker now SUPPRESSES its own trace record for an
+  RPC-served execution whose reply reached the caller — the caller's `round_trip` record
+  is THE record for the span (Java gate `journaled || rpc == null || notDelivered`;
+  journaling not ported). The RPC marker in this port = an `inbox.` reply address;
+  `inbox::deliver` now returns delivery status. Callback dispatch (route `reply_to`,
+  e.g. Event Script tasks) keeps self-recording — verified live (the
+  `v1.event.over.http.rpc` worker record). **Consequence handled:** annotations now ride
+  the REPLY envelope — new wire-compatible `annotations` field on `EventEnvelope`
+  (`HashMap<String, rmpv::Value>`, skip-if-empty, same key as Java's standard wire
+  format, so they cross Event-over-HTTP hops in either language direction); the worker
+  attaches them (Java `applyTraceContext`), the caller folds them into the record and
+  strips them (Java `saveResponse`), and the worker clears any inbound annotations so
+  they never leak into a function's input.
+- **I2 (foreign span adoption):** `span_id_from_responder` — the record adopts the
+  reply's span only when the reply's `from` equals the requested route (direct RPC); a
+  RELAYED reply (flow answering on behalf of the adapter route) keeps `parent_span_id`
+  but omits `span_id`. Also REMOVED the zero-traced-bracket gate I had added on the
+  caller record — Java's inbox has no such gate; a zero-traced hop's nested RPC records
+  its callee's span (the hop itself still contributes/emits nothing).
+- **I3 (programmatic wire span):** `event_over_http_with_headers` applies
+  `apply_current_trace` (now pub(crate)) to the wire envelope at entry — Java parity
+  with the trace-aware `po.request(..., endpoint, rpc)` touch — so remote functions
+  parent onto the caller's task span in BOTH patterns (declarative was already correct).
+
+**Tests:** new regression `relayed_reply_does_not_donate_its_span_to_the_rpc_record`
+(the Java `SpanPropagationTest` unique-span invariant; interceptor relaying a nested
+reply); the lineage / zero-trace / span-lineage suites rewritten to assert
+one-record-per-span + annotation folding + reply-annotations stripped. Workspace 244 /
+clippy 0 / fmt. **Live acceptance drive PASSED** (hello-flow → hello-world, both
+patterns, span-level log analysis): no duplicate spans, no foreign span ids on
+round_trip records, callee `event.api.service` parented onto the caller task's span in
+both patterns (`872c07ea` programmatic case). Docs updated: observability.md (the
+one-record-per-span contract), CHANGELOG Unreleased #3, INCREMENTS §63 (amended in
+place — same unshipped increment).
+
+**Known Java-matching shape:** a relayed span (e.g. `http.flow.adapter`'s own span) may
+have NO record of its own — its worker record is suppressed (RPC-served interceptor) and
+the caller record cannot adopt a relayed span. Java post-140640d8 behaves identically;
+the span id still appears as the child's `parent_span_id` pointer.
+
+## Memory References
+
+- referenced: ot-event-over-http (interop-drive follow-up on the increment-63 branch),
+  port-bottom-up-faithful, conventions-rust-baseline
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

**Route aliases.** `#[preload(route = "hello.world, hello.declarative", ...)]` now accepts a
comma-separated list of route names: the macro validates the list at compile time
(whitespace-trimmed; an empty segment is a compile error) and `AutoStart` registers one
shared function object under every name with the same instances and visibility — the
counterpart of the Java engine's multi-route `@PreLoad`.

**Application log context on by default.** platform-core embeds a built-in
`default-log-context.yaml` carrying the standard trace context (cid, traceId, tracePath,
spanId, parentSpanId, service, timestamp), so json/compact log lines are trace-correlated
with zero setup. An application's own `app-log-context.yaml` replaces the template entirely,
and `app.log.context=false` opts out. Same file names, keys, and precedence as the Java
engine; text-format logging is unaffected.

**RPC round-trip telemetry with span lineage.** This port emitted no caller-side
`round_trip` trace record at all. `PostOffice::request_direct` now records it with span
lineage from day one: `span_id` is the responder's own span from the reply and
`parent_span_id` is the caller's span carried on the outbound request, so RPC round-trips —
including remote Event-over-HTTP calls — chain into one continuous span tree. Honors
`skip.rpc.tracing`, stays silent inside untraced brackets, and the reply envelope now
carries the round-trip time. A companion fix stops an untraced hop from leaking a nested
reply's span id.

**Event-over-HTTP demo pair.** hello-flow (now port 8100, the structural parallel of the
Java composable-example) gains two REST endpoints against the hello-world echo (port 8085,
now published as `hello.world, hello.declarative`): `/api/event/http/demo` — declarative,
the flow task is a foreign route resolved through `event-over-http.yaml` — and
`/api/event/http/programmatic` — a flow task passes the peer's Event API endpoint URL
directly to the request API. A loopback e2e test exercises both patterns over the real HTTP
stack, and docs mirror the Java guide's walk-through (mermaid sequence diagram, step-by-step
curl, cross-language section).

## Why

The Java engine ships these in its next release (the v4.10 line, PR
Accenture/mercury-composable#215); the two engines enter it in lock-step so the shipped
examples are drop-in cross-language counterparts. The same curl against
`/api/event/http/demo` exercises Rust→Rust or Rust→Java with zero configuration changes —
a no-code demo is the easiest way to get a new reader interested — and observability
behaves identically on both sides: trace-correlated logs out of the box and RPC round-trips
stitched into the span tree across the language boundary. Closes the parity gaps found
while building the interop capability (increments 59–62, PR #166).

## Verification

- Workspace: 243 tests green (+6 new: macro validation, log-context defaults, span-lineage
  regression, hello-flow e2e); `clippy --all-targets` 0 warnings; `fmt --check` clean.
- Live two-app run: both demo endpoints verified with trace-log inspection — callee
  round-trip records parent onto the caller's task spans across the HTTP hop.

**Note:** applications logging in json/compact format will see a new `context` block after
upgrade (documented in the CHANGELOG); hello-flow moved from port 8086 to 8100 and now
shares it with minigraph-playground (run one at a time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>