### PR TITLE
The demo echo displays the clean envelope-header view

### DIFF
--- a/docs/guides/event-over-http.md
+++ b/docs/guides/event-over-http.md
@@ -252,11 +252,9 @@ tasks:
     {
       "body": { "hello": "world" },
       "headers": {
-        "my_route": "hello.declarative",
-        "my_trace_id": "51fb9a95cb6b47169dd83771283aebc2",
-        "my_trace_path": "POST /api/event/http/declarative",
-        "my_correlation_id": "8c9f2a1b34dd4e0f9a7b1c2d3e4f5a6b",
         "x-flow-id": "event-over-http-declarative",
+        "x-correlation-id": "51fb9a95cb6b47169dd83771283aebc2",
+        "user": "demo",
         "...": "..."
       },
       "instance": 4,
@@ -265,10 +263,11 @@ tasks:
     ```
 
     The `origin` identifies the application instance that actually executed the function —
-    the hello-world app, not the app you called. The `my_*` keys are the read-only
-    metadata the worker injects into the function's input header copy at delivery (they
-    are never transported in the event itself, and never leave a function as response
-    headers); `my_route` names the alias that served the call.
+    the hello-world app, not the app you called. The echoed `headers` map is the clean
+    envelope-header view (`input.headers()` on the `EventEnvelope`): the engine never
+    transports its read-only `my_*` metadata in the event, so none appears here — the
+    function reads that metadata from its injected input headers instead. The `user`
+    entry is session info added by the authentication demo shown below.
 
 5. Look at both applications' logs: the trace context propagated across the HTTP hop
    automatically. Both apps log telemetry under the **same trace id**, the
@@ -307,11 +306,6 @@ calls the primary route `hello.world`, the declarative endpoint calls the alias
 `hello.declarative`. Choose declarative when the target address is deployment
 configuration (the usual case); choose programmatic when the code must compute or vary
 the target at runtime.
-
-Both engines inject the same read-only `my_*` metadata into the function's input header
-copy at delivery, so the echoed headers include `my_route` — `hello.world` for the
-programmatic call, `hello.declarative` for the declarative one — directly naming the
-route that served it, in either language.
 
 ### Authentication: the event.api.auth demo
 

--- a/docs/test-reports/event-over-http-interop.md
+++ b/docs/test-reports/event-over-http-interop.md
@@ -65,7 +65,9 @@ Rust at [PR #167](https://github.com/Accenture/mercury/pull/167).
   application instance that actually executed the function — in the other language.
 - Java callee: the echoed `my_route` header discriminates the pattern —
   `hello.declarative` (declarative) vs `hello.world` (programmatic) — demonstrating why
-  the echo function registers two route names.
+  the echo function registers two route names. (The demo echo has since been changed to
+  display the clean envelope-header view, so the injected metadata no longer appears in
+  its output; the two route names remain.)
 
 ## Results — trace continuity
 

--- a/examples/hello-flow/resources/application.yml
+++ b/examples/hello-flow/resources/application.yml
@@ -2,6 +2,12 @@
 # The structural parallel of the Java composable-example (same port 8100).
 application.name: hello-flow
 
+# structured logging (increment 5): text = plain console line (default),
+# json = pretty-print JSON, compact = single-line jsonl (no CR/LF per record).
+# Both JSON forms carry the app-log-context block. Override at launch with the
+# -D runtime argument (the JVM -D analog): hello_flow -- -Dlog.format=compact
+log.format: json
+
 # REST automation serves rest.yaml; the flow engine loads flows.yaml — both
 # by their default locations in this resources/ folder.
 rest.automation: true

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -182,7 +182,7 @@ struct HelloWorld;
 impl ComposableFunction for HelloWorld {
     async fn handle_event(
         &self,
-        headers: HashMap<String, String>,
+        _headers: HashMap<String, String>,
         input: EventEnvelope,
         instance: usize,
     ) -> Result<EventEnvelope, AppError> {
@@ -201,8 +201,12 @@ impl ComposableFunction for HelloWorld {
                 .set_header("id", "1"),
         )
         .await?;
+        // Note that the '_headers' input = input.headers() plus injected read-only metadata
+        // (my_route, my_trace_id, my_trace_path and my_correlation_id).
+        // Since we want to echo back the original request headers, we use input.headers().
         let echo_headers = Value::Map(
-            headers
+            input
+                .headers()
                 .iter()
                 .map(|(k, v)| (Value::from(k.as_str()), Value::from(v.as_str())))
                 .collect(),

--- a/memory/sessions/2026-07-24-023941.md
+++ b/memory/sessions/2026-07-24-023941.md
@@ -1,0 +1,17 @@
+# Session (2026-07-24T02:39:41.000Z)
+
+**Agent:** Claude Code
+
+*(lightweight)* Mirror of the Java demo clean-echo fix (Eric's edits + review corrections,
+coordinated from the Java session): the hello-world echo now displays input.headers() (the
+clean envelope view) instead of the injected params map — a live proof that my_* metadata
+never rides the wire; hello-flow adopts log.format=json for side-by-side parity. Review
+corrections: Rust-idiomatic comments, yml example binary name, guide sample updated to the
+clean-echo shape + my_route claim retired, test-report historical claim annotated (in sync
+with the Java copy). Branch `fix/demo-clean-echo`, commit `8c4a88d9`. Examples green.
+
+## Memory References
+
+(none)
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

Mirror of the Java demo fix: the hello-world echo now echoes `input.headers()` — the clean
envelope-header view — instead of the injected input-header params map, and hello-flow
adopts `log.format: json` for side-by-side log parity. Review corrections riding the fix:
Rust-idiomatic comments (explaining the now-unused `_headers` param), the yml comment
example references the right binary, the guide's sample response updated to the clean-echo
shape, the `my_route` claim retired, and the interop test report's historical claim
annotated in sync with the Java copy.

## Why

A four-direction interop review showed the echo re-exposing the injected read-only `my_*`
metadata as application data in its response payload — demo-code behavior, not an engine
defect. With the fix, the demo proves the boundary contract live: the echoed headers show
that metadata never rides the wire. Identical output in all four combinations before and
after the fix confirms the two engines remain fully in sync.

## Verification

Both example crates build and test green; all four interop combinations re-run manually
after the fix with clean echoes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>