### PR TITLE
Telemetry presentation parity with the Java reference: visible edge spans, context gating, event.api.auth demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,55 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
+## Unreleased
+
+### Added
+
+1. **Event-over-HTTP authentication demo.** The hello-world example overrides the default
+   `/api/event` endpoint with a demo authentication service (`event.api.auth`) that
+   validates the caller's `authorization` header against a shared secret resolved from
+   the environment (`demo.peer.token: ${DEMO_PEER_TOKEN:demo}` on both peers — no
+   hard-coded credential). The hello-flow example presents the token declaratively (a
+   `headers` block in `event-over-http.yaml`) and programmatically (the request API's
+   security headers), and session info injected by the auth service rides to the target
+   function as read-only headers — REST automation now forwards auth-verdict headers as
+   the request's `session` map (Java parity). The echo also forwards to a new
+   `hello.pojo` function so span propagation is visible in the trace (lambda-example
+   parity).
+
+### Changed
+
+1. **The declarative demo endpoint is renamed for symmetry with its programmatic twin:**
+   `/api/event/http/demo` → `/api/event/http/declarative` and flow id
+   `event-over-http-demo` → `event-over-http-declarative` in the hello-flow example.
+2. **REST automation dispatches the endpoint service as a CALLBACK** (Java `HttpRouter`
+   parity): the event carries `reply_to = async.http.response` and its `cid` is the HTTP
+   context id, while the business correlation-id rides the `my_correlation_id` envelope
+   header (the worker's trace bracket prefers it, so `po.my_correlation_id()` is
+   unchanged). The endpoint service's worker now self-records its span — the first leg
+   of every trace is a real span record — and the response leg (`async.http.response`)
+   is itself a visible function span parenting onto the replying function's span. The
+   telemetry topology of a two-app Event-over-HTTP call is now an exact structural
+   replica of the Java engine's — verified record-for-record against the Java reference
+   signature (both patterns, incl. the deliberate cross-pattern asymmetry of the
+   caller-side response leg).
+
+### Fixed
+
+1. **The application log context no longer leaks onto context-less lines.** The
+   `context` block appears ONLY on log lines emitted inside a traced function execution
+   with a real request trace (Java parity: the log context registers per worker
+   execution in lockstep with the trace bracket). Telemetry records and framework/system
+   lines carry no context block at all — previously they carried a partial block with
+   constants and a timestamp.
+2. **Reserved `my_*` metadata is stripped from HTTP response headers** (Java
+   `copyResponseHeaders` protected-metadata parity): `my_route`, `my_trace_id`,
+   `my_trace_path` and `my_correlation_id` never reach the wire.
+3. **The Event-over-HTTP client returns a non-envelope response as-is** (e.g. an
+   authentication-layer 401 in the REST error shape) with its HTTP status, instead of
+   failing with "Invalid event-over-http response" (Java `handleFutureResponse` parity).
+
+---
 ## Version 4.10.0, 7/22/2026
 
 Feature release: cross-language Event-over-HTTP interoperability with the canonical

--- a/crates/platform-core/src/automation/event_api.rs
+++ b/crates/platform-core/src/automation/event_api.rs
@@ -123,6 +123,13 @@ impl ComposableFunction for EventApiService {
         let Some(to) = inner.to().map(str::to_string) else {
             return Ok(reply(400, error_envelope(400, "Missing routing path")));
         };
+        // session info injected by an authentication service on this /api/event
+        // entry rides to the target function as read-only headers (Java parity:
+        // sessionInfo.forEach(request::setHeader))
+        let mut inner = inner;
+        for (key, value) in request.session() {
+            inner = inner.set_header(key, value);
+        }
         if !self.platform.has_route(&to) {
             return Ok(reply(
                 404,
@@ -272,13 +279,13 @@ pub async fn event_over_http_with_headers(
         .request_direct(http_event, timeout + Duration::from_millis(100))
         .await?;
     // the response body is the serialized reply envelope (octet-stream →
-    // binary); anything else is a transport-level failure
+    // binary); a non-envelope response — e.g. an authentication-layer 401 in
+    // the REST error JSON shape, produced before the Event API service ever
+    // ran — is returned as-is with its HTTP status (Java parity:
+    // EventEmitter.handleFutureResponse)
     match response.body() {
         Value::Binary(bytes) => EventEnvelope::from_bytes(bytes),
-        other => Err(AppError::new(
-            500,
-            format!("Invalid event-over-http response: {other:?}"),
-        )),
+        _ => Ok(response),
     }
 }
 

--- a/crates/platform-core/src/automation/http_client.rs
+++ b/crates/platform-core/src/automation/http_client.rs
@@ -286,6 +286,11 @@ impl AsyncHttpRequest {
         self.method.as_deref().unwrap_or("GET")
     }
 
+    /// The request URI path (Java `AsyncHttpRequest.getUrl`).
+    pub fn url(&self) -> &str {
+        self.url.as_deref().unwrap_or("/")
+    }
+
     pub fn target_host(&self) -> Option<&str> {
         self.target_host.as_deref()
     }
@@ -297,6 +302,13 @@ impl AsyncHttpRequest {
     /// All request headers in insertion order.
     pub fn headers(&self) -> &[(String, String)] {
         &self.headers
+    }
+
+    /// Session info injected by an authentication service (Java
+    /// `AsyncHttpRequest.getSessionInfo`): headers returned on the auth
+    /// verdict, riding to the target function as read-only headers.
+    pub fn session(&self) -> &[(String, String)] {
+        &self.session
     }
 
     pub fn header(&self, key: &str) -> Option<&str> {

--- a/crates/platform-core/src/automation/mod.rs
+++ b/crates/platform-core/src/automation/mod.rs
@@ -14,5 +14,8 @@ pub use event_api::{
 };
 pub use http_client::{AsyncHttpRequest, ASYNC_HTTP_REQUEST};
 pub use routing::{AssignedRoute, CorsInfo, HeaderInfo, RouteInfo, RoutingTable};
-pub use server::{server_address, start_http_server, MY_CORRELATION_ID};
+pub use server::{
+    server_address, start_http_server, AsyncHttpResponseService, ASYNC_HTTP_RESPONSE,
+    MY_CORRELATION_ID,
+};
 pub use ws_server::register_ws_service;

--- a/crates/platform-core/src/automation/server.rs
+++ b/crates/platform-core/src/automation/server.rs
@@ -23,23 +23,33 @@
 //! (always, independent of tracing) → **start a trace** when the entry says
 //! `tracing: true` (a valid W3C `traceparent` wins and contributes the
 //! caller's span as our parent; else the trace-id header; else generated) →
-//! optional authentication → build the `AsyncHttpRequest`-shaped event → RPC
-//! to the target function → map the response envelope back to HTTP (status,
-//! body by type, response-header transforms + CORS headers). Errors use the
-//! Java JSON shape `{status, message, type: "error"}`.
+//! optional authentication (an RPC; verdict headers become **session info**)
+//! → build the `AsyncHttpRequest`-shaped event → **CALLBACK dispatch** to the
+//! target service (Java `HttpRouter` parity: the event carries
+//! `reply_to = async.http.response` and `cid` = the HTTP context id, so the
+//! endpoint service's worker self-records its span — the first leg is a real
+//! span record — and the response leg is itself a function span; the business
+//! correlation-id rides the `my_correlation_id` envelope header) → the
+//! [`AsyncHttpResponseService`] correlates the reply back to the waiting
+//! connection → map the response envelope back to HTTP (status, body by type,
+//! response-header transforms + CORS headers; the reserved `my_*` metadata is
+//! stripped, Java `copyResponseHeaders` parity). Errors use the Java JSON
+//! shape `{status, message, type: "error"}`.
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
+use async_trait::async_trait;
 use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
+use tokio::sync::oneshot;
 
 use crate::envelope::EventEnvelope;
-use crate::function::AppError;
+use crate::function::{AppError, ComposableFunction};
 use crate::platform::Platform;
 use crate::post_office::PostOffice;
 use crate::trace;
@@ -52,6 +62,59 @@ use super::routing::{AssignedRoute, RoutingTable};
 /// Reserved read-only request header exposing the business correlation-id to
 /// the target function (Java `HttpRouter.MY_CORRELATION_ID`).
 pub const MY_CORRELATION_ID: &str = "my_correlation_id";
+
+/// Route of the HTTP response-correlation service (Java
+/// `AsyncHttpClient.ASYNC_HTTP_RESPONSE`).
+pub const ASYNC_HTTP_RESPONSE: &str = "async.http.response";
+
+/// Reserved `my_*` metadata headers that must never reach the HTTP wire
+/// (Java `WorkerHandler.copyResponseHeaders` protected-metadata handling).
+const PROTECTED_METADATA: [&str; 4] = [
+    "my_route",
+    "my_trace_id",
+    "my_trace_path",
+    MY_CORRELATION_ID,
+];
+
+/// Pending HTTP contexts awaiting their response envelope — keyed by the
+/// per-request context id that rides the dispatched event's `cid`
+/// (Java `HttpRouter` contexts + `AsyncContextHolder`).
+fn pending_responses() -> &'static Mutex<HashMap<String, oneshot::Sender<EventEnvelope>>> {
+    static PENDING: OnceLock<Mutex<HashMap<String, oneshot::Sender<EventEnvelope>>>> =
+        OnceLock::new();
+    PENDING.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// The `async.http.response` service (Java `AsyncHttpResponse`) — the HTTP
+/// response leg as a REAL registered function: a REST-automation dispatch is a
+/// **callback** to the endpoint service, whose reply (or a flow's response)
+/// arrives here carrying the HTTP context id as its correlation id, and this
+/// service hands the envelope back to the waiting connection. Because it is
+/// an ordinary traced worker, the response leg is a visible span that parents
+/// onto the replying function's span — exactly the Java reference topology.
+/// A missing context (the connection timed out) drops the reply silently.
+pub struct AsyncHttpResponseService;
+
+#[async_trait]
+impl ComposableFunction for AsyncHttpResponseService {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        if let Some(context_id) = input.correlation_id().map(str::to_string) {
+            let sender = pending_responses()
+                .lock()
+                .expect("pending http contexts poisoned")
+                .remove(&context_id);
+            if let Some(sender) = sender {
+                let _ = sender.send(input);
+            }
+        }
+        Ok(EventEnvelope::new())
+    }
+}
 
 /// The address the first HTTP server bound to in this process (first-bind
 /// wins; `start_http_server` still binds a fresh listener on every call).
@@ -80,6 +143,18 @@ struct RouterState {
 /// the bound address; the accept loop runs as a background task.
 pub async fn start_http_server(platform: &Platform) -> Result<SocketAddr, AppError> {
     let config = AppConfigReader::get_instance();
+    // the response-correlation service is part of the HTTP boundary itself
+    // (Java AppStarter registers AsyncHttpResponse with the server, private,
+    // 500 instances); idempotent — tolerate a concurrent registration
+    if !platform.has_route(ASYNC_HTTP_RESPONSE) {
+        if let Err(e) =
+            platform.register_private(ASYNC_HTTP_RESPONSE, Arc::new(AsyncHttpResponseService), 500)
+        {
+            if !platform.has_route(ASYNC_HTTP_RESPONSE) {
+                return Err(e);
+            }
+        }
+    }
     let rest_yaml = config.get_property_or("yaml.rest.automation", "classpath:/rest.yaml");
     let reader = ConfigReader::load(&rest_yaml)
         .map_err(|e| AppError::new(500, format!("Unable to load {rest_yaml} - {e}")))?;
@@ -364,7 +439,8 @@ async fn process(
     } else {
         format!("{method} {path}?{query_text}")
     };
-    // optional authentication before dispatch (simple route form)
+    // optional authentication before dispatch (simple route form) — an RPC,
+    // so the auth verdict reports as a round_trip record (Java parity)
     if let Some(auth_route) = &info.authentication {
         let auth_event = build_event(
             auth_route,
@@ -387,7 +463,29 @@ async fn process(
         if !verdict.body_as::<bool>().unwrap_or(false) {
             return Err(AppError::new(401, "Unauthorized"));
         }
+        // headers on the auth verdict become SESSION INFO that rides to the
+        // target function as read-only headers (Java HttpRouter parity —
+        // e.g. the event.api.auth demo injects `user: demo`)
+        if !verdict.headers().is_empty() {
+            let session: serde_json::Map<String, serde_json::Value> = verdict
+                .headers()
+                .iter()
+                .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                .collect();
+            http_request["session"] = serde_json::Value::Object(session);
+        }
     }
+    // CALLBACK dispatch (Java HttpRouter parity): the endpoint service is
+    // invoked with reply_to = async.http.response and cid = the HTTP context
+    // id — its worker self-records its span (no RPC suppression), and the
+    // response leg is a visible function span. The business correlation-id
+    // rides the my_correlation_id envelope header instead of the cid slot.
+    let context_id = uuid::Uuid::new_v4().simple().to_string();
+    let (tx, rx) = oneshot::channel();
+    pending_responses()
+        .lock()
+        .expect("pending http contexts poisoned")
+        .insert(context_id.clone(), tx);
     let event = build_event(
         &info.service,
         &http_request,
@@ -396,8 +494,32 @@ async fn process(
         &trace_id,
         &trace_path,
         &parent_span,
-    )?;
-    let result = po.request(event, info.timeout).await?;
+    )?
+    .set_correlation_id(&context_id)
+    .set_reply_to(ASYNC_HTTP_RESPONSE);
+    if let Err(e) = po.send(event).await {
+        pending_responses()
+            .lock()
+            .expect("pending http contexts poisoned")
+            .remove(&context_id);
+        return Err(e);
+    }
+    let result = match tokio::time::timeout(info.timeout, rx).await {
+        Ok(Ok(envelope)) => envelope,
+        Ok(Err(_)) => {
+            return Err(AppError::new(500, "Response channel closed unexpectedly"));
+        }
+        Err(_) => {
+            pending_responses()
+                .lock()
+                .expect("pending http contexts poisoned")
+                .remove(&context_id);
+            return Err(AppError::new(
+                408,
+                format!("Timeout for {} ms", info.timeout.as_millis()),
+            ));
+        }
+    };
     // map the response envelope back to HTTP (Java AsyncHttpResponse:
     // updateHeadersAndContentType + updateHeaders)
     let status = status_of(result.status());
@@ -407,6 +529,11 @@ async fn process(
     let mut response_headers: HashMap<String, String> = HashMap::new();
     for (name, value) in result.headers() {
         let key = name.to_lowercase();
+        // the reserved my_* metadata never reaches the HTTP wire (Java
+        // WorkerHandler.copyResponseHeaders protected-metadata parity)
+        if PROTECTED_METADATA.contains(&key.as_str()) {
+            continue;
+        }
         match key.as_str() {
             // the response-streaming contract (x-stream-id + x-ttl) is a
             // documented deferral in this port (D10) — recognized like Java
@@ -480,6 +607,10 @@ fn build_event(
         .set_to(to)
         .set_from("http.request")
         .set_correlation_id(cid)
+        // the business correlation-id channel (Java parity): the header
+        // survives when the dispatch overwrites cid with the HTTP context id,
+        // and the worker's trace bracket prefers it for my_correlation_id()
+        .set_header(MY_CORRELATION_ID, cid)
         .set_body(http_request)?;
     // a binary body (unknown content type) rides as MsgPack binary — the
     // JSON-shaped request map can't carry bytes (Java: byte[] on the

--- a/crates/platform-core/src/logging.rs
+++ b/crates/platform-core/src/logging.rs
@@ -174,28 +174,19 @@ impl LogContextConfig {
     /// tokens resolved live, constants, then the developer's custom keys.
     /// Keys resolving to nothing are omitted.
     ///
-    /// `state` is the current trace bracket when the line runs inside a traced
-    /// function. Outside a trace (`None`) the block still renders with the
-    /// trace-independent keys — constants and `$utc` — while trace-bound
-    /// tokens and custom keys are omitted. (A deliberate refinement over Java,
-    /// where the block appears only on traced lines — maintainer-directed so
-    /// application-level log lines carry the static context too.)
+    /// `state` is the current trace bracket — the context block exists ONLY
+    /// for a log line emitted inside a traced function execution with a real
+    /// request trace (Java parity: the log context is registered per worker
+    /// execution in lockstep with the trace bracket; framework, system and
+    /// telemetry lines carry no context at all, not even the constants).
     pub fn render(
         &self,
-        state: Option<&trace::TraceState>,
+        state: &trace::TraceState,
         log_time: std::time::SystemTime,
     ) -> serde_json::Map<String, serde_json::Value> {
         let mut out = serde_json::Map::new();
         for (output_key, token_name) in &self.tokens {
-            let value = match state {
-                Some(state) => state.token(token_name, log_time),
-                // only $utc resolves without a trace
-                None if token_name == "utc" => {
-                    Some(serde_json::Value::String(trace::iso8601_utc(log_time)))
-                }
-                None => None,
-            };
-            if let Some(value) = value {
+            if let Some(value) = state.token(token_name, log_time) {
                 out.insert(output_key.clone(), value);
             }
         }
@@ -205,11 +196,9 @@ impl LogContextConfig {
                 serde_json::Value::String(constant.clone()),
             );
         }
-        if let Some(state) = state {
-            for (key, value) in &state.custom_log_keys {
-                if !value.is_null() {
-                    out.insert(key.clone(), value.clone());
-                }
+        for (key, value) in &state.custom_log_keys {
+            if !value.is_null() {
+                out.insert(key.clone(), value.clone());
             }
         }
         out
@@ -290,16 +279,25 @@ impl log::Log for PlatformLogger {
             serde_json::Value::String(message)
         };
         line.insert("message".into(), message_value);
-        // the application log context (when the optional config is present):
-        // inside a traced worker the full set renders — the logger runs
-        // synchronously on the same task, so the task-local is found; outside
-        // a trace the trace-independent keys (constants, $utc) still render
+        // the application log context: ONLY inside a traced worker with a
+        // real request trace (Java parity — the context registers per worker
+        // execution in lockstep with the trace bracket; a zero-traced route
+        // registers none). Framework/system/telemetry lines carry no context
+        // block at all — constants never leak onto context-less lines.
         let config = LogContextConfig::instance();
         if config.is_enabled() {
-            let context = trace::with_current(|state| config.render(Some(state), now))
-                .unwrap_or_else(|| config.render(None, now));
-            if !context.is_empty() {
-                line.insert("context".into(), serde_json::Value::Object(context));
+            let context = trace::with_current(|state| {
+                if state.zero_traced {
+                    None
+                } else {
+                    Some(config.render(state, now))
+                }
+            })
+            .flatten();
+            if let Some(context) = context {
+                if !context.is_empty() {
+                    line.insert("context".into(), serde_json::Value::Object(context));
+                }
             }
         }
         let line = serde_json::Value::Object(line);

--- a/crates/platform-core/src/platform.rs
+++ b/crates/platform-core/src/platform.rs
@@ -568,13 +568,15 @@ async fn worker_loop(
         // nothing changes on the wire.
         let trace_state = match (event.trace_id(), event.trace_path()) {
             (Some(trace_id), Some(trace_path)) => {
-                let mut state = TraceState::new(
-                    &route,
-                    trace_id,
-                    trace_path,
-                    event.span_id(),
-                    event.correlation_id(),
-                );
+                // the business correlation-id prefers the my_correlation_id
+                // envelope header (Java PostOffice parity) — the cid slot may
+                // carry an internal correlation id (the HTTP context id of a
+                // REST callback dispatch, or a flow task's composite id)
+                let business_cid = event
+                    .header(crate::automation::MY_CORRELATION_ID)
+                    .or_else(|| event.correlation_id());
+                let mut state =
+                    TraceState::new(&route, trace_id, trace_path, event.span_id(), business_cid);
                 state.zero_traced = zero_traced;
                 Some(state)
             }

--- a/crates/platform-core/tests/telemetry.rs
+++ b/crates/platform-core/tests/telemetry.rs
@@ -333,7 +333,7 @@ context:
     state
         .custom_log_keys
         .insert("user".into(), serde_json::json!("demo"));
-    let rendered = config.render(Some(&state), std::time::SystemTime::now());
+    let rendered = config.render(&state, std::time::SystemTime::now());
     assert_eq!(rendered["cid"], serde_json::json!("order-1"));
     assert_eq!(rendered["service"], serde_json::json!("v1.demo"));
     assert_eq!(rendered["environment"], serde_json::json!("dev"));

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -80,6 +80,7 @@
 | 61 | Event over HTTP phase 2, increment 3 — /api/event service + client: RPC/async dispatch, 403 private gate, 404/400/408, compact rejection, trace propagation (x-trace-id + traceparent); ships in default rest.yaml | 2026-07-21 | — | 235 |
 | 62 | Declarative Event over HTTP (`yaml.event.over.http`) — route→target map with per-target security headers; transparent PostOffice send/request forwarding (callback dance, x-event-api recursion guard); plus the D2 ttl fix (ceil + wire grace + local-wait grace) | 2026-07-22 | — | 237 |
 | 63 | Java-parity batch pre-4.10: `#[preload]` route aliases, app-log-context ON by default (built-in `default-log-context.yaml` + `app.log.context` switch), caller-side RPC `round_trip` telemetry record with span lineage, Event-over-HTTP demo endpoints in hello-flow (declarative + programmatic; port 8086→8100) | 2026-07-23 | — | 244 |
+| 64 | Telemetry presentation parity with the Java reference: REST automation callback dispatch + `async.http.response` span (first/response legs are real spans), log-context gating (traced lines only), `my_*` response-header strip, business-cid header channel, `event.api.auth` demo + session info, demo→declarative rename, `hello.pojo` — rust-to-rust trace = EXACT replica of java-to-java (empty signature diff, both patterns) | 2026-07-23 | — | 245 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1819,6 +1820,57 @@ lock-step (Java references: mercury-composable commits `9f9050e1` log-context de
   interop section — structurally mirrors the Java guide), hello-flow/hello-world READMEs,
   port sweep 8086→8100 across guides. CHANGELOG "Unreleased" section.
 - Workspace 244 / clippy 0 / fmt.
+
+---
+
+## Increment 64 — Telemetry presentation parity: the Java reference topology, exactly (2026-07-23)
+
+Eric's manual four-direction interop testing sharpened the bar: the rust-to-rust trace
+log must be an **exact structural replica** of java-to-java (normalized signature:
+8 records declarative / 9 programmatic, per-record service + parent edge + kind + path).
+Rationale (standing invariant): installations are polyglot — DevSecOps teams see both
+engines' telemetry in one aggregation, so presentation differences are support burden.
+Java reference: mercury-composable branch `feature/event-api-span-and-auth`.
+
+- **REST automation dispatches the endpoint service as a CALLBACK** (the structural
+  fix Eric green-lit): the dispatched event carries `reply_to = async.http.response` and
+  `cid` = the HTTP context id (a per-request oneshot in a pending map); the new
+  `async.http.response` service (registered by `start_http_server`, private, 500
+  instances, traced) correlates the reply to the waiting connection. Consequences:
+  the endpoint service's worker self-records its span (the missing first leg), and the
+  response leg is a visible span parenting onto the replying function's span — on the
+  caller side it parents onto the CALLEE's function span in the declarative pattern
+  (the flow relays the remote reply) and onto the local task span in the programmatic
+  one (the reference's deliberate asymmetry).
+- **Business correlation-id channel** (Java PostOffice parity): the `my_correlation_id`
+  envelope header carries the business id past the context-id cid slot; the worker's
+  trace bracket prefers it, so `po.my_correlation_id()` / `model.cid` semantics are
+  unchanged (flow tasks now correctly see the business id rather than the composite).
+- **Log-context gating** (items 1+2 of Eric's bug list): the `context` block renders
+  ONLY inside a traced, non-zero-traced worker bracket — telemetry records and
+  framework/system lines lost their partial constants-only block (the increment-5
+  "outside-a-trace constants" divergence is retired; Java lockstep model).
+- **`my_*` response-header strip** at the REST boundary (`copyResponseHeaders` parity).
+- **`event.api.auth` demo** (Java lambda-example twin): hello-world overrides
+  `/api/event` with `authentication: 'event.api.auth'`; the shared token resolves from
+  `${DEMO_PEER_TOKEN:demo}` on both peers; REST automation now forwards auth-verdict
+  headers as **session info** (`session` map → `/api/event` relays them as read-only
+  headers — `user: demo` proves the path in the echo). NOTE: `authentication:` support
+  already existed (increment 6); the session-info half is new. hello-flow presents the
+  token declaratively (`headers:` in event-over-http.yaml) and programmatically
+  (`event_over_http_with_headers`); the client returns non-envelope responses (the
+  auth 401) as-is (Java `handleFutureResponse` parity). New loopback e2e
+  `examples/hello-world/tests/event_api_auth.rs` (accept 200 + session proof / wrong
+  401 / missing 401 — the Java `EventApiAuthTest` twin).
+- **Renames + hello.pojo**: `/api/event/http/demo` → `/api/event/http/declarative`,
+  flow id `event-over-http-demo` → `event-over-http-declarative`; hello-world gains
+  `hello.pojo` and the echo forwards to it fire-and-forget (span propagation visible,
+  lambda-example parity).
+- **Acceptance:** live two-app drive, normalized span-owner diff against the Java
+  reference signature = **EMPTY** for both patterns; one record per span, no dangling
+  parents; log-context gating verified (36 context-less framework/telemetry records, 0
+  violations); response headers clean; auth 200/401/401 live. Workspace 245 / clippy 0 /
+  fmt.
 
 ---
 

--- a/docs/guides/event-over-http.md
+++ b/docs/guides/event-over-http.md
@@ -391,5 +391,14 @@ at any peer that exposes the routes.
 The full cross-language matrix — both directions, both patterns, RPC and async, error
 semantics and trace continuity — was exercised by live bidirectional interop drives
 between the two engines; the permanent record is the
-[Interop Test Report](https://accenture.github.io/mercury-composable/test-reports/event-over-http-interop/)
-on the Java docs site.
+[Interop Test Report](../test-reports/event-over-http-interop.md) (mirrored on the
+[Java docs site](https://accenture.github.io/mercury-composable/test-reports/event-over-http-interop/)).
+
+## See also
+
+- [Interop Test Report (Java ⇄ Rust)](../test-reports/event-over-http-interop.md) — the live
+  bidirectional validation of both patterns, with span-level trace evidence and the
+  learnings kept as a playbook for future language ports.
+- [REST Automation](rest-automation.md) — declarative HTTP endpoints, no controllers.
+- [EventEnvelope](event-envelope-reference.md) — the envelope and the standard wire format.
+- [Observability Model](observability.md) — the span tree and the application log context.

--- a/docs/guides/event-over-http.md
+++ b/docs/guides/event-over-http.md
@@ -162,7 +162,7 @@ sequenceDiagram
     participant U as curl
     participant C as hello-flow (8100)
     participant L as hello-world (8085)
-    U->>C: POST /api/event/http/demo
+    U->>C: POST /api/event/http/declarative
     Note over C: flow task "hello.declarative"<br/>route is not local — resolved<br/>via event-over-http.yaml
     C->>L: POST /api/event<br/>(MsgPack envelope + trace context)
     Note over L: hello.declarative echo<br/>(alias of hello.world)
@@ -193,20 +193,25 @@ peer.demo.host: '127.0.0.1'
 peer.demo.port: 8085
 ```
 
-`event-over-http.yaml` maps the foreign route to the peer's Event API endpoint:
+`event-over-http.yaml` maps the foreign route to the peer's Event API endpoint (the
+`headers` block presents the shared demo token — see the
+[authentication demo](#authentication-the-eventapiauth-demo) below):
 
 ```yaml
 event.http:
   - route: 'hello.declarative'
     target: 'http://${peer.demo.host:127.0.0.1}:${peer.demo.port}/api/event'
+    # security headers (optional. Added for this demo only)
+    headers:
+      authorization: '${DEMO_PEER_TOKEN:demo}'
 ```
 
-and the REST endpoint `GET/POST /api/event/http/demo` (see `rest.yaml`) runs the flow
-`event-over-http-demo` whose task simply names the route:
+and the REST endpoint `GET/POST /api/event/http/declarative` (see `rest.yaml`) runs the flow
+`event-over-http-declarative` whose task simply names the route:
 
 ```yaml
 tasks:
-  - name: 'event-over-http-demo'
+  - name: 'event-over-http-declarative'
     input:
       - 'input.header -> header'
       - 'input.body -> *'
@@ -236,7 +241,7 @@ tasks:
 
     ```shell
     curl -s -X POST -H "content-type: application/json" \
-         -d '{"hello": "world"}' http://127.0.0.1:8100/api/event/http/demo
+         -d '{"hello": "world"}' http://127.0.0.1:8100/api/event/http/declarative
     ```
 
 4. The hello-world echo replies through the same path in reverse — the response arrives as
@@ -247,7 +252,7 @@ tasks:
       "body": { "hello": "world" },
       "headers": {
         "x-event-api": "callback",
-        "x-flow-id": "event-over-http-demo",
+        "x-flow-id": "event-over-http-declarative",
         "...": "..."
       },
       "instance": 4,
@@ -278,8 +283,12 @@ it directly to the request API — so `hello.world` needs **no entry** in
 
 ```rust
 let endpoint = format!("http://{host}:{port}/api/event");
+let security_headers = HashMap::from([
+    ("authorization".to_string(), config.get_property_or("demo.peer.token", "demo")),
+]);
 let request = EventEnvelope::new().set_to("hello.world").set_raw_body(input.body().clone());
-let response = event_over_http(&po, &endpoint, request, Duration::from_secs(10), true).await?;
+let response = event_over_http_with_headers(
+    &po, &endpoint, request, Duration::from_secs(10), true, &security_headers).await?;
 ```
 
 ```shell
@@ -301,6 +310,52 @@ the target at runtime.
     it. The Rust worker does not inject `my_route`; with the Rust callee, tell the
     patterns apart by the endpoint you called or by the declarative marker
     `x-event-api: callback` in the echoed headers.
+
+### Authentication: the event.api.auth demo
+
+The demo pair also shows how to protect the Event API endpoint. The hello-world example
+overrides the default `/api/event` entry in its `rest.yaml` to attach an authentication
+service:
+
+```yaml
+  - service: "event.api.service"
+    methods: ['POST']
+    url: "/api/event"
+    timeout: 60s
+    authentication: 'event.api.auth'
+    tracing: true
+```
+
+The `event.api.auth` function validates the caller's `authorization` header against a
+shared secret that **both peers resolve from the environment** — never hard-code a real
+credential in source or configuration files:
+
+```yaml
+# application.yml on both sides - "demo" is the local-development fallback
+demo.peer.token: '${DEMO_PEER_TOKEN:demo}'
+```
+
+On the calling side, the declarative route presents the token as a security header in
+`event-over-http.yaml`:
+
+```yaml
+event.http:
+  - route: 'hello.declarative'
+    target: 'http://${peer.demo.host:127.0.0.1}:${peer.demo.port}/api/event'
+    # security headers (optional. Added for this demo only)
+    headers:
+      authorization: '${DEMO_PEER_TOKEN:demo}'
+```
+
+and the programmatic task passes the same token in the security-headers argument of
+`event_over_http_with_headers`. A wrong or missing token gets an HTTP-401 without ever
+reaching the target function.
+
+When authentication passes, headers returned by the auth service become **session info**
+that rides to the target function as read-only headers — the demo's auth service adds
+`user: demo`, so you can see it echoed in the response body as proof that the request
+went through authentication. Replace the demo function with your own OAuth 2.0
+bearer-token validation for production use.
 
 ### Same demo, different language
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -293,17 +293,16 @@ the span join up in the backend, with the `user` key added by `update_context`:
 ```
 
 !!! note "Rust port"
-    Two deliberate divergences from the Java feature. **Outside a trace, the block still
-    renders its trace-independent keys** (constants and `$utc`) — in Java the block
-    appears only on traced lines; here application-level lines (startup, framework
-    events) carry the static context too. **An invalid `$token` is advisory** — reported
-    and skipped — where Java throws at load.
+    One deliberate divergence from the Java feature: **an invalid `$token` is
+    advisory** — reported and skipped — where Java throws at load.
 
 ## Scope and boundaries
 
-- Trace-bound context keys appear only on lines emitted **inside** a traced function
-  execution; framework boot logs and work `tokio::spawn`ed from inside a function carry
-  only the trace-independent keys — the same boundary the distributed trace has.
+- The `context` block appears **only** on lines emitted inside a traced function
+  execution with a real request trace (Java parity: the log context registers per worker
+  execution in lockstep with the trace bracket). Framework boot logs, telemetry records,
+  and work `tokio::spawn`ed from inside a function carry **no context block at all** —
+  constants never leak onto context-less lines.
 - Feature off (`app.log.context: false`) costs one boolean check per log line.
 - The `text` format never renders a context block, whatever the configuration.
 

--- a/docs/guides/rest-automation.md
+++ b/docs/guides/rest-automation.md
@@ -154,13 +154,15 @@ sent to this route (with the endpoint's timeout). The contract:
 - return body `true` → the request proceeds to `service`;
 - return body `false` (or anything that is not boolean `true`) → **401 Unauthorized**;
 - return an error (`Err(AppError)` / status ≥ 400) → that status and message are returned
-  to the caller, so the function can reject with a custom status such as 403.
+  to the caller, so the function can reject with a custom status such as 403;
+- **headers on the verdict envelope become session info** that rides to the target
+  function as read-only headers (the `session` map of the `AsyncHttpRequest`) — e.g. put
+  the validated user id there. A working example is the `event.api.auth` demo in the
+  [Event over HTTP](event-over-http.md#authentication-the-eventapiauth-demo) guide.
 
 !!! note "Rust port"
     Only the simple form — one route for the endpoint — is ported. The Java routing specs
-    (`'default: svc'`, `'header: svc'`, `'header: value: svc'`) and the Java option of
-    returning an `EventEnvelope` whose headers become session info for the target function
-    are not yet available: the verdict must be a boolean.
+    (`'default: svc'`, `'header: svc'`, `'header: value: svc'`) are not yet available.
 
 #### `tracing`
 

--- a/docs/test-reports/event-over-http-interop.md
+++ b/docs/test-reports/event-over-http-interop.md
@@ -1,0 +1,242 @@
+---
+title: Interop Test Report — Event over HTTP, Java ⇄ Rust
+summary: Permanent record of the live bidirectional interoperability validation between the
+  Java and Rust implementations - wire format, calling patterns, and telemetry presentation
+  parity - kept as a playbook for future language ports.
+layer: reference
+audience: [developer, architect]
+keywords: [interop, event over http, rust, wire format, test report, tracing]
+---
+
+# Interop Test Report — Event over HTTP, Java ⇄ Rust
+
+*Live bidirectional interoperability validation between the Java engine
+([mercury-composable](https://github.com/Accenture/mercury-composable)) and the official
+Rust implementation ([mercury](https://github.com/Accenture/mercury)): the wire-format and
+calling-pattern drives conducted 2026-07-22 as the release gate for the v4.10 line, and the
+telemetry presentation-parity drive conducted 2026-07-23.*
+
+This report is a permanent record. It documents what was tested, the evidence collected,
+and — in the interest of honest engineering — the defects the drives surfaced and how each
+was fixed and re-verified. Everything here is reproducible from the shipped examples by
+following the [Event over HTTP](../guides/event-over-http.md#zero-code-demo-hello-flow-to-hello-world) walk-through.
+It is also kept as a **playbook for future language ports** (e.g. Python) — see the
+learnings section at the end.
+
+## Background: the wire-format validation drive
+
+The first interop drive (2026-07-22, morning) validated the language-neutral
+[standard event envelope wire format](https://accenture.github.io/mercury-composable/guides/event-envelope-wire-format/) end-to-end:
+Java→Rust 7/7 and Rust→Java 7/7 test cases, including binary payloads, in-band error
+semantics (403/404/408 as envelope status), async acknowledgement, and W3C trace
+continuity in both directions. That drive found and fixed three defects — a Java HTTP
+client read-timeout truncation
+([PR #214](https://github.com/Accenture/mercury-composable/pull/214)) and its Rust mirror
+plus an example echo binary drop
+([mercury PR #166](https://github.com/Accenture/mercury/pull/166)). Golden conformance
+vectors are shared verbatim between the two repositories.
+
+## This drive: the two calling patterns, both directions
+
+The second drive validated the two Event-over-HTTP usage patterns — **programmatic** (the
+PostOffice request API with an explicit Event API endpoint URL) and **declarative** (a
+foreign route resolved through `event-over-http.yaml`) — using the shipped example
+applications as-is.
+
+| Role | Drive A | Drive B |
+|------|---------|---------|
+| Caller (port 8100) | Java composable-example | Rust hello-flow |
+| Callee (port 8085) | Rust hello-world | Java lambda-example |
+
+Endpoints exercised on each caller: `POST /api/event/http/demo` (declarative; renamed to
+`/api/event/http/declarative` after v4.10.0), `POST /api/event/http/programmatic`, and
+`GET /api/event/http/demo`. **Zero configuration
+changes between drives** — the callees are drop-in counterparts of each other (same port,
+same public routes `hello.world` / `hello.declarative`), which is the point of the demo.
+
+**Versions under test:** Java at
+[PR #215](https://github.com/Accenture/mercury-composable/pull/215) (pre-4.10, CI green);
+Rust at [PR #167](https://github.com/Accenture/mercury/pull/167).
+
+## Results — functionality: 6/6 pass
+
+- Every request returned HTTP 200 with `Content-Type: application/json` and the correct
+  echo: the request body round-tripped intact, and the `origin` field identified the
+  application instance that actually executed the function — in the other language.
+- Java callee: the echoed `my_route` header discriminates the pattern —
+  `hello.declarative` (declarative) vs `hello.world` (programmatic) — demonstrating why
+  the echo function registers two route names.
+
+## Results — trace continuity
+
+Distributed traces were inspected at the individual span level in both applications' logs.
+
+**Java → Rust: a fully connected cross-language span tree in both patterns.** For the
+declarative call (trace `a6b8fa67…`): Java `http.flow.adapter` (span `9fbd1bdc`) → Rust
+`event.api.service` (span `a092275c`, parent `9fbd1bdc` — chained across the wire) → Rust
+`hello.declarative` (span `8e505921`) — and back on the Java side, the response callback
+span parents onto the **Rust** function's span, closing the loop. The programmatic call
+chains the same way through the Java `v1.event.over.http.rpc` task span.
+
+**Rust → Java:** the declarative call chained fully (Java `hello.declarative` parented
+onto the Rust flow-adapter span, matching Java-caller behavior exactly; even the echo's
+internal fire-and-forget `hello.pojo` call chained onto the echo's span). The programmatic
+call initially joined by trace id only — see finding I3 below.
+
+With the [default-on application log context](../guides/observability.md#the-application-log-context),
+every structured log line on both sides carried the same trace id — logs and spans join up
+across the language boundary with zero setup.
+
+## Findings and resolution
+
+Span-level analysis surfaced three telemetry-fidelity defects, all in the Rust port and
+none affecting functionality. Recording them here is deliberate: the drives exist to find
+exactly this class of issue.
+
+- **I1 — duplicate span records.** The Rust callee emitted two records per RPC-served span
+  (its worker record plus the caller-side round-trip record). The Java engine emits exactly
+  one: the worker suppresses its own record when serving an RPC and the caller's inbox
+  record — carrying `exec_time`, `round_trip`, and span lineage — is *the* record for that
+  span. The Rust port now applies the same suppression, and the callee's annotations ride
+  the reply envelope (a wire-compatible field that survives Event-over-HTTP hops in either
+  direction).
+- **I2 — foreign span adoption on relayed replies.** A round-trip record adopted the span
+  id of whatever function produced the reply — for a flow, that is the flow's final task,
+  not the requested route — misattributing and duplicating a span reported elsewhere. Both
+  engines now adopt the reply's span id only when the reply comes from the requested route
+  itself (Java: `InboxBase.spanIdFromResponder`, commit `140640d8`; Rust: commit
+  `8328d720`). The same defect had been caught on the Java side by the event-script
+  engine's span-uniqueness regression suite during this same release cycle.
+- **I3 — missing caller span on the programmatic wire envelope.** The Rust programmatic
+  client did not stamp the calling function's span id onto the outbound envelope, so the
+  remote callee's record lost its `parent_span_id` (the declarative path was correct). Now
+  fixed; both patterns parent identically.
+
+**Re-drive after the fixes (both directions, both patterns):** exactly one record per span
+(zero duplicates), no foreign span ids on round-trip records, and callee records parent
+onto the caller's task span in both patterns — every parent id cross-checked as a real
+span in the caller's log.
+
+## Verdict
+
+**Interop validation passed in full.** Both Event-over-HTTP patterns are functionally
+proven Java ⇄ Rust with zero configuration changes, and distributed-trace telemetry is
+span-accurate across the language boundary in both directions. The shipped examples are
+drop-in cross-language counterparts, and the walk-through in the
+[Event over HTTP guide](../guides/event-over-http.md#zero-code-demo-hello-flow-to-hello-world) reproduces this
+validation with a single `curl`.
+
+## The presentation-parity drive (2026-07-23)
+
+After v4.10.0 shipped, a manual review of all four direction combinations
+(java-to-java, rust-to-rust, java-to-rust, rust-to-java) side by side — the way a
+DevSecOps operator reads an aggregated log stream — raised the bar from "trace continuity
+works" to a stronger requirement:
+
+> **Field installations stay polyglot for a long time. Operators aggregate both engines'
+> telemetry and logs in one place, and any presentation difference is a support burden.
+> The same-language logs of the two engines must be exact structural replicas of each
+> other — then cross-language runs are symmetric by construction.**
+
+That review surfaced loose ends the per-direction drives had not:
+
+- **Java:** the `/api/event` edge connected to no span — `event.api.service` was a
+  zero-tracing relay, so the remote target function parented onto a span from another
+  application with nothing in between, and the HTTP response leg floated unparented.
+- **Rust:** an incomplete application log-context block (constants only) appeared on
+  telemetry and system lines that carry no request trace; the first-leg
+  `http.flow.adapter` span was never recorded (its RPC-style dispatch suppressed the
+  worker record), leaving `parent_span_id` values that pointed at spans no record
+  reported; and reserved `my_*` metadata could leak into HTTP response headers.
+
+### Method: a normalized reference signature
+
+The Java engine is the reference implementation. After fixing the Java `/api/event` edge
+(the service is now traced: its span parents onto the remote caller's span, the target
+function parents onto it, and both response legs chain onto real spans), a live
+java-to-java run was distilled into a **normalized trace signature**: per calling pattern,
+the exact set of telemetry records — service name, parent edge (expressed symbolically so
+span-id values don't matter), record kind (`round_trip` for RPC-served spans vs
+`exec-only` for callback-served worker records), and path. Volatile fields (ids, origins,
+timestamps, durations, thread/instance numbers, ordering) are exempt; everything else must
+match record-for-record.
+
+**Declarative pattern — 8 records:**
+
+| side | service | parent (span owner) | kind | path |
+|------|---------|---------------------|------|------|
+| caller | http.flow.adapter | (root) | exec-only | POST /api/event/http/declarative |
+| caller | task.executor | http.flow.adapter@caller | exec-only | POST /api/event/http/declarative |
+| callee | event.api.auth | http.flow.adapter@caller | round_trip | POST /api/event |
+| callee | event.api.service | http.flow.adapter@caller | exec-only | POST /api/event |
+| callee | hello.declarative | event.api.service@callee | round_trip | POST /api/event/http/declarative |
+| callee | hello.pojo | hello.declarative@callee | exec-only | POST /api/event/http/declarative |
+| callee | async.http.response | event.api.service@callee | exec-only | POST /api/event |
+| caller | async.http.response | hello.declarative@callee | exec-only | POST /api/event/http/declarative |
+
+**Programmatic pattern — 9 records:** identical shape with the caller's
+`v1.event.over.http.rpc` task span between the flow adapter and the callee (the callee's
+`event.api.auth` / `event.api.service` parent onto it), the callee function being
+`hello.world`, and one deliberate asymmetry: the caller's `async.http.response` parents
+onto the **callee's function span** in the declarative pattern (the flow task's reply *is*
+the remote reply) but onto the **local task span** in the programmatic one (the flow's
+reply is produced locally by that task).
+
+The signature also pins the invariants: one record per span, no dangling parents, HTTP
+response headers free of reserved `my_*` metadata, and the log-context gating rule — a
+`context` block appears **only** on log lines emitted inside a traced function execution;
+telemetry and system lines carry none at all.
+
+### Reaching the bar required refactoring, not patching
+
+Matching the signature exposed genuine low-level variance in the Rust port's RPC
+implementation, resolved structurally: its REST automation now dispatches endpoint
+services as **callbacks** through a registered `async.http.response` service (the Java
+twin) instead of RPC through a oneshot inbox — which is what made the first-leg and
+response-leg spans real — and the business correlation-id moved to the reserved
+envelope-header channel for exact `PostOffice` parity. The log context was re-gated to
+render only inside a traced, non-zero-traced worker execution. The same drive added the
+`event.api.auth` authentication demo to both engines (a shared token resolved from the
+`DEMO_PEER_TOKEN` environment variable — authentication appears in the trace as a real
+span, and its session info rides to the target function as proof).
+
+### Result: empty diff in all four directions
+
+| Direction | Declarative (8 records) | Programmatic (9 records) |
+|-----------|-------------------------|--------------------------|
+| java → java (reference) | — | — |
+| rust → rust | **empty diff** | **empty diff** |
+| java → rust | **empty diff** | **empty diff** |
+| rust → java | **empty diff** | **empty diff** |
+
+Exactly as predicted: once the same-language logs were replicas, the cross-language runs
+were symmetric with no additional work. Authentication verified in every direction
+(session proof in the echo; wrong or missing token → HTTP-401), response headers clean,
+and zero context blocks on untraced lines in either engine.
+
+## Learnings for future language ports
+
+This validation arc is the playbook for bringing the next language (e.g. Python) into the
+family:
+
+1. **Golden conformance vectors first.** The wire format is proven byte-identically with
+   vectors shared verbatim between repositories — no prose interpretation.
+2. **Same-language baseline before cross-language testing.** Distill a live run of the
+   reference engine (java-to-java) into a normalized trace signature; the new port must
+   produce an **empty diff** on its own same-language run. Cross-language symmetry then
+   follows by construction — do not chase cross-language differences directly.
+3. **The signature is more than topology.** It pins record kinds (round_trip vs
+   exec-only), path values, one-record-per-span, no dangling parents, log-context gating,
+   and transport-header hygiene — the things an operator actually sees in an aggregated
+   view. Presentation parity is a standing invariant, not a one-off acceptance test:
+   polyglot installations put both engines' output in front of the same DevSecOps team.
+4. **Expect refactoring, not configuration.** Matching the signature will surface genuine
+   low-level differences (RPC vs callback dispatch, context scoping). Fix the structure;
+   telemetry-layer workarounds recreate the drift later.
+5. **The demo pair is the reusable test vehicle.** A new port implements the hello-world /
+   hello-flow counterparts on the same ports and route names, and every drive in this
+   report — functionality, trace continuity, authentication, signature diff — runs against
+   it unchanged, with zero configuration.
+6. **Live drives find what unit tests do not.** Every drive in this story surfaced real
+   defects (timeout truncation, span misattribution, context leakage, an invisible relay
+   edge) that per-repository test suites had not caught.

--- a/examples/hello-flow/README.md
+++ b/examples/hello-flow/README.md
@@ -93,11 +93,14 @@ cargo run -p hello-world      # or the Java lambda-example — same port, same r
 **Declarative** (zero code — the target address is deployment configuration):
 the flow's task is the foreign route `hello.declarative`, which does not
 exist here; `resources/event-over-http.yaml` resolves it to the peer's
-`/api/event` endpoint and the call crosses the wire automatically.
+`/api/event` endpoint and the call crosses the wire automatically — carrying
+the shared demo token as a security header (the peer's `/api/event` is
+protected by its `event.api.auth` service; both sides resolve the token from
+the `DEMO_PEER_TOKEN` environment variable, default `demo` for local dev).
 
 ```bash
 curl -s -X POST -H 'content-type: application/json' \
-     -d '{"hello":"world"}' http://127.0.0.1:8100/api/event/http/demo
+     -d '{"hello":"world"}' http://127.0.0.1:8100/api/event/http/declarative
 ```
 
 **Programmatic** (the code computes the target at runtime): the flow's task
@@ -133,7 +136,7 @@ orchestration is configuration.
 |---|---|
 | `src/main.rs` | the composable functions + the one-line main |
 | `resources/flows/hello-flow.yml` | **the transaction** (decision + 2 end tasks) |
-| `resources/flows/event-over-http-demo.yml` | the declarative Event-over-HTTP demo flow |
+| `resources/flows/event-over-http-declarative.yml` | the declarative Event-over-HTTP demo flow |
 | `resources/flows/event-over-http-programmatic.yml` | the programmatic Event-over-HTTP demo flow |
 | `resources/event-over-http.yaml` | the declarative route → peer mapping |
 | `resources/flows.yaml` | which flows to compile at startup |

--- a/examples/hello-flow/resources/application.yml
+++ b/examples/hello-flow/resources/application.yml
@@ -17,3 +17,10 @@ mandatory.health.dependencies: 'flow.engine.health'
 yaml.event.over.http: 'classpath:/event-over-http.yaml'
 peer.demo.host: '127.0.0.1'
 peer.demo.port: 8085
+
+# Shared demo secret for the Event-over-HTTP authentication demo. The called
+# party's "event.api.auth" service expects this value in the "authorization"
+# header. Resolved from the DEMO_PEER_TOKEN environment variable so no real
+# credential is ever hard-coded ("demo" is the fallback for local development
+# only). The declarative side reads the same variable in event-over-http.yaml.
+demo.peer.token: '${DEMO_PEER_TOKEN:demo}'

--- a/examples/hello-flow/resources/event-over-http.yaml
+++ b/examples/hello-flow/resources/event-over-http.yaml
@@ -6,3 +6,6 @@
 event.http:
   - route: 'hello.declarative'
     target: 'http://${peer.demo.host:127.0.0.1}:${peer.demo.port}/api/event'
+    # security headers (optional. Added for this demo only)
+    headers:
+      authorization: '${DEMO_PEER_TOKEN:demo}'

--- a/examples/hello-flow/resources/flows.yaml
+++ b/examples/hello-flow/resources/flows.yaml
@@ -1,6 +1,6 @@
 flows:
   - 'hello-flow.yml'
-  - 'event-over-http-demo.yml'
+  - 'event-over-http-declarative.yml'
   - 'event-over-http-programmatic.yml'
 
 location: 'classpath:/flows/'

--- a/examples/hello-flow/resources/flows/event-over-http-declarative.yml
+++ b/examples/hello-flow/resources/flows/event-over-http-declarative.yml
@@ -6,15 +6,15 @@
 # or HTTP client code.
 #
 flow:
-  id: 'event-over-http-demo'
+  id: 'event-over-http-declarative'
   description: 'Demonstrate Event-over-Http protocol using declarative means'
   ttl: 10s
   exception: 'v1.hello.exception'
 
-first.task: 'event-over-http-demo'
+first.task: 'event-over-http-declarative'
 
 tasks:
-  - name: 'event-over-http-demo'
+  - name: 'event-over-http-declarative'
     input:
       - 'input.header -> header'
       - 'input.body -> *'

--- a/examples/hello-flow/resources/flows/event-over-http-programmatic.yml
+++ b/examples/hello-flow/resources/flows/event-over-http-programmatic.yml
@@ -2,7 +2,7 @@
 # The PROGRAMMATIC Event-over-HTTP demo: the task is an ordinary composable
 # function (v1.event.over.http.rpc) that passes the peer's /api/event URL
 # directly to the request API — so its target route 'hello.world' needs NO
-# entry in event-over-http.yaml. Compare with event-over-http-demo.yml,
+# entry in event-over-http.yaml. Compare with event-over-http-declarative.yml,
 # which reaches the same peer function declaratively via its alias route.
 #
 flow:

--- a/examples/hello-flow/resources/rest.yaml
+++ b/examples/hello-flow/resources/rest.yaml
@@ -12,8 +12,8 @@ rest:
   # route 'hello.declarative', resolved through event-over-http.yaml
   - service: "http.flow.adapter"
     methods: ['GET', 'POST']
-    url: "/api/event/http/demo"
-    flow: 'event-over-http-demo'
+    url: "/api/event/http/declarative"
+    flow: 'event-over-http-declarative'
     timeout: 15s
     tracing: true
 

--- a/examples/hello-flow/src/main.rs
+++ b/examples/hello-flow/src/main.rs
@@ -37,7 +37,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use platform_core::automation::event_over_http;
+use platform_core::automation::event_over_http_with_headers;
 use platform_core::{
     main_application, preload, AppConfigReader, AppError, ComposableFunction, EntryPoint,
     EventEnvelope, Platform, PostOffice,
@@ -94,8 +94,13 @@ impl ComposableFunction for GreetingComposer {
 /// `hello.world` does NOT appear in `event-over-http.yaml` — compare with
 /// `hello.declarative` (an alias of the same peer function), which is
 /// resolved through that configuration file instead. The two REST endpoints
-/// `/api/event/http/programmatic` and `/api/event/http/demo` therefore hit
-/// the same peer function through the two different patterns.
+/// `/api/event/http/programmatic` and `/api/event/http/declarative`
+/// therefore hit the same peer function through the two different patterns.
+///
+/// The peer's `/api/event` endpoint is protected by the `event.api.auth`
+/// demo — this task presents the shared token (resolved from the
+/// DEMO_PEER_TOKEN environment variable via `demo.peer.token`) as a security
+/// header on the HTTP request.
 #[preload(route = "v1.event.over.http.rpc", instances = 10)]
 struct EventOverHttpRpc;
 
@@ -111,6 +116,14 @@ impl ComposableFunction for EventOverHttpRpc {
         let host = config.get_property_or("peer.demo.host", "127.0.0.1");
         let port = config.get_property_or("peer.demo.port", "8085");
         let endpoint = format!("http://{host}:{port}/api/event");
+        // the peer's /api/event is protected by the event.api.auth demo —
+        // present the shared token as a security header (never hard-coded;
+        // "demo" is only the local-dev default inside ${DEMO_PEER_TOKEN:demo})
+        let mut security_headers = HashMap::new();
+        security_headers.insert(
+            "authorization".to_string(),
+            config.get_property_or("demo.peer.token", "demo"),
+        );
         let mut request = EventEnvelope::new()
             .set_to("hello.world")
             .set_raw_body(input.body().clone());
@@ -118,8 +131,15 @@ impl ComposableFunction for EventOverHttpRpc {
             request = request.set_header(key, value);
         }
         let po = PostOffice::new(&Platform::get_instance());
-        let response =
-            event_over_http(&po, &endpoint, request, Duration::from_secs(10), true).await?;
+        let response = event_over_http_with_headers(
+            &po,
+            &endpoint,
+            request,
+            Duration::from_secs(10),
+            true,
+            &security_headers,
+        )
+        .await?;
         if response.status() != 200 {
             // surface the remote error to the flow's exception handler
             return Err(AppError::new(

--- a/examples/hello-flow/tests/event_over_http_demo.rs
+++ b/examples/hello-flow/tests/event_over_http_demo.rs
@@ -133,7 +133,8 @@ async fn both_event_over_http_demo_endpoints_round_trip() {
 
     // DECLARATIVE pattern: flow task names the foreign route, resolved
     // through event-over-http.yaml — zero code
-    let (status, body) = http_post(port, "/api/event/http/demo", "{\"hello\":\"world\"}").await;
+    let (status, body) =
+        http_post(port, "/api/event/http/declarative", "{\"hello\":\"world\"}").await;
     assert_eq!(status, 200, "declarative demo body: {body}");
     let response: serde_json::Value = serde_json::from_str(&body).expect("json");
     assert_eq!(response["body"]["hello"], serde_json::json!("world"));

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -14,3 +14,6 @@ serde_json = "1"
 log = "0.4"
 rmpv = "1"
 tokio = { version = "1", features = ["time"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -85,7 +85,12 @@ function under two route names (`hello.world, hello.declarative` — a
 comma-separated alias list, one shared handler). It is the standing callee
 of the `hello-flow` example's two Event-over-HTTP demo endpoints, and the
 drop-in counterpart of the Java `lambda-example` (same port 8085, same
-routes) — so the demo doubles as a cross-language interop demo. See the
+routes) — so the demo doubles as a cross-language interop demo. The
+`/api/event` endpoint is protected by the `event.api.auth` demo service:
+callers must present the shared token (`DEMO_PEER_TOKEN`, default `demo`)
+in the `authorization` header, and the auth service injects `user: demo` as
+session info that shows up in the echo. The echo also forwards to
+`hello.pojo` so the span propagation is visible in the trace. See the
 hello-flow README and the docs site's *Event over HTTP* guide.
 
 Stop with Ctrl-C (graceful shutdown cleans the elastic store).

--- a/examples/hello-world/resources/application.yml
+++ b/examples/hello-world/resources/application.yml
@@ -23,3 +23,10 @@ info.app.description: 'mercury hello-world example'
 show.env.variables: 'GREETING_USER, ENV_NAME'
 show.application.properties: 'application.name, log.format, rest.server.port, greeting.instances'
 mandatory.health.dependencies: 'demo.health'
+
+# Shared demo secret for the Event-over-HTTP authentication demo. The
+# "event.api.auth" service compares the caller's "authorization" header
+# against this value. Resolved from the DEMO_PEER_TOKEN environment variable
+# so no real credential is ever hard-coded ("demo" is the fallback for local
+# development only).
+demo.peer.token: '${DEMO_PEER_TOKEN:demo}'

--- a/examples/hello-world/resources/rest.yaml
+++ b/examples/hello-world/resources/rest.yaml
@@ -9,6 +9,18 @@ rest:
     headers: header_1
     tracing: true
 
+  # Override the default "/api/event" endpoint to attach the demo
+  # authentication service (the EventApiAuth function). A calling party must
+  # present the shared demo token in the "authorization" header - see
+  # "demo.peer.token" in application.yml (resolved from the DEMO_PEER_TOKEN
+  # environment variable).
+  - service: "event.api.service"
+    methods: ['POST']
+    url: "/api/event"
+    timeout: 60s
+    authentication: 'event.api.auth'
+    tracing: true
+
 cors:
   - id: cors_1
     options:

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -192,6 +192,15 @@ impl ComposableFunction for HelloWorld {
             tokio::time::sleep(Duration::from_millis(ms)).await;
         }
         log::info!("echo #{instance} got a request");
+        // forward an event to hello.pojo so the span-id of this function is
+        // seen propagated to hello.pojo (Java lambda-example parity)
+        let po = PostOffice::new(&Platform::get_instance());
+        po.send(
+            EventEnvelope::new()
+                .set_to("hello.pojo")
+                .set_header("id", "1"),
+        )
+        .await?;
         let echo_headers = Value::Map(
             headers
                 .iter()
@@ -216,6 +225,81 @@ fn sleep_ms(body: &Value) -> Option<u64> {
         .iter()
         .find(|(k, _)| k.as_str() == Some("sleep_ms"))
         .and_then(|(_, v)| v.as_u64())
+}
+
+// ---- the PoJo demo function (Java lambda-example: hello.pojo) ----
+
+/// Mirrors the Java lambda-example's `hello.pojo`: returns a place-holder
+/// object for `id = 1` (the echo forwards here fire-and-forget so the span
+/// propagation from `hello.world` is visible in the trace), 404 otherwise.
+#[preload(route = "hello.pojo", instances = 10, is_private = false)]
+struct HelloPoJo;
+
+#[async_trait]
+impl ComposableFunction for HelloPoJo {
+    async fn handle_event(
+        &self,
+        headers: HashMap<String, String>,
+        _input: EventEnvelope,
+        instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        match headers.get("id").map(String::as_str) {
+            Some("1") => {
+                log::info!("PoJo delivered by instance #{instance}");
+                EventEnvelope::new().set_body(serde_json::json!({
+                    "id": 1,
+                    "name": "Simple PoJo class",
+                    "address": "100 World Blvd, Planet Earth",
+                    "instance": instance,
+                    "origin": Platform::origin(),
+                }))
+            }
+            Some(_) => Err(AppError::new(404, "Not found. Try id = 1")),
+            None => Err(AppError::new(400, "Missing parameter 'id'")),
+        }
+    }
+}
+
+// ---- the Event-over-HTTP authentication demo (Java lambda-example: event.api.auth) ----
+
+/// Demo authentication service for the Event-over-HTTP endpoint.
+///
+/// The `rest.yaml` entry for `POST /api/event` declares
+/// `authentication: 'event.api.auth'`, so every incoming Event API request is
+/// delivered here first. This demo compares the caller's `authorization`
+/// header against a shared token that both peers resolve from the environment
+/// (`demo.peer.token: ${DEMO_PEER_TOKEN:demo}` in application.yml) — never
+/// hard-code a real credential in source or configuration files.
+///
+/// Returning an envelope with a boolean body tells the REST automation engine
+/// to continue (`true`) or reject with HTTP-401 (`false`). Additional headers
+/// on the envelope become **session info** that rides to the target function
+/// as read-only headers — the `user` header in this demo. Replace this
+/// function with your own OAuth 2.0 bearer-token validation for production.
+#[preload(route = "event.api.auth", instances = 10)]
+struct EventApiAuth;
+
+#[async_trait]
+impl ComposableFunction for EventApiAuth {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let request = platform_core::automation::AsyncHttpRequest::from_value(input.body());
+        let expected = AppConfigReader::get_instance().get_property_or("demo.peer.token", "demo");
+        let authorized = request.header("authorization") == Some(expected.as_str());
+        log::info!(
+            "Event API authorization {} {} = {}",
+            request.method(),
+            request.url(),
+            if authorized { "PASS" } else { "FAIL" }
+        );
+        EventEnvelope::new()
+            .set_header("user", "demo")
+            .set_body(authorized)
+    }
 }
 
 // ---- the static-content request filter (increment 8) ----

--- a/examples/hello-world/tests/event_api_auth.rs
+++ b/examples/hello-world/tests/event_api_auth.rs
@@ -1,0 +1,106 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! End-to-end coverage of the Event-over-HTTP authentication demo — the Rust
+//! twin of the Java lambda-example's `EventApiAuthTest`: `rest.yaml`
+//! overrides the default `/api/event` endpoint with the `event.api.auth`
+//! service, which validates the caller's `authorization` header against the
+//! shared demo token (`demo.peer.token`, resolved from `DEMO_PEER_TOKEN`).
+//!
+//! One test function on purpose: the app boots ONCE per process (AutoStart is
+//! a run-once lifecycle), so the accept / wrong-token / missing-token cases
+//! run sequentially against the same server.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use platform_core::automation::{self, event_over_http, event_over_http_with_headers};
+use platform_core::{overrides, AutoStart, EventEnvelope, Platform, PostOffice};
+
+// The application under test is a BIN crate — include its source so the
+// link-time inventory in this test binary carries the app's functions
+// (the echo, hello.pojo and event.api.auth).
+#[allow(dead_code)]
+#[path = "../src/main.rs"]
+mod app;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn event_api_auth_accepts_shared_token_and_rejects_others() {
+    let holding = std::env::temp_dir().join(format!("hello-world-auth-{}", std::process::id()));
+    overrides::set("transient.data.store", &holding.display().to_string());
+    overrides::set("rest.server.port", "0");
+    AutoStart::main(vec![]).await.expect("app lifecycle");
+    let port = automation::server_address().expect("server started").port();
+    let endpoint = format!("http://127.0.0.1:{port}/api/event");
+    let po = PostOffice::new(&Platform::get_instance());
+
+    // 1. ACCEPT: the shared demo token passes authentication, and the session
+    // info injected by event.api.auth (user: demo) rides to the target
+    // function as a read-only header — visible in the echo
+    let mut security_headers = HashMap::new();
+    security_headers.insert("authorization".to_string(), "demo".to_string());
+    let request = EventEnvelope::new()
+        .set_to("hello.world")
+        .set_body(serde_json::json!({"hello": "auth"}))
+        .expect("body");
+    let response = event_over_http_with_headers(
+        &po,
+        &endpoint,
+        request,
+        Duration::from_secs(8),
+        true,
+        &security_headers,
+    )
+    .await
+    .expect("authorized call");
+    assert_eq!(response.status(), 200);
+    let echo: serde_json::Value = response.body_as().expect("echo json");
+    assert_eq!(echo["body"]["hello"], serde_json::json!("auth"));
+    assert_eq!(
+        echo["headers"]["user"],
+        serde_json::json!("demo"),
+        "session info injected by event.api.auth must reach the target"
+    );
+
+    // 2. WRONG TOKEN: rejected with HTTP-401 before reaching the target
+    let mut wrong = HashMap::new();
+    wrong.insert("authorization".to_string(), "let-me-in".to_string());
+    let request = EventEnvelope::new()
+        .set_to("hello.world")
+        .set_body("x")
+        .expect("body");
+    let response = event_over_http_with_headers(
+        &po,
+        &endpoint,
+        request,
+        Duration::from_secs(8),
+        true,
+        &wrong,
+    )
+    .await
+    .expect("transport ok");
+    assert_eq!(response.status(), 401, "wrong token must be rejected");
+
+    // 3. MISSING TOKEN: rejected with HTTP-401
+    let request = EventEnvelope::new()
+        .set_to("hello.world")
+        .set_body("x")
+        .expect("body");
+    let response = event_over_http(&po, &endpoint, request, Duration::from_secs(8), true)
+        .await
+        .expect("transport ok");
+    assert_eq!(response.status(), 401, "missing token must be rejected");
+}

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.10.0**: tracks the canonical mercury-composable line (Java 4.10.0 released the same day — one version, two languages; cross-language Event-over-HTTP interop validated by live bidirectional drives).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-23 | agent: Claude Code (2026-07-23-022937)
+- **last_session:** 2026-07-23 | agent: Claude Code (2026-07-23-152724)
 - **last_review:** 2026-07-23 | through 2026-07-23-013514.md
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -61,6 +61,17 @@ scanning (→ compile-time registration; no runtime scanning in Rust). platform-
   `docs/arch-decisions/ADR.md` (ADR-0001…0007, adapted from the Java repo — read on demand).
   <!-- id: inv-never-couple-functions | created: 2026-07-15 | last_used: 2026-07-15 | uses: 1 | tier: core | origin: 2026-07-15-221632.md -->
 
+- **Telemetry/log presentation parity with the Java reference implementation** — the
+  trace-record topology (record count per trace, service names, parent edges,
+  round_trip-vs-exec kinds, paths) and the log presentation (app-log-context gating,
+  header hygiene) of this port must remain an exact structural replica of the Java
+  engine's, which is THE reference. Rationale (Eric, 2026-07-23): field installations
+  stay POLYGLOT for a long time — DevSecOps teams see both engines' telemetry and logs
+  in one aggregation, and any presentation difference is a support burden they will
+  flag. This is a standing invariant, not a one-off acceptance criterion; the Java-to-
+  Java normalized signature is the acceptance instrument (see increment 64).
+  <!-- id: inv-telemetry-presentation-parity | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: core | origin: 2026-07-23-152724.md -->
+
 *(More invariants will be distilled from mercury-composable's docs/ADRs as each layer is
 ported — e.g. stateless functions, HTTP-style status codes.)*
 
@@ -100,6 +111,19 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
 
 > Mark completed items `- [x]` and leave them in place — the review sweeps them to
 > the archive once older than `archive_window` sessions. Don't archive them by hand.
+
+- [ ] (feature branch awaiting Eric — 2026-07-23) **Telemetry presentation-parity batch
+  (increment 64) IMPLEMENTED on branch `feature/event-api-span-and-auth`** (mirror of the
+  Java reference branch of the same name; NOT pushed — Eric gates). rust-to-rust trace =
+  EXACT replica of java-to-java (empty normalized-signature diff, both patterns; signature
+  file /tmp/java-to-java-reference-signature.md). Structural changes: REST automation
+  CALLBACK dispatch + `async.http.response` span (first + response legs are real spans;
+  business cid moved to the `my_correlation_id` header channel), log-context gating
+  (traced lines only — the increment-5 outside-a-trace divergence retired), `my_*`
+  response-header strip, `event.api.auth` demo + session-info forwarding,
+  demo→declarative rename, hello.pojo forward. Workspace 245/clippy 0/fmt; acceptance
+  drive verified (topology/gating/headers/auth). Close when merged.
+  <!-- id: thread-telemetry-parity-batch | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-23-152724.md -->
 
 - [x] (release — 2026-07-23; CLOSED same day) **v4.10.0 SHIPPED via the normal flow, in
   lock-step with the Java engine** — tag `v4.10.0` on merge commit `4dc70337`

--- a/memory/sessions/2026-07-23-152724.md
+++ b/memory/sessions/2026-07-23-152724.md
@@ -1,0 +1,74 @@
+# Session (2026-07-23T15:27:24.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Increment 64 — telemetry presentation parity with the Java reference** (Eric's
+manual four-direction interop testing; Java fixed FIRST on mercury-composable branch
+`feature/event-api-span-and-auth` = THE reference; acceptance sharpened mid-batch to
+"rust-to-rust must be an EXACT structural replica of java-to-java" per the normalized
+signature /tmp/java-to-java-reference-signature.md). Rust branch
+`feature/event-api-span-and-auth`, NOT pushed — Eric gates.
+
+**Structural fixes (Eric explicitly green-lit low-level RPC refactoring):**
+
+1. **REST automation CALLBACK dispatch** (the root of the missing first-leg span): the
+   endpoint service is no longer invoked as an inbox RPC — the event carries
+   `reply_to = async.http.response` + `cid` = a per-request HTTP context id, and the new
+   `async.http.response` service (registered by `start_http_server`, private, 500
+   instances, traced — Java `AsyncHttpResponse` twin) completes the pending oneshot.
+   The endpoint worker now self-records its span, and the response leg is a visible
+   span parenting onto the replying function's span — including the reference's
+   deliberate cross-pattern asymmetry on the caller side (declarative parents onto the
+   CALLEE's function span; programmatic onto the local task span). Timeout → 408 at the
+   router; pending-map cleanup.
+2. **Business-cid header channel** (Java PostOffice parity): `my_correlation_id` rides
+   as an ENVELOPE header past the context-id cid slot; the worker's trace bracket
+   prefers it — `po.my_correlation_id()` unchanged for direct functions AND now correct
+   (business, not composite) inside flow tasks.
+3. **Log-context gating (Eric's bugs 1+2):** the `context` block renders ONLY inside a
+   traced, non-zero-traced worker bracket — telemetry records and framework/system
+   lines carry NO context at all (constants no longer leak). The increment-5
+   "outside-a-trace constants render" divergence is RETIRED (superseded by Eric's
+   direction; Java lockstep model). `LogContextConfig::render` now takes `&TraceState`.
+4. **`my_*` response-header strip** at the REST boundary (`my_route`/`my_trace_id`/
+   `my_trace_path`/`my_correlation_id`; Java `copyResponseHeaders` parity). NOTE: could
+   not reproduce Eric's leak on current main rust-to-rust (headers were clean) — the
+   strip is defense-in-depth at the documented Java protection point.
+5. **`event.api.auth` demo** (item 7): REST automation `authentication:` support
+   ALREADY EXISTED (increment 6); the missing half was **session info** — auth-verdict
+   headers now ride as the request's `session` map and `/api/event` relays them to the
+   target as read-only headers (`user: demo` visible in the echo). hello-world:
+   `event.api.auth` function + `/api/event` rest.yaml override + `demo.peer.token:
+   ${DEMO_PEER_TOKEN:demo}` (no hard-coded credential). hello-flow: token declaratively
+   (event-over-http.yaml `headers:`) + programmatically
+   (`event_over_http_with_headers`). Client fix: a non-envelope response (the auth 401)
+   returns as-is with its HTTP status (Java `handleFutureResponse` parity). New e2e
+   `examples/hello-world/tests/event_api_auth.rs` (200+session / 401 / 401).
+6. **Renames + hello.pojo:** `/api/event/http/demo` → `/api/event/http/declarative`,
+   flow id likewise (rest.yaml/flows/tests/docs/READMEs); hello-world gains
+   `hello.pojo` (lambda-example twin) and the echo forwards to it fire-and-forget.
+
+**Acceptance (the empty-diff bar): PASSED.** Live two-app drive (hello-flow 8100 →
+hello-world 8085, both patterns), records extracted from both logs, span ids normalized
+to owner names, diffed against the signature: **DECLARATIVE 8/8, PROGRAMMATIC 9/9 —
+missing NONE, extra NONE, span duplicates NONE, no dangling parents.** Log-context
+gating verified (36 context-less framework/telemetry records, 0 violations; traced app
+lines carry the full context). HTTP response headers clean. Auth live: 200 (+`user:
+demo` in echo) / wrong 401 / missing 401. Workspace 245 / clippy 0 / fmt.
+
+**New Architectural Invariant recorded** (Eric via coordinator):
+[[inv-telemetry-presentation-parity]] — polyglot field installations put both engines'
+telemetry/logs in one aggregation, so presentation parity with the Java reference is a
+STANDING invariant of this port, not a one-off acceptance criterion.
+
+## Memory References
+
+- created: inv-telemetry-presentation-parity (born tier: core — Architectural
+  Invariant), thread-telemetry-parity-batch (born tier: working)
+- referenced: port-bottom-up-faithful, conventions-rust-baseline (INCREMENTS ledger,
+  parity notes, fmt/clippy gates), inv-never-couple-functions (the callback dispatch
+  keeps coupling route-name + envelope only)
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>

--- a/memory/sessions/2026-07-23-152724.md
+++ b/memory/sessions/2026-07-23-152724.md
@@ -63,6 +63,17 @@ demo` in echo) / wrong 401 / missing 401. Workspace 245 / clippy 0 / fmt.
 telemetry/logs in one aggregation, so presentation parity with the Java reference is a
 STANDING invariant of this port, not a one-off acceptance criterion.
 
+Also (same session): **deposited the interop test report** into this repo's docs as a
+permanent record (`docs/test-reports/event-over-http-interop.md`, Eric: "the interop
+story stays as a learning for future ports to other languages like Python") — copied
+verbatim from the Java branch's just-updated report (presentation-parity drive +
+normalized signature tables + four-way empty-diff + learnings), with only the three
+relative links adapted to this docs tree (wire-format spec link points at the Java
+site's normative page); added to the mkdocs Reference nav ("Interop Test Report
+(Java ⇄ Rust)") and cross-linked from the event-over-http guide's new See-also,
+mirroring the Java guide. mkdocs unavailable locally — strict build deferred to CI;
+anchors and paths verified by hand.
+
 ## Memory References
 
 - created: inv-telemetry-presentation-parity (born tier: core — Architectural

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,6 +135,7 @@ nav:
       - Platform & PostOffice API: guides/api-overview.md
       - Reserved Names & Headers: guides/reserved-names-and-headers.md
       - Actuators & HTTP Client: guides/actuators-and-http-client.md
+      - "Interop Test Report (Java ⇄ Rust)": test-reports/event-over-http-interop.md
   - Background:
       - Port Scope & Fidelity: background/port-scope.md
       - Architecture Decisions: arch-decisions/ADR.md


### PR DESCRIPTION
## What

REST automation now dispatches endpoint services as **callbacks** through a new registered
`async.http.response` service (the Java twin) instead of RPC through a oneshot inbox,
making the first-leg (`http.flow.adapter`) and response-leg spans real records; the
business correlation-id moves to the reserved `my_correlation_id` envelope-header channel
for exact PostOffice parity (fixing `model.cid` inside flow tasks as well). The application
log context now registers in lockstep with the trace bracket — a `context` block appears
only on log lines emitted inside a traced, non-zero-traced function execution; telemetry
and system lines carry none. Reserved `my_*` metadata is stripped at the REST boundary's
response-header copy. The declarative demo endpoint is renamed
`/api/event/http/declarative`, and the demo pair gains the `event.api.auth` authentication
demo (shared secret from `DEMO_PEER_TOKEN`, session-info forwarding implemented — the
missing half of the existing rest.yaml `authentication:` support) plus the `hello.pojo`
span-propagation hop. The Java ⇄ Rust interop test report is deposited into this repo's
docs as a permanent record, byte-identical to the Java site's copy apart from link paths.

## Why

Field installations stay polyglot — DevSecOps teams aggregate both engines' telemetry and
logs in one place, so presentation differences are support burden. The Java engine is the
reference implementation: its live java-to-java run is distilled into a normalized trace
signature (record set, symbolic parent edges, round_trip vs exec-only kinds, paths,
one-record-per-span, context gating, header hygiene), and this port must produce an exact
structural replica — a bar that required refactoring the low-level RPC dispatch, not
patching the telemetry. Presentation parity is recorded as a standing core invariant of
this port, and the report's "Learnings for future language ports" section keeps the method
as the playbook for the next language.

## Verification

- Workspace 245 tests green, clippy 0 warnings, fmt clean.
- Live rust-to-rust drive: **empty diff** against the reference signature, both patterns
  (8 + 9 records); log-context gating (zero violations across 36 untraced records),
  response headers clean, auth 200/401/401.
- Cross-language: java-to-rust and rust-to-java verified live — **empty diff** in both,
  confirming the symmetry falls out of same-language parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>