### PR TITLE
chore(release): version 4.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
+## Version 4.10.3, 7/23/2026
+
+Patch release for **field deployment**, in lock-step with the Java engine's v4.10.3 —
+releases are immutable, so the post-4.10.2 fixes roll up into a new patch. No engine
+behavior changes: demo hygiene and refreshed playground webapp dependencies.
+
+### Changed
+
+1. **The demo echo displays the clean envelope-header view
+   ([#175](https://github.com/Accenture/mercury/pull/175)).** The hello-world echo now
+   reflects the function's ENVELOPE headers (the transported view) rather than the
+   injected input copy — making the demo a live proof that the reserved `my_*` metadata
+   never rides the wire: the injected keys are visible in the function (and documented),
+   but the echoed transport view is clean. The hello-flow example adopts
+   `log.format=json`, so a side-by-side java/rust demo run reads identically in both
+   terminals (presentation parity down to the demo experience).
+2. **Playground webapp dependencies refreshed from npm
+   ([#174](https://github.com/Accenture/mercury/pull/174)).** Fresh resolution of the
+   knowledge-graph Playground webapp lockfile within the declared semver ranges
+   (including the dependabot react-router advisory bump,
+   [#173](https://github.com/Accenture/mercury/pull/173)): `npm audit` clean, package
+   registry and integrity checksums verified. Webapp-only — no Rust crate dependency
+   changes.
+
+---
 ## Version 4.10.2, 7/23/2026
 
 Patch release: **the metadata contract, hardened in lock-step with the Java engine**. A

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.10.2"
+version = "4.10.3"
 dependencies = [
  "async-trait",
  "log",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "event-script"
-version = "4.10.2"
+version = "4.10.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "event-script-macros"
-version = "4.10.2"
+version = "4.10.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -367,7 +367,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.10.2"
+version = "4.10.3"
 dependencies = [
  "async-trait",
  "event-script",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.10.2"
+version = "4.10.3"
 dependencies = [
  "async-trait",
  "log",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph"
-version = "4.10.2"
+version = "4.10.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph-macros"
-version = "4.10.2"
+version = "4.10.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -579,7 +579,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minigraph-playground"
-version = "4.10.2"
+version = "4.10.3"
 dependencies = [
  "async-trait",
  "event-script",
@@ -684,7 +684,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "platform-core"
-version = "4.10.2"
+version = "4.10.3"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macros"
-version = "4.10.2"
+version = "4.10.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.10.2"
+version = "4.10.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury-composable"

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.10.2**: tracks the canonical mercury-composable line (Java 4.10.2 released the same day — one version, two languages; metadata contract: injected at entry, sanitized at exit, never transported).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-23 | agent: Claude Code (2026-07-23-231506)
+- **last_session:** 2026-07-24 | agent: Claude Code (2026-07-24-025820)
 - **last_review:** 2026-07-23 | through 2026-07-23-013514.md
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -81,7 +81,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Rust layer by layer, foundation → UI (platform-core, then event-script, then active
   knowledge graph), preserving the Java project's behavior. The Java repo is the canonical
   spec (map, don't mirror).
-  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-23 | uses: 84 | tier: active | origin: 2026-07-15-215538.md -->
+  <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-07-24 | uses: 85 | tier: active | origin: 2026-07-15-215538.md -->
 ## Conventions
 
 > Established with the first code (increment 1, 2026-07-15); enforced from the first commit.
@@ -105,12 +105,23 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   2026-07-16): annotated functions + `platform_core::auto_start_main!();` with the app's
   `resources/` beside its `Cargo.toml` — never cargo examples inside a library crate.
   Event-script and knowledge-graph demos land as sibling `examples/<name>/` crates.
-  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-23 | uses: 83 | tier: active | origin: 2026-07-15-224707.md -->
+  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-24 | uses: 84 | tier: active | origin: 2026-07-15-224707.md -->
 
 ## Open Threads
 
 > Mark completed items `- [x]` and leave them in place — the review sweeps them to
 > the archive once older than `archive_window` sessions. Don't archive them by hand.
+
+- [ ] (release in flight — 2026-07-24) **v4.10.3 release prepared** (field-deployment
+  roll-up; no engine behavior changes). Branch `chore/release-4.10.3` from main
+  `d2048eea` (PR #175 merge): bump 4.10.2→4.10.3 (root Cargo.toml only; lock
+  regenerated), fresh CHANGELOG `## Version 4.10.3, 7/23/2026` — demo hygiene (clean
+  envelope-header echo = live proof my_* never rides the wire; hello-flow
+  log.format=json, PR #175) + playground webapp npm refresh (incl. dependabot #173;
+  audit clean, PR #174). Gate: workspace 252 / clippy 0 / fmt. NOT pushed — Eric pushes
+  and opens the PR; the Java v4.10.3 is the field-deployment artifact, Rust ships in
+  lock-step. Close when tagged and published.
+  <!-- id: thread-release-4-10-3 | created: 2026-07-24 | last_used: 2026-07-24 | uses: 1 | tier: working | origin: 2026-07-24-025820.md -->
 
 - [x] (release — 2026-07-23; CLOSED same day) **v4.10.2 SHIPPED via the normal flow, in
   lock-step with the Java engine** — tag `v4.10.2` on merge commit `6a39bccc`
@@ -460,7 +471,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   event_over_http stamps the caller's trace/span on the wire envelope (apply_current_
   trace at client entry). Workspace 244/clippy 0/fmt. See session 2026-07-23-013514.**
   → serves: vision-mercury
-  <!-- id: ot-event-over-http | created: 2026-07-21 | last_used: 2026-07-23 | uses: 10 | tier: active | origin: 2026-07-21-233234.md -->
+  <!-- id: ot-event-over-http | created: 2026-07-21 | last_used: 2026-07-23 | uses: 10 | tier: archive-candidate | origin: 2026-07-21-233234.md -->
 
 - [ ] **(knowledge-harvest) Harvest the canonical vision/specs from mercury-composable (Java).**
   **Gate satisfied 2026-07-15** — the maintainer added `~/sandbox/mercury-composable` and

--- a/memory/sessions/2026-07-24-025820.md
+++ b/memory/sessions/2026-07-24-025820.md
@@ -1,0 +1,30 @@
+# Session (2026-07-24T02:58:20.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**v4.10.3 release prepared** (field-deployment roll-up, lock-step with the Java engine's
+v4.10.3 — releases are immutable, so the post-4.10.2 fixes ship as a new patch). Branch
+`chore/release-4.10.3` from main `d2048eea` (the PR #175 merge). NOT pushed — Eric
+pushes and opens the PR.
+
+- **Version bump 4.10.2 → 4.10.3:** the surface re-verified as the root Cargo.toml
+  workspace field alone (members inherit; Cargo.lock regenerated, 10 members; only
+  historical mentions elsewhere, untouched).
+- **CHANGELOG:** fresh `## Version 4.10.3, 7/23/2026` section (no Unreleased existed).
+  Summary: field-deployment patch, no engine behavior changes — demo hygiene (the echo
+  displays the clean envelope-header view, a live proof that my_* metadata never rides
+  the wire; hello-flow adopts log.format=json for side-by-side parity, PR #175) and the
+  playground webapp dependency refresh (fresh npm resolution within semver incl. the
+  dependabot react-router bump #173, audit clean, registry+integrity verified, PR #174).
+- **Gate at the new version:** workspace 252 tests green, clippy 0, fmt clean.
+- Continuity: new release-in-flight thread [[thread-release-4-10-3]].
+
+## Memory References
+
+- created: thread-release-4-10-3 (born tier: working)
+- referenced: port-bottom-up-faithful, conventions-rust-baseline (CHANGELOG conventions,
+  fmt/clippy gates), inv-telemetry-presentation-parity (the demo-hygiene items serve it)
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

Version bump 4.10.2 → 4.10.3 (root workspace field; members inherit; Cargo.lock
regenerated) and the CHANGELOG's `Version 4.10.3, 7/23/2026` section covering PR #175
(the demo echo's clean envelope-header view + hello-flow `log.format=json` for
side-by-side demo parity) and PR #174 (playground webapp dependency refresh, audit-clean,
registry + integrity verified). The Java counterpart v4.10.3 is the field-deployment
artifact; the Rust engine ships in lock-step.

## Why

A field deployment needs the post-4.10.2 fixes, and releases are immutable — so they roll
up into a new patch on both engines the same day, keeping the one-version/two-languages
line intact. The content is deliberately behavior-neutral: demo hygiene that doubles as
living documentation of the metadata contract (the echoed transport view is clean because
`my_*` metadata is injected, never transported), and a dependency refresh for the
Playground webapp with a clean audit. Gate verified at the new version: 252 workspace
tests, clippy-clean, fmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>