### PR TITLE
chore(release): version 4.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,47 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
-## Unreleased
+## Version 4.10.2, 7/23/2026
+
+Patch release: **the metadata contract, hardened in lock-step with the Java engine**. A
+composable function has exactly three inputs — headers, body and instance; the headers
+are a **copy** of the envelope headers with read-only metadata **injected by the worker
+at entry and sanitized at exit** — metadata is never transported in the event itself.
+The business correlation-id rides an engine-managed envelope tag (`my_cid`) and is echoed
+on every HTTP response, and the RPC reply path is aligned with the Java design: a
+**single reserved `temporary.inbox` route** keyed by correlation id — the `inbox.*`
+namespace belongs to applications — registered with deterministic essential-service
+sequencing, with the mesh-era `route@origin` syntax never generated. Re-verified live in
+all four direction combinations at an **empty trace-signature diff** — the full battery
+(functionality, correlation echo, injected-metadata parity, authentication, signature) is
+recorded in the [Interop Test Report](docs/test-reports/event-over-http-interop.md).
+The release also mirrors the team-contributed Event Script **collection plugins**
+(`isEmpty`, `getFirst`, `getLast` — flows are engine-portable, so plugins must exist on
+both engines). Metadata/reply-path changes in PR
+[#171](https://github.com/Accenture/mercury/pull/171).
 
 ### Added
 
-1. **The HTTP response echoes the business correlation-id.** REST automation returns the
+1. **The HTTP response echoes the business correlation-id
+   ([#171](https://github.com/Accenture/mercury/pull/171)).** REST automation returns the
    request's correlation-id (inbound or edge-generated) on the response under the
    configured header name (default `X-Correlation-Id`), so an edge caller can correlate
    without parsing the body. A response header of the same name set by the function takes
    precedence. The edge also stamps the resolved value onto the request dataset headers,
    so the function, the flow engine (`model.cid`) and the response all see the SAME id.
 
-2. **The `inbox.*` route namespace belongs to applications.** RPC replies now resolve
+2. **Collection plugins for Event Script: `isEmpty`, `getFirst`, `getLast`.** Contributed
+   to the Java engine in mercury-composable
+   [PR #220](https://github.com/Accenture/mercury-composable/pull/220) and mirrored here
+   for flow portability — Event Script flows are engine-portable YAML, so
+   `f:isEmpty(...)` behaves identically on both engines, including error text (which
+   reads the same in aggregated logs). `isEmpty`: a single Collection/Map/String/array —
+   true when it has no elements (use `isNull`/`notNull` for null checks; null or an
+   unsupported type is an error). `getFirst`/`getLast`: a single non-empty List — its
+   first/last element.
+
+3. **The `inbox.*` route namespace belongs to applications
+   ([#171](https://github.com/Accenture/mercury/pull/171)).** RPC replies now resolve
    through the ONE reserved reply-listener route, `temporary.inbox` (Java `TemporaryInbox`
    parity: private, zero-tracing, 500 instances, registered by the essential-service step
    at the highest startup priority and present on every platform from construction), keyed
@@ -36,7 +65,8 @@ the design rationale in [`docs/design/`](docs/design/).
 
 ### Fixed
 
-1. **Protected metadata is never transported in the event.** The business correlation-id
+1. **Protected metadata is never transported in the event
+   ([#171](https://github.com/Accenture/mercury/pull/171)).** The business correlation-id
    now rides an engine-managed envelope tag (`tags` wire field — wire-compatible with the
    Java engine) instead of a `my_correlation_id` envelope header, and the worker injects
    the `my_*` read-only keys (`my_route`, `my_trace_id`, `my_trace_path`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.10.1"
+version = "4.10.2"
 dependencies = [
  "async-trait",
  "log",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "event-script"
-version = "4.10.1"
+version = "4.10.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "event-script-macros"
-version = "4.10.1"
+version = "4.10.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -367,7 +367,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.10.1"
+version = "4.10.2"
 dependencies = [
  "async-trait",
  "event-script",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.10.1"
+version = "4.10.2"
 dependencies = [
  "async-trait",
  "log",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph"
-version = "4.10.1"
+version = "4.10.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph-macros"
-version = "4.10.1"
+version = "4.10.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -579,7 +579,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minigraph-playground"
-version = "4.10.1"
+version = "4.10.2"
 dependencies = [
  "async-trait",
  "event-script",
@@ -684,7 +684,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "platform-core"
-version = "4.10.1"
+version = "4.10.2"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macros"
-version = "4.10.1"
+version = "4.10.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.10.1"
+version = "4.10.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury-composable"

--- a/crates/event-script/src/plugins.rs
+++ b/crates/event-script/src/plugins.rs
@@ -287,6 +287,66 @@ fn plugin_ne(args: &[Value]) -> Result<Value, String> {
     Ok(Value::Boolean(rest.iter().any(|v| v != first)))
 }
 
+// ---- Collection operators (contributed to the Java engine in
+// mercury-composable PR #220; mirrored for flow portability — a flow using
+// f:isEmpty(...) must behave identically on both engines, including error
+// text read in aggregated logs) ----
+
+/// `f:isEmpty(value)` — true when a Collection/Map/String/array has no
+/// elements (Java `IsEmptyOperator`). Null checks belong to `isNull` /
+/// `notNull`: a null input is an error, as is an unsupported type.
+fn plugin_is_empty(args: &[Value]) -> Result<Value, String> {
+    let [value] = args else {
+        return Err("One input is required to check if value is empty".to_string());
+    };
+    match value {
+        Value::Nil => Err("Input cannot be null to check if value is empty".to_string()),
+        Value::Array(items) => Ok(Value::Boolean(items.is_empty())),
+        Value::Map(entries) => Ok(Value::Boolean(entries.is_empty())),
+        Value::String(text) => Ok(Value::Boolean(
+            text.as_str().map(str::is_empty).unwrap_or(true),
+        )),
+        // the byte-array analog of a Java primitive array
+        Value::Binary(bytes) => Ok(Value::Boolean(bytes.is_empty())),
+        other => Err(format!(
+            "Unsupported input type to check if value is empty: {}",
+            value_type_name(other)
+        )),
+    }
+}
+
+/// `f:getFirst(list)` — the first element of a non-empty List (Java
+/// `GetFirstOperator`). Null, non-list or empty input is an error.
+fn plugin_get_first(args: &[Value]) -> Result<Value, String> {
+    let [value] = args else {
+        return Err("One input is required to get first item from list".to_string());
+    };
+    match value {
+        Value::Nil => Err("Input cannot be null to get first item from list".to_string()),
+        Value::Array(items) => match items.first() {
+            Some(first) => Ok(first.clone()),
+            None => Err("Input cannot be empty to get first item from list".to_string()),
+        },
+        _ => Err("Input must be a list to get first item".to_string()),
+    }
+}
+
+/// `f:getLast(list)` — the last element of a non-empty List (Java
+/// `GetLastOperator`). Null, non-list or empty input is an error.
+fn plugin_get_last(args: &[Value]) -> Result<Value, String> {
+    let [value] = args else {
+        return Err("One input is required to get last item from list".to_string());
+    };
+    match value {
+        Value::Nil => Err("Input cannot be null to get last item from list".to_string()),
+        Value::Array(items) => match items.last() {
+            Some(last) => Ok(last.clone()),
+            None => Err("Input cannot be empty to get last item from list".to_string()),
+        },
+        _ => Err("Input must be a list to get last item".to_string()),
+    }
+}
+
 fn builtin_registrations() -> HashMap<String, Registration> {
     let mut map = HashMap::new();
     let implemented: &[(&str, PluginBody)] = &[
@@ -338,6 +398,10 @@ fn builtin_registrations() -> HashMap<String, Registration> {
         ("uniqueSet", plugin_unique_set),
         ("defaultValue", plugin_default_value),
         ("validate", plugin_validate),
+        // Collection operators (Java PR #220 mirror)
+        ("isEmpty", plugin_is_empty),
+        ("getFirst", plugin_get_first),
+        ("getLast", plugin_get_last),
     ];
     for (name, body) in completed {
         map.insert(name.to_string(), Registration::Implemented(*body));
@@ -350,6 +414,123 @@ include!("plugins_e8.rs");
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Twin of the Java `IsEmptyOperatorTest` (PR #220): positives across
+    /// the supported types — incl. the byte-array analog of an empty /
+    /// non-empty primitive array — and invalid inputs with exact messages.
+    #[test]
+    fn is_empty_matches_java_semantics() {
+        // discovery: the plugin is registered under its f: name
+        assert!(contains_simple_plugin("isEmpty"));
+        let t = Value::Boolean(true);
+        let f = Value::Boolean(false);
+        // Collection (list)
+        assert_eq!(calculate("isEmpty", &[Value::Array(vec![])]), Ok(t.clone()));
+        assert_eq!(
+            calculate("isEmpty", &[Value::Array(vec![Value::from(1)])]),
+            Ok(f.clone())
+        );
+        // Map
+        assert_eq!(calculate("isEmpty", &[Value::Map(vec![])]), Ok(t.clone()));
+        assert_eq!(
+            calculate(
+                "isEmpty",
+                &[Value::Map(vec![(Value::from("k"), Value::from("v"))])]
+            ),
+            Ok(f.clone())
+        );
+        // CharSequence (string)
+        assert_eq!(calculate("isEmpty", &[Value::from("")]), Ok(t.clone()));
+        assert_eq!(calculate("isEmpty", &[Value::from("x")]), Ok(f.clone()));
+        // primitive array analog (byte array)
+        assert_eq!(
+            calculate("isEmpty", &[Value::Binary(vec![])]),
+            Ok(t.clone())
+        );
+        assert_eq!(
+            calculate("isEmpty", &[Value::Binary(vec![7u8])]),
+            Ok(f.clone())
+        );
+        // invalid inputs: exact Java-parity messages
+        assert_eq!(
+            calculate("isEmpty", &[]),
+            Err("One input is required to check if value is empty".to_string())
+        );
+        assert_eq!(
+            calculate("isEmpty", &[Value::from(""), Value::from("")]),
+            Err("One input is required to check if value is empty".to_string())
+        );
+        assert_eq!(
+            calculate("isEmpty", &[Value::Nil]),
+            Err("Input cannot be null to check if value is empty".to_string())
+        );
+        assert_eq!(
+            calculate("isEmpty", &[Value::from(42)]),
+            Err("Unsupported input type to check if value is empty: Integer".to_string())
+        );
+        assert_eq!(
+            calculate("isEmpty", &[Value::Boolean(true)]),
+            Err("Unsupported input type to check if value is empty: Boolean".to_string())
+        );
+    }
+
+    /// Twin of the Java `GetFirstOperatorTest` / `GetLastOperatorTest`
+    /// (PR #220): a single non-empty List; null, non-list or empty input is
+    /// an error with the exact message.
+    #[test]
+    fn get_first_and_get_last_match_java_semantics() {
+        assert!(contains_simple_plugin("getFirst"));
+        assert!(contains_simple_plugin("getLast"));
+        let list = Value::Array(vec![Value::from("a"), Value::from(2), Value::from("z")]);
+        assert_eq!(
+            calculate("getFirst", std::slice::from_ref(&list)),
+            Ok(Value::from("a"))
+        );
+        assert_eq!(
+            calculate("getLast", std::slice::from_ref(&list)),
+            Ok(Value::from("z"))
+        );
+        // single-element list: first == last
+        let one = Value::Array(vec![Value::from(7)]);
+        assert_eq!(
+            calculate("getFirst", std::slice::from_ref(&one)),
+            Ok(Value::from(7))
+        );
+        assert_eq!(calculate("getLast", &[one]), Ok(Value::from(7)));
+        // invalid inputs: exact Java-parity messages
+        assert_eq!(
+            calculate("getFirst", &[]),
+            Err("One input is required to get first item from list".to_string())
+        );
+        assert_eq!(
+            calculate("getLast", &[]),
+            Err("One input is required to get last item from list".to_string())
+        );
+        assert_eq!(
+            calculate("getFirst", &[Value::Nil]),
+            Err("Input cannot be null to get first item from list".to_string())
+        );
+        assert_eq!(
+            calculate("getLast", &[Value::Nil]),
+            Err("Input cannot be null to get last item from list".to_string())
+        );
+        assert_eq!(
+            calculate("getFirst", &[Value::from("not-a-list")]),
+            Err("Input must be a list to get first item".to_string())
+        );
+        assert_eq!(
+            calculate("getLast", &[Value::from(9)]),
+            Err("Input must be a list to get last item".to_string())
+        );
+        assert_eq!(
+            calculate("getFirst", &[Value::Array(vec![])]),
+            Err("Input cannot be empty to get first item from list".to_string())
+        );
+        assert_eq!(
+            calculate("getLast", &[Value::Array(vec![])]),
+            Err("Input cannot be empty to get last item from list".to_string())
+        );
+    }
 
     #[test]
     fn core_plugins_match_java_semantics() {

--- a/crates/event-script/tests/flow_runtime.rs
+++ b/crates/event-script/tests/flow_runtime.rs
@@ -434,11 +434,31 @@ fn json_body(reply: &EventEnvelope) -> serde_json::Value {
 
 // ---- the E2E scenarios ----
 
+/// One-time process setup shared by EVERY test in this binary (the same
+/// `Once` pattern as compiler.rs / mapping_engine.rs). Tests run in parallel
+/// threads, and the FIRST touch of `AppConfigReader` freezes the resource
+/// roots into the config snapshot — `Platform::new()` touches the config
+/// through the reply-listener registration (its worker resolves
+/// `skip.rpc.tracing`), so a test that skipped this setup could freeze the
+/// snapshot WITHOUT `tests/resources`: `yaml.flow.automation` would fall back
+/// to the single default manifest and the more-flows/rust-flows fixtures
+/// would never load ("Flow dynamic-reserved-key not found" — seen on slow CI
+/// runners). Every test body must call this first.
+fn setup_config() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        platform_core::resources::prepend_resource_root("tests/resources");
+        let holding =
+            std::env::temp_dir().join(format!("mercury-flow-test-{}", std::process::id()));
+        platform_core::overrides::set("transient.data.store", &holding.display().to_string());
+        // pin the configuration snapshot NOW, with the test root in place
+        let _ = platform_core::AppConfigReader::get_instance();
+    });
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn flows_run_end_to_end_like_java() {
-    platform_core::resources::prepend_resource_root("tests/resources");
-    let holding = std::env::temp_dir().join(format!("mercury-flow-test-{}", std::process::id()));
-    platform_core::overrides::set("transient.data.store", &holding.display().to_string());
+    setup_config();
     // the one-liner lifecycle collects the engine (compiler/manager/executor)
     // and every task function above from the annotation inventory
     AutoStart::main(vec![]).await.expect("lifecycle");
@@ -1316,6 +1336,7 @@ async fn flows_run_end_to_end_like_java() {
 /// "Missing body in dataset" from both launch() and request().
 #[tokio::test]
 async fn flow_launch_requires_a_body_in_the_dataset() {
+    setup_config();
     let platform = Platform::new();
     let no_body = from_json(&serde_json::json!({"header": {}}));
     let err = FlowExecutor::request(

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -83,6 +83,7 @@
 | 64 | Telemetry presentation parity with the Java reference: REST automation callback dispatch + `async.http.response` span (first/response legs are real spans), log-context gating (traced lines only), `my_*` response-header strip, business-cid header channel, `event.api.auth` demo + session info, demo→declarative rename, `hello.pojo` — rust-to-rust trace = EXACT replica of java-to-java (empty signature diff, both patterns) | 2026-07-23 | — | 245 |
 | 65 | Metadata injection hardening (Java parity): business cid rides the engine-managed `my_cid` envelope tag (wire-compatible `tags` field), worker injects the four `my_*` read-only keys into the input header copy at entry and sanitizes them (+ `x-event-api`) at exit — metadata is never transported; REST response echoes X-Correlation-Id; edge stamps the resolved cid onto the dataset headers | 2026-07-23 | — | 249 |
 | 66 | `temporary.inbox` alignment (Java parity): ONE reserved RPC reply-listener route keyed by correlation id — the `inbox.*` namespace freed for applications; RPC marker = the reserved `rpc` tag; `@origin` addressing never generated, parsed away inbound; reply dispatch direct on the sender's runtime | 2026-07-23 | — | 250 |
+| 67 | Collection plugins mirror (`isEmpty`/`getFirst`/`getLast` — contributed to the Java engine in mercury-composable PR #220): flows are engine-portable YAML, so plugins + error text behave identically on both engines | 2026-07-23 | — | 252 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -1965,6 +1966,29 @@ staging area queued to a human operator, e.g. `inbox.approval`). Mirror of Java'
   manual replies are the interceptor pattern). Workspace 250 / clippy 0 / fmt;
   span-signature acceptance re-run (rust-to-rust empty diff — the reserved route is
   zero-traced, signature unchanged).
+
+---
+
+## Increment 67 — Collection plugins mirror: isEmpty, getFirst, getLast (2026-07-23)
+
+Team-contributed to the Java engine (mercury-composable PR #220, author Chris H) and
+mirrored here per Eric's ruling: Event Script flows are engine-portable YAML and this
+port has the full simple-plugin system, so `f:isEmpty(...)` must behave identically on
+both engines — including ERROR TEXT, which DevSecOps teams read in aggregated logs
+(presentation parity extends to error messages).
+
+- `isEmpty` — exactly one input; Collection/Map/String/array (the byte-array `Binary`
+  is the primitive-array analog) → boolean; null input or an unsupported type is an
+  error with the Java message ("Input cannot be null to check if value is empty" /
+  "Unsupported input type to check if value is empty: <Type>") — null checks belong to
+  `isNull`/`notNull` per the house convention.
+- `getFirst`/`getLast` — exactly one input; a non-empty List → its first/last element;
+  null, non-list, or empty list errors match the Java messages verbatim.
+- Registered in the built-in table (the loader reports 45 built-ins now); test twins of
+  the Java suites (positives across all supported types incl. empty/non-empty byte
+  arrays; every invalid case asserting the exact message; registry discovery). Docs:
+  syntax guide's Built-in Plugins table gains the **Collection** category (Java wording);
+  hello-flow README count. Workspace 252 / clippy 0 / fmt.
 
 ---
 

--- a/docs/guides/event-script/syntax.md
+++ b/docs/guides/event-script/syntax.md
@@ -1424,6 +1424,9 @@ For example:
 | **Logical**         | startsWith      | Two strings, case insensitive.                                                                                        |
 | **Logical**         | endsWith        | Two strings, case insensitive.                                                                                        |
 | **Logical**         | includes        | Two strings, case insensitive OR one list and one string                                                              |
+| **Collection**      | isEmpty         | A single Collection, Map, String or array — true when it has no elements. Use `isNull` / `notNull` for null checks; a null or unsupported input is an error. |
+| **Collection**      | getFirst        | A single non-empty List — returns its first element.                                                                  |
+| **Collection**      | getLast         | A single non-empty List — returns its last element.                                                                   |
 | **Type Conversion** | b64             | Either a base64 encoded String, OR a byte array.                                                                      |
 | **Type Conversion** | binary          | Either a byte[], Map or String                                                                                        |
 | **Type Conversion** | length          | Either a byte[], List or String                                                                                       |

--- a/examples/hello-flow/README.md
+++ b/examples/hello-flow/README.md
@@ -13,7 +13,7 @@ binds the endpoint to the flow with one line:
 ```
 
 Linking the `event-script` crate self-registers the whole engine (compiler,
-manager, task executor, HTTP adapter, resilience handler, 42 built-in
+manager, task executor, HTTP adapter, resilience handler, 45 built-in
 plugins) through the same annotation inventory that collects the app's own
 functions — `main()` is still one line.
 

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.10.1**: tracks the canonical mercury-composable line (Java 4.10.1 released the same day — one version, two languages; telemetry presentation parity: empty normalized-signature diff in all four direction combinations).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-23 | agent: Claude Code (2026-07-23-221942)
+- **last_session:** 2026-07-23 | agent: Claude Code (2026-07-23-231506)
 - **last_review:** 2026-07-23 | through 2026-07-23-013514.md
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -81,7 +81,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Rust layer by layer, foundation → UI (platform-core, then event-script, then active
   knowledge graph), preserving the Java project's behavior. The Java repo is the canonical
   spec (map, don't mirror).
-  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-23 | uses: 82 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-23 | uses: 84 | tier: active | origin: 2026-07-15-215538.md -->
 ## Conventions
 
 > Established with the first code (increment 1, 2026-07-15); enforced from the first commit.
@@ -105,14 +105,26 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   2026-07-16): annotated functions + `platform_core::auto_start_main!();` with the app's
   `resources/` beside its `Cargo.toml` — never cargo examples inside a library crate.
   Event-script and knowledge-graph demos land as sibling `examples/<name>/` crates.
-  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-23 | uses: 81 | tier: active | origin: 2026-07-15-224707.md -->
+  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-23 | uses: 83 | tier: active | origin: 2026-07-15-224707.md -->
 
 ## Open Threads
 
 > Mark completed items `- [x]` and leave them in place — the review sweeps them to
 > the archive once older than `archive_window` sessions. Don't archive them by hand.
 
-- [ ] (feature branch awaiting Eric — 2026-07-23) **Metadata injection hardening
+- [ ] (release in flight — 2026-07-23) **v4.10.2 release prepared** (patch: metadata
+  contract + temporary.inbox alignment + the mirrored collection plugins). Branch
+  `chore/release-4.10.2` from main `f86fbec2` (PR #171 merge): collection-plugins
+  feature commit (isEmpty/getFirst/getLast — Java PR #220 mirror, error text verbatim,
+  45 built-ins) + release bump 4.10.1→4.10.2 (root Cargo.toml only; lock regenerated),
+  CHANGELOG `## Version 4.10.2, 7/23/2026` led by the metadata contract + reply-path
+  alignment, four-way empty diff noted, interop report linked, PR #171 stamped. Gate:
+  workspace 252 / clippy 0 / fmt. NOT pushed — Eric pushes and opens the PR; the Java
+  v4.10.2 (its #221 + #220) releases in parallel. Close when tagged and published.
+  <!-- id: thread-release-4-10-2 | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-23-231506.md -->
+
+- [x] (feature branch — 2026-07-23; MERGED as PR [#171](https://github.com/Accenture/mercury/pull/171),
+  merge `f86fbec2`) **Metadata injection hardening
   (increment 65) IMPLEMENTED on branch `feature/metadata-injection-hardening`** (mirror
   of the Java reference branch of the same name; NOT pushed — Eric gates). Eric's design
   ruling: a function's headers are a COPY with read-only metadata INJECTED at entry and
@@ -133,7 +145,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   250/clippy 0/fmt; span signature UNCHANGED (empty diff re-verified). Serves
   [[inv-telemetry-presentation-parity]]. Close when
   merged.
-  <!-- id: thread-metadata-injection-hardening | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-23-213440.md -->
+  <!-- id: thread-metadata-injection-hardening | created: 2026-07-23 | last_used: 2026-07-23 | uses: 3 | tier: active | origin: 2026-07-23-213440.md -->
 
 - [x] (release — 2026-07-23; CLOSED same day) **v4.10.1 SHIPPED via the normal flow, in
   lock-step with the Java engine** — tag `v4.10.1` on merge commit `2c4e4066`

--- a/memory/sessions/2026-07-23-231506.md
+++ b/memory/sessions/2026-07-23-231506.md
@@ -1,0 +1,45 @@
+# Session (2026-07-23T23:15:06.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**v4.10.2 release prepared** (lock-step with the Java engine's parallel v4.10.2 prep;
+its content: #221 metadata hardening + #220 collection plugins). Branch
+`chore/release-4.10.2` from main `f86fbec2` (the PR #171 merge). Two commits: the
+collection-plugins feature, then the release bump. NOT pushed — Eric pushes and opens
+the PR.
+
+- **Collection plugins mirror (increment 67, commit `48851859`)** — Eric's mid-prep
+  correction: the three team-contributed Event Script plugins (Java PR #220, author
+  Chris H) are NOT Java-only; flows are engine-portable YAML, so `f:isEmpty(...)` must
+  behave identically on both engines INCLUDING error text (presentation parity extends
+  to error messages). `isEmpty` (Collection/Map/String/array — Binary is the
+  primitive-array analog; null/unsupported = error, null checks belong to
+  isNull/notNull), `getFirst`/`getLast` (single non-empty List) — Java error messages
+  verbatim; test twins of the Java suites (positives across types, exact-message
+  invalid cases, registry discovery); syntax guide gains the Collection category;
+  45 built-ins now.
+- **Version bump 4.10.1 → 4.10.2:** the surface re-verified as the root Cargo.toml
+  workspace field alone (members inherit; Cargo.lock regenerated, 10 members at
+  4.10.2; only historical mentions elsewhere, untouched).
+- **CHANGELOG:** `## Unreleased` → `## Version 4.10.2, 7/23/2026`, led by the metadata
+  contract (headers = copy + injected at entry + sanitized at exit; metadata never
+  transported) and the RPC reply-path alignment (single reserved temporary.inbox; the
+  inbox.* namespace belongs to applications; essential-service sequencing; @origin
+  never generated), noting the four-way empty-diff re-verification, linking the
+  interop test report, mentioning the mirrored collection plugins (origin credited),
+  PR #171 stamped on the metadata/reply-path entries.
+- **Gate at the new version:** workspace 252 tests green (250 + 2 plugin suites),
+  clippy 0, fmt clean.
+- Continuity: [[thread-metadata-injection-hardening]] closed (merged as PR #171,
+  merge `f86fbec2`); new release-in-flight thread [[thread-release-4-10-2]].
+
+## Memory References
+
+- created: thread-release-4-10-2 (born tier: working)
+- referenced: thread-metadata-injection-hardening (closed — PR #171 merged),
+  inv-telemetry-presentation-parity (error-text parity is this invariant applied to
+  plugins), port-bottom-up-faithful, conventions-rust-baseline
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>

--- a/memory/sessions/2026-07-23-231506.md
+++ b/memory/sessions/2026-07-23-231506.md
@@ -35,6 +35,25 @@ the PR.
 - Continuity: [[thread-metadata-injection-hardening]] closed (merged as PR #171,
   merge `f86fbec2`); new release-in-flight thread [[thread-release-4-10-2]].
 
+Also (same session): **CI flake on PR #172 diagnosed, reproduced and fixed** (commit on
+the release branch). Failure: flow_runtime's `flows_run_end_to_end_like_java` — "Flow
+dynamic-reserved-key not found". ROOT CAUSE (not introduced by this branch — latent on
+main since PR #171): the two tests in the binary run in parallel threads;
+`flow_launch_requires_a_body_in_the_dataset` calls `Platform::new()`, which since
+increment 66 touches `AppConfigReader` (the reply-listener worker resolves
+skip.rpc.tracing) — if that snapshot freezes BEFORE the e2e test's
+`prepend_resource_root("tests/resources")`, `yaml.flow.automation` falls back to the
+single default manifest and more-flows.yaml/rust-flows.yaml never load. Reproduced
+locally under CPU load (1-in-14/1-in-20 runs; the failing run's log shows "Loading event
+scripts from classpath:/flows.yaml" ONLY — the smoking gun); PR #171's green CI was
+timing luck. FIX: the established `setup_config()` Once pattern (as in compiler.rs /
+mapping_engine.rs) — both tests pin roots + overrides + the config snapshot first.
+0 failures in 80 loaded runs after the fix (plus --test-threads=1 pass). LESSON
+(test-binary convention, now uniform across event-script): any test binary whose tests
+run in parallel must pin the AppConfigReader snapshot inside a shared Once BEFORE any
+test body — Platform::new() now touches the config, so "the other test doesn't need
+setup" no longer holds.
+
 ## Memory References
 
 - created: thread-release-4-10-2 (born tier: working)


### PR DESCRIPTION
## What

Version bump 4.10.1 → 4.10.2 and the CHANGELOG's `Version 4.10.2, 7/23/2026` section
covering PR #171 — the metadata contract (read-only `my_*` keys injected at entry,
sanitized at exit, never transported; business cid on the engine-managed `my_cid` tag;
`X-Correlation-Id` echoed on every response) and the RPC reply-path alignment (one
reserved `temporary.inbox`, the `inbox.*` namespace freed for applications, deterministic
essential-service sequencing, `@origin` never generated) — plus the mirrored
team-contributed Event Script collection plugins (`isEmpty`, `getFirst`, `getLast`;
origin mercury-composable PR #220, error messages matched verbatim). The Java counterpart
releases the same content in parallel (its #221 metadata hardening + #220 plugins).

## Why

Lock-step patch release with the Java engine. The metadata contract and the minimal
reserved-name surface are the cross-engine design ruling from the four-direction interop
review, re-verified live at an empty trace-signature diff in all four combinations; the
collection plugins ship on both engines because Event Script flows are engine-portable
YAML — a flow using `f:isEmpty(...)` must behave identically, down to the error text
operators read in aggregated logs. Gate verified at the new version: 252 workspace tests,
clippy-clean, fmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>