### PR TITLE
chore(release): version 4.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,26 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
-## Unreleased
+## Version 4.10.1, 7/23/2026
+
+Patch release: **telemetry presentation parity with the Java reference engine**. Field
+installations stay polyglot — DevSecOps teams aggregate both engines' telemetry and logs
+in one place — so the trace-record topology and log presentation of this port must be an
+**exact structural replica** of the Java engine's. After this release they are: the
+normalized-signature diff is **empty in all four direction combinations** (java→java,
+rust→rust, java→rust, rust→java; both calling patterns, incl. authentication). The
+`/api/event` edge is a visible span aligned with the Java reference, the application log
+context appears only on lines with a real request trace, the declarative demo endpoint is
+renamed for symmetry, the new `event.api.auth` demo shows endpoint protection with
+session-info forwarding, and the full interop story — evidence, defects, fixes, and the
+learnings kept as a playbook for future language ports — is deposited in this repo's docs
+as the [Interop Test Report](docs/test-reports/event-over-http-interop.md). All changes
+in PR [#169](https://github.com/Accenture/mercury/pull/169).
 
 ### Added
 
-1. **Event-over-HTTP authentication demo.** The hello-world example overrides the default
+1. **Event-over-HTTP authentication demo
+   ([#169](https://github.com/Accenture/mercury/pull/169)).** The hello-world example overrides the default
    `/api/event` endpoint with a demo authentication service (`event.api.auth`) that
    validates the caller's `authorization` header against a shared secret resolved from
    the environment (`demo.peer.token: ${DEMO_PEER_TOKEN:demo}` on both peers — no
@@ -29,10 +44,12 @@ the design rationale in [`docs/design/`](docs/design/).
 
 ### Changed
 
-1. **The declarative demo endpoint is renamed for symmetry with its programmatic twin:**
+1. **The declarative demo endpoint is renamed for symmetry with its programmatic twin
+   ([#169](https://github.com/Accenture/mercury/pull/169)):**
    `/api/event/http/demo` → `/api/event/http/declarative` and flow id
    `event-over-http-demo` → `event-over-http-declarative` in the hello-flow example.
-2. **REST automation dispatches the endpoint service as a CALLBACK** (Java `HttpRouter`
+2. **REST automation dispatches the endpoint service as a CALLBACK
+   ([#169](https://github.com/Accenture/mercury/pull/169))** (Java `HttpRouter`
    parity): the event carries `reply_to = async.http.response` and its `cid` is the HTTP
    context id, while the business correlation-id rides the `my_correlation_id` envelope
    header (the worker's trace bracket prefers it, so `po.my_correlation_id()` is
@@ -46,16 +63,19 @@ the design rationale in [`docs/design/`](docs/design/).
 
 ### Fixed
 
-1. **The application log context no longer leaks onto context-less lines.** The
+1. **The application log context no longer leaks onto context-less lines
+   ([#169](https://github.com/Accenture/mercury/pull/169)).** The
    `context` block appears ONLY on log lines emitted inside a traced function execution
    with a real request trace (Java parity: the log context registers per worker
    execution in lockstep with the trace bracket). Telemetry records and framework/system
    lines carry no context block at all — previously they carried a partial block with
    constants and a timestamp.
-2. **Reserved `my_*` metadata is stripped from HTTP response headers** (Java
+2. **Reserved `my_*` metadata is stripped from HTTP response headers
+   ([#169](https://github.com/Accenture/mercury/pull/169))** (Java
    `copyResponseHeaders` protected-metadata parity): `my_route`, `my_trace_id`,
    `my_trace_path` and `my_correlation_id` never reach the wire.
-3. **The Event-over-HTTP client returns a non-envelope response as-is** (e.g. an
+3. **The Event-over-HTTP client returns a non-envelope response as-is
+   ([#169](https://github.com/Accenture/mercury/pull/169))** (e.g. an
    authentication-layer 401 in the REST error shape) with its HTTP status, instead of
    failing with "Invalid event-over-http response" (Java `handleFutureResponse` parity).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.10.0"
+version = "4.10.1"
 dependencies = [
  "async-trait",
  "log",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "event-script"
-version = "4.10.0"
+version = "4.10.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "event-script-macros"
-version = "4.10.0"
+version = "4.10.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -367,7 +367,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.10.0"
+version = "4.10.1"
 dependencies = [
  "async-trait",
  "event-script",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.10.0"
+version = "4.10.1"
 dependencies = [
  "async-trait",
  "log",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph"
-version = "4.10.0"
+version = "4.10.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph-macros"
-version = "4.10.0"
+version = "4.10.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -579,7 +579,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minigraph-playground"
-version = "4.10.0"
+version = "4.10.1"
 dependencies = [
  "async-trait",
  "event-script",
@@ -684,7 +684,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "platform-core"
-version = "4.10.0"
+version = "4.10.1"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macros"
-version = "4.10.0"
+version = "4.10.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.10.0"
+version = "4.10.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury-composable"

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.10.0**: tracks the canonical mercury-composable line (Java 4.10.0 released the same day — one version, two languages; cross-language Event-over-HTTP interop validated by live bidirectional drives).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-23 | agent: Claude Code (2026-07-23-152724)
+- **last_session:** 2026-07-23 | agent: Claude Code (2026-07-23-163133)
 - **last_review:** 2026-07-23 | through 2026-07-23-013514.md
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -81,7 +81,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Rust layer by layer, foundation → UI (platform-core, then event-script, then active
   knowledge graph), preserving the Java project's behavior. The Java repo is the canonical
   spec (map, don't mirror).
-  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-23 | uses: 79 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-23 | uses: 81 | tier: active | origin: 2026-07-15-215538.md -->
 ## Conventions
 
 > Established with the first code (increment 1, 2026-07-15); enforced from the first commit.
@@ -105,14 +105,27 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   2026-07-16): annotated functions + `platform_core::auto_start_main!();` with the app's
   `resources/` beside its `Cargo.toml` — never cargo examples inside a library crate.
   Event-script and knowledge-graph demos land as sibling `examples/<name>/` crates.
-  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-23 | uses: 78 | tier: active | origin: 2026-07-15-224707.md -->
+  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-23 | uses: 80 | tier: active | origin: 2026-07-15-224707.md -->
 
 ## Open Threads
 
 > Mark completed items `- [x]` and leave them in place — the review sweeps them to
 > the archive once older than `archive_window` sessions. Don't archive them by hand.
 
-- [ ] (feature branch awaiting Eric — 2026-07-23) **Telemetry presentation-parity batch
+- [ ] (release in flight — 2026-07-23) **v4.10.1 release prepared** (patch: the telemetry
+  presentation-parity batch). Branch `chore/release-4.10.1` from main `ecec21c5` (PR #169
+  merge): workspace version 4.10.0→4.10.1 (root Cargo.toml only — members inherit;
+  Cargo.lock regenerated; sweep re-verified the surface is just the workspace field),
+  CHANGELOG `## Version 4.10.1, 7/23/2026` led by the presentation-parity story (empty
+  normalized-signature diff in all four directions; polyglot-DevSecOps rationale) with
+  PR #169 stamped on every entry. Gate green at the new version: workspace 245 / clippy
+  0 / fmt. NOT pushed — Eric pushes and opens the PR. The Java counterpart PR #217
+  (reference-side changes) is in CI; the Java repo follows with its own release. Close
+  when tagged and published.
+  <!-- id: thread-release-4-10-1 | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-23-163133.md -->
+
+- [x] (feature branch — 2026-07-23; MERGED as PR [#169](https://github.com/Accenture/mercury/pull/169),
+  merge `ecec21c5`) **Telemetry presentation-parity batch
   (increment 64) IMPLEMENTED on branch `feature/event-api-span-and-auth`** (mirror of the
   Java reference branch of the same name; NOT pushed — Eric gates). rust-to-rust trace =
   EXACT replica of java-to-java (empty normalized-signature diff, both patterns; signature
@@ -123,7 +136,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   response-header strip, `event.api.auth` demo + session-info forwarding,
   demo→declarative rename, hello.pojo forward. Workspace 245/clippy 0/fmt; acceptance
   drive verified (topology/gating/headers/auth). Close when merged.
-  <!-- id: thread-telemetry-parity-batch | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-23-152724.md -->
+  <!-- id: thread-telemetry-parity-batch | created: 2026-07-23 | last_used: 2026-07-23 | uses: 2 | tier: active | origin: 2026-07-23-152724.md -->
 
 - [x] (release — 2026-07-23; CLOSED same day) **v4.10.0 SHIPPED via the normal flow, in
   lock-step with the Java engine** — tag `v4.10.0` on merge commit `4dc70337`

--- a/memory/sessions/2026-07-23-163133.md
+++ b/memory/sessions/2026-07-23-163133.md
@@ -1,0 +1,36 @@
+# Session (2026-07-23T16:31:33.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**v4.10.1 release prepared** (Eric's direction; the patch carrying the telemetry
+presentation-parity batch, PR [#169](https://github.com/Accenture/mercury/pull/169)
+merged as `ecec21c5`). Branch `chore/release-4.10.1` from main HEAD. NOT pushed — Eric
+pushes and opens the PR. The Java counterpart PR #217 (reference-side changes) is in CI;
+the Java repo follows with its own release.
+
+- **Version bump 4.10.0 → 4.10.1:** the surface re-verified as exactly ONE field — the
+  root `Cargo.toml` workspace version (members inherit; nothing new crept in with #169;
+  the digit-guarded sweep found only historical mentions, left untouched). Cargo.lock
+  regenerated (10 member entries at 4.10.1).
+- **CHANGELOG:** `## Unreleased` → `## Version 4.10.1, 7/23/2026`, led by the
+  presentation-parity story: exact structural replica of the Java reference — empty
+  normalized-signature diff in all four direction combinations (both patterns, incl.
+  authentication); polyglot-DevSecOps rationale; /api/event visible-edge alignment;
+  log-context gating fix; declarative rename; event.api.auth demo with session-info
+  forwarding; interop test report deposited in this repo's docs as the playbook for
+  future language ports. PR #169 stamped on every entry.
+- **Gate at the new version:** workspace 245 tests green, clippy 0 warnings,
+  `fmt --check` clean.
+- Continuity: [[thread-telemetry-parity-batch]] closed (merged as #169); new
+  release-in-flight thread [[thread-release-4-10-1]].
+
+## Memory References
+
+- created: thread-release-4-10-1 (born tier: working)
+- referenced: thread-telemetry-parity-batch (closed — PR #169 merged),
+  inv-telemetry-presentation-parity (the release headline), port-bottom-up-faithful,
+  conventions-rust-baseline (CHANGELOG/INCREMENTS conventions, fmt/clippy gates)
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

Version bump 4.10.0 → 4.10.1 (root workspace field; members inherit; Cargo.lock
regenerated) and the CHANGELOG's `Version 4.10.1, 7/23/2026` section covering PR #169: the
telemetry presentation-parity batch (callback dispatch with visible first/response legs,
log-context gating, `my_*` header hygiene), the declarative endpoint rename, the
`event.api.auth` demo with session-info forwarding, and the interop test report now hosted
in this repo's docs. The Java counterpart PR #217 carries the reference-side changes and is
merged; the Java repo follows with its own v4.10.1.

## Why

Patch release in lock-step with the Java engine, delivering a standing invariant set from
field experience: polyglot installations aggregate both engines' telemetry and logs in
front of the same DevSecOps team, so the two engines' output must be structurally
identical. After this release the rust-to-rust trace log is an exact replica of
java-to-java — verified by an empty normalized-signature diff in all four direction
combinations — and the validation arc is preserved in-repo as the playbook for future
language ports (e.g. Python). Gate verified at the new version: 245 workspace tests,
clippy-clean, fmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>