### PR TITLE
feat(macros): the engine dogfoods its extension points + one conflict policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,56 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
+## Unreleased
+
+### Added
+
+1. **The engine dogfoods its extension points (annotation→macro consistency, in lock-step
+   with the Java reference).** All 46 built-in mapping plugins are now `#[simple_plugin]`
+   declarations and both built-in fetch features are `#[fetch_feature]` declarations —
+   discovered through the same link-time inventory as user code, exactly like Java's 47
+   `@SimplePlugin` and 2 `@FetchFeature` classes. The hard-wired
+   `builtin_registrations()` / `register_builtins()` seedings are gone, and the loaders
+   assert the registered counts at startup so a linker-elision regression fails the boot
+   loudly. Behavior is identical: same names, same bodies, same error messages (the
+   existing suites prove it). `#[simple_plugin]` now accepts the positional string form
+   (`#[simple_plugin("getFirst")]`), mirroring `#[fetch_feature]`'s grammar — the string
+   is the registered name, `name = "..."` remains an equivalent alias, and omitting both
+   keeps the camelCase-of-fn-name derivation.
+2. **Marker stacking is order-insensitive, matching Java annotation semantics.**
+   `#[zero_tracing]` and `#[event_interceptor]` are now real attribute macros using the
+   `#[optional_service]` self-reattachment pattern: written above or below `#[preload]`,
+   the behavior is identical (previously they were consumed only when written below — an
+   order requirement Java does not have). The inline-args form
+   (`#[preload(..., zero_tracing, interceptor)]`) is unchanged; a marker with no primary
+   attribute on the item is a compile error with a helpful message.
+3. **Compile-fail guards for the macro surfaces** (`tests/ui`, trybuild): eleven fixtures
+   across the three runtime crates pin every deliberate macro compile error — unknown
+   parameters, missing required names/routes, empty route segments and conditions, and
+   markers with no primary attribute — so error messages are part of the tested contract.
+4. **`#[fetch_feature]` accepts a stacked `#[optional_service("condition")]` marker**
+   (Java `@OptionalService` parity, same grammar as on the platform macros): a declared
+   feature loads only when the configuration condition holds, logged as
+   `Skip optional FetchFeature - {name}` otherwise. `#[simple_plugin]` deliberately takes
+   no such marker — plugins are Event Script capabilities (flow vocabulary), never
+   conditionally on/off.
+
+### Fixed
+
+1. **One conflict policy across every registry** (matching the Java engine's actual
+   `Platform.register` behavior): explicit registration wins over declarative, and a
+   duplicate name warns + last-wins — simple plugins
+   (`Reloading SimplePlugin {name} - please check duplicated plugin name`, including a
+   user plugin shadowing a built-in), fetch features
+   (`Reloading FetchFeature {name} - please check duplicated feature name`, previously
+   first-wins on the declarative path), and websocket services (previously silent
+   replace). Preload routes already warned + reloaded.
+2. **Two stale doc claims corrected**: `#[preload]` DOES accept a comma-separated route
+   list (aliases are compile-validated and used in production), and the public/private
+   function distinction IS ported (private by default; a private function is not
+   reachable through `/api/event`).
+
+---
 ## Version 4.10.5, 7/24/2026
 
 Security patch in lock-step with the Java engine's v4.10.5.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "serde_json",
  "serde_json_path",
  "tokio",
+ "trybuild",
  "uuid",
 ]
 
@@ -358,6 +359,12 @@ dependencies = [
  "libc",
  "r-efi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "hashbrown"
@@ -547,6 +554,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "trybuild",
  "uuid",
 ]
 
@@ -708,6 +716,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite",
+ "trybuild",
  "uuid",
 ]
 
@@ -1070,6 +1079,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1181,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "target-triple"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1274,10 +1307,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06649c6f63d86604ba0c8950d5a1829fc9a17afd70fc6629f481d75b6a624c78"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "tungstenite"
@@ -1402,6 +1489,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1544,6 +1640,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "yasna"

--- a/crates/event-script-macros/src/lib.rs
+++ b/crates/event-script-macros/src/lib.rs
@@ -21,7 +21,7 @@
 //! compile time and resolve at runtime.
 //!
 //! ```ignore
-//! #[simple_plugin(name = "myCalc")]           // name defaults to camelCase
+//! #[simple_plugin("myCalc")]                  // the string is the registered name
 //! fn my_calc(args: &[Value]) -> Result<Value, String> { ... }
 //! ```
 
@@ -31,21 +31,35 @@ use syn::{parse_macro_input, ItemFn, LitStr};
 
 /// Register a plugin function (Java `@SimplePlugin` + `PluginFunction`).
 /// The function must have the signature
-/// `fn(&[rmpv::Value]) -> Result<rmpv::Value, String>`. The plugin name
-/// defaults to the camelCase form of the function name (the Java
-/// class-name-to-camelCase convention); override with `name = "..."`.
+/// `fn(&[rmpv::Value]) -> Result<rmpv::Value, String>`.
+///
+/// The positional string is the registered plugin name — the analog of
+/// overriding Java's `PluginFunction.getName()` — with `name = "..."` as an
+/// equivalent alias; omitting both derives the name as the camelCase form of
+/// the function name (the Java class-name-to-camelCase convention). The
+/// argument grammar is identical to `#[fetch_feature]` where the two macros
+/// overlap (the contract rule: the string is the registered name; omit it to
+/// derive from the declaration).
 #[proc_macro_attribute]
 pub fn simple_plugin(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut name: Option<LitStr> = None;
-    let parser = syn::meta::parser(|meta| {
-        if meta.path.is_ident("name") {
-            name = Some(meta.value()?.parse()?);
-            Ok(())
-        } else {
-            Err(meta.error("unknown simple_plugin parameter (expected name)"))
-        }
-    });
-    parse_macro_input!(args with parser);
+    // positional form: #[simple_plugin("getFirst")] — mirrors #[fetch_feature]
+    if let Ok(positional) = syn::parse::<LitStr>(args.clone()) {
+        name = Some(positional);
+    } else {
+        let parser = syn::meta::parser(|meta| {
+            if meta.path.is_ident("name") {
+                name = Some(meta.value()?.parse()?);
+                Ok(())
+            } else {
+                Err(meta.error(
+                    "unknown simple_plugin parameter (expected a plugin name literal or \
+                     name = \"...\")",
+                ))
+            }
+        });
+        parse_macro_input!(args with parser);
+    }
     let item = parse_macro_input!(input as ItemFn);
     let fn_ident = &item.sig.ident;
     let plugin_name = match name {

--- a/crates/event-script/Cargo.toml
+++ b/crates/event-script/Cargo.toml
@@ -29,4 +29,6 @@ event-script-macros = { path = "../event-script-macros" }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
+# compile-fail guards for the macro surfaces (tests/ui)
+trybuild = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }

--- a/crates/event-script/src/lib.rs
+++ b/crates/event-script/src/lib.rs
@@ -47,6 +47,12 @@
 //! before-application hook at sequence 5 (essential services 0, plugins 3,
 //! flows 5, user code ≥ 6 — the Java sequence contract).
 
+// The #[simple_plugin] macro expands to `::event_script::...` paths; the
+// engine's own built-in plugins are declared with the same macro (the engine
+// dogfoods its extension point), so the crate must resolve its public name
+// from within.
+extern crate self as event_script;
+
 pub mod adapter;
 pub mod compiler;
 pub mod conversions;
@@ -60,6 +66,7 @@ pub mod mlm;
 pub mod mock;
 pub mod model;
 pub mod plugins;
+mod plugins_e8;
 pub mod resilience;
 pub mod util;
 pub mod validator;
@@ -165,15 +172,32 @@ impl ComposableFunction for SimpleExceptionHandler {
 
 /// The plugin loader (Java `SimplePluginLoader`,
 /// `@BeforeApplication(sequence = 3)` — before flows compile at sequence 5,
-/// so `f:` names in mappings validate against user plugins too).
+/// so `f:` names in mappings validate against user plugins too). Built-in and
+/// user plugins alike are `#[simple_plugin]` declarations collected from the
+/// link-time inventory; this hook forces the one-time fold and asserts the
+/// count, so a linker-elision regression fails the boot loudly instead of
+/// silently compiling flows against an empty registry (the
+/// registration-metadata contract: discovery must fail loudly when a registry
+/// that should be populated is empty).
 #[before_application(sequence = 3)]
 pub struct SimplePluginLoader;
 
 #[async_trait]
 impl EntryPoint for SimplePluginLoader {
     async fn start(&self, _args: &[String]) -> Result<(), AppError> {
-        let user = plugins::load_inventory_plugins();
-        log::info!("Total {user} user plugin(s) registered");
+        let total = plugins::load_inventory_plugins();
+        if total < plugins::BUILTIN_PLUGIN_COUNT {
+            return Err(AppError::new(
+                500,
+                format!(
+                    "SimplePlugin registry incomplete: {total} plugin(s) collected, expected at \
+                     least the {} built-ins - check that the event-script inventory was not \
+                     elided at link time",
+                    plugins::BUILTIN_PLUGIN_COUNT
+                ),
+            ));
+        }
+        log::info!("Total {total} simple plugin(s) registered");
         Ok(())
     }
 }

--- a/crates/event-script/src/plugins.rs
+++ b/crates/event-script/src/plugins.rs
@@ -36,12 +36,19 @@
 use std::collections::HashMap;
 use std::sync::{OnceLock, RwLock};
 
+use event_script_macros::simple_plugin;
 use rmpv::Value;
 
 use crate::conversions::{
     convert_boolean, convert_double, convert_float, convert_integer, convert_long, get_b64,
     get_binary_value, get_length, get_text_value,
 };
+use crate::plugins_e8::value_type_name;
+
+/// The number of built-in `#[simple_plugin]` declarations the engine itself
+/// ships (this module + `plugins_e8`) — the startup floor the
+/// `SimplePluginLoader` asserts against linker elision.
+pub const BUILTIN_PLUGIN_COUNT: usize = 46;
 
 /// A plugin body (Java `PluginFunction.calculate`): evaluated argument values
 /// in, one value out; a descriptive error is the Java
@@ -63,7 +70,32 @@ platform_core::inventory::collect!(SimplePluginEntry);
 
 fn registry() -> &'static RwLock<HashMap<String, Registration>> {
     static PLUGINS: OnceLock<RwLock<HashMap<String, Registration>>> = OnceLock::new();
-    PLUGINS.get_or_init(|| RwLock::new(builtin_registrations()))
+    PLUGINS.get_or_init(|| {
+        // Fold the link-time inventory exactly once. The engine's own 46
+        // built-ins are #[simple_plugin] declarations (the engine dogfoods
+        // its extension point, like Java's @SimplePlugin classes under
+        // com.accenture.services.plugins), collected together with user
+        // plugins. A duplicate name warns + last-wins (the one conflict
+        // policy, D2) — including a user plugin shadowing a built-in. The
+        // SimplePluginLoader hook (before_application sequence 3) forces
+        // this fold before flows compile and asserts the count.
+        let mut map: HashMap<String, Registration> = HashMap::new();
+        for entry in platform_core::inventory::iter::<SimplePluginEntry> {
+            if map
+                .insert(
+                    entry.name.to_string(),
+                    Registration::Implemented(entry.body),
+                )
+                .is_some()
+            {
+                log::warn!(
+                    "Reloading SimplePlugin {} - please check duplicated plugin name",
+                    entry.name
+                );
+            }
+        }
+        RwLock::new(map)
+    })
 }
 
 /// True when a plugin name is registered (Java `containsSimplePlugin`).
@@ -74,12 +106,19 @@ pub fn contains_simple_plugin(name: &str) -> bool {
         .contains_key(name)
 }
 
-/// Register a plugin body (the E-8 `#[simple_plugin]` macro will call this).
+/// Register a plugin body programmatically. Explicit registration wins over
+/// declarative (it runs later and replaces); a duplicate name warns +
+/// last-wins — the one conflict policy (D2), matching Java's
+/// `SimplePluginLoader` wording.
 pub fn register_plugin(name: &str, body: PluginBody) {
-    registry()
+    if registry()
         .write()
         .expect("plugin registry")
-        .insert(name.to_string(), Registration::Implemented(body));
+        .insert(name.to_string(), Registration::Implemented(body))
+        .is_some()
+    {
+        log::warn!("Reloading SimplePlugin {name} - please check duplicated plugin name");
+    }
 }
 
 /// Invoke a plugin by name with evaluated arguments (Java
@@ -92,15 +131,12 @@ pub fn calculate(name: &str, args: &[Value]) -> Result<Value, String> {
     }
 }
 
-/// Load every `#[simple_plugin]` from the link-time inventory (Java
-/// `SimplePluginLoader.preloadSimplePlugins`). Returns how many were added.
+/// Force the one-time inventory fold (Java
+/// `SimplePluginLoader.preloadSimplePlugins`) and return how many plugin
+/// names are registered — built-ins and user `#[simple_plugin]` declarations
+/// alike arrive through the same link-time inventory.
 pub fn load_inventory_plugins() -> usize {
-    let mut count = 0;
-    for entry in platform_core::inventory::iter::<SimplePluginEntry> {
-        register_plugin(entry.name, entry.body);
-        count += 1;
-    }
-    count
+    registry().read().expect("plugin registry").len()
 }
 
 /// Java pattern shared by the conversion plugins: one argument converts to a
@@ -119,57 +155,67 @@ fn one_or_list(
     }
 }
 
+#[simple_plugin("text")]
 fn plugin_text(args: &[Value]) -> Result<Value, String> {
     one_or_list(args, "Text conversion", |v| {
         Ok(Value::from(get_text_value(v)))
     })
 }
 
+#[simple_plugin("int")]
 fn plugin_int(args: &[Value]) -> Result<Value, String> {
     one_or_list(args, "Integer conversion", |v| {
         Ok(Value::from(convert_integer(v)))
     })
 }
 
+#[simple_plugin("long")]
 fn plugin_long(args: &[Value]) -> Result<Value, String> {
     one_or_list(args, "Long conversion", |v| {
         Ok(Value::from(convert_long(v)))
     })
 }
 
+#[simple_plugin("float")]
 fn plugin_float(args: &[Value]) -> Result<Value, String> {
     one_or_list(args, "Float conversion", |v| {
         Ok(Value::F32(convert_float(v)))
     })
 }
 
+#[simple_plugin("double")]
 fn plugin_double(args: &[Value]) -> Result<Value, String> {
     one_or_list(args, "Double conversion", |v| {
         Ok(Value::F64(convert_double(v)))
     })
 }
 
+#[simple_plugin("boolean")]
 fn plugin_boolean(args: &[Value]) -> Result<Value, String> {
     one_or_list(args, "Boolean conversion", |v| {
         convert_boolean(v).map(Value::Boolean)
     })
 }
 
+#[simple_plugin("binary")]
 fn plugin_binary(args: &[Value]) -> Result<Value, String> {
     one_or_list(args, "Binary conversion", |v| {
         Ok(Value::Binary(get_binary_value(v)))
     })
 }
 
+#[simple_plugin("b64")]
 fn plugin_b64(args: &[Value]) -> Result<Value, String> {
     one_or_list(args, "Base64 conversion", get_b64)
 }
 
+#[simple_plugin("uuid")]
 fn plugin_uuid(_args: &[Value]) -> Result<Value, String> {
     // Java UUIDGenerator ignores its input and returns a fresh v4 uuid
     Ok(Value::from(uuid::Uuid::new_v4().to_string()))
 }
 
+#[simple_plugin("length")]
 fn plugin_length(args: &[Value]) -> Result<Value, String> {
     match args {
         [one] => Ok(Value::from(get_length(one))),
@@ -177,6 +223,7 @@ fn plugin_length(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+#[simple_plugin("not")]
 fn plugin_not(args: &[Value]) -> Result<Value, String> {
     match args {
         [one] => Ok(Value::Boolean(!convert_boolean(one)?)),
@@ -184,6 +231,7 @@ fn plugin_not(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+#[simple_plugin("and")]
 fn plugin_and(args: &[Value]) -> Result<Value, String> {
     if args.len() < 2 {
         return Err("Input is required to 'AND' values".to_string());
@@ -196,6 +244,7 @@ fn plugin_and(args: &[Value]) -> Result<Value, String> {
     Ok(Value::Boolean(true))
 }
 
+#[simple_plugin("or")]
 fn plugin_or(args: &[Value]) -> Result<Value, String> {
     if args.len() < 2 {
         return Err("Input is required to 'OR' values".to_string());
@@ -208,6 +257,7 @@ fn plugin_or(args: &[Value]) -> Result<Value, String> {
     Ok(Value::Boolean(false))
 }
 
+#[simple_plugin("concat")]
 fn plugin_concat(args: &[Value]) -> Result<Value, String> {
     if args.len() < 2 {
         return Err("Input is required for String Concatenation".to_string());
@@ -217,6 +267,7 @@ fn plugin_concat(args: &[Value]) -> Result<Value, String> {
     ))
 }
 
+#[simple_plugin("substring")]
 fn plugin_substring(args: &[Value]) -> Result<Value, String> {
     let [value, rest @ ..] = args else {
         return Err("Input is required for substring".to_string());
@@ -253,6 +304,7 @@ fn plugin_substring(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+#[simple_plugin("isNull")]
 fn plugin_is_null(args: &[Value]) -> Result<Value, String> {
     match args {
         [one] => Ok(Value::Boolean(matches!(one, Value::Nil))),
@@ -260,6 +312,7 @@ fn plugin_is_null(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+#[simple_plugin("notNull")]
 fn plugin_not_null(args: &[Value]) -> Result<Value, String> {
     match args {
         [one] => Ok(Value::Boolean(!matches!(one, Value::Nil))),
@@ -267,6 +320,7 @@ fn plugin_not_null(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+#[simple_plugin("eq")]
 fn plugin_eq(args: &[Value]) -> Result<Value, String> {
     let [first, rest @ ..] = args else {
         return Err("Input is required to check for equality".to_string());
@@ -277,6 +331,7 @@ fn plugin_eq(args: &[Value]) -> Result<Value, String> {
     Ok(Value::Boolean(rest.iter().all(|v| v == first)))
 }
 
+#[simple_plugin("ne")]
 fn plugin_ne(args: &[Value]) -> Result<Value, String> {
     let [first, rest @ ..] = args else {
         return Err("Input is required to check for inequality".to_string());
@@ -295,6 +350,7 @@ fn plugin_ne(args: &[Value]) -> Result<Value, String> {
 /// `f:isEmpty(value)` — true when a Collection/Map/String/array has no
 /// elements (Java `IsEmptyOperator`). Null checks belong to `isNull` /
 /// `notNull`: a null input is an error, as is an unsupported type.
+#[simple_plugin("isEmpty")]
 fn plugin_is_empty(args: &[Value]) -> Result<Value, String> {
     let [value] = args else {
         return Err("One input is required to check if value is empty".to_string());
@@ -317,6 +373,7 @@ fn plugin_is_empty(args: &[Value]) -> Result<Value, String> {
 
 /// `f:getFirst(list)` — the first element of a non-empty List (Java
 /// `GetFirstOperator`). Null, non-list or empty input is an error.
+#[simple_plugin("getFirst")]
 fn plugin_get_first(args: &[Value]) -> Result<Value, String> {
     let [value] = args else {
         return Err("One input is required to get first item from list".to_string());
@@ -333,6 +390,7 @@ fn plugin_get_first(args: &[Value]) -> Result<Value, String> {
 
 /// `f:getLast(list)` — the last element of a non-empty List (Java
 /// `GetLastOperator`). Null, non-list or empty input is an error.
+#[simple_plugin("getLast")]
 fn plugin_get_last(args: &[Value]) -> Result<Value, String> {
     let [value] = args else {
         return Err("One input is required to get last item from list".to_string());
@@ -346,74 +404,10 @@ fn plugin_get_last(args: &[Value]) -> Result<Value, String> {
         _ => Err("Input must be a list to get last item".to_string()),
     }
 }
-
-fn builtin_registrations() -> HashMap<String, Registration> {
-    let mut map = HashMap::new();
-    let implemented: &[(&str, PluginBody)] = &[
-        ("text", plugin_text),
-        ("int", plugin_int),
-        ("long", plugin_long),
-        ("float", plugin_float),
-        ("double", plugin_double),
-        ("boolean", plugin_boolean),
-        ("binary", plugin_binary),
-        ("b64", plugin_b64),
-        ("uuid", plugin_uuid),
-        ("length", plugin_length),
-        ("not", plugin_not),
-        ("and", plugin_and),
-        ("or", plugin_or),
-        ("concat", plugin_concat),
-        ("substring", plugin_substring),
-        ("isNull", plugin_is_null),
-        ("notNull", plugin_not_null),
-        ("eq", plugin_eq),
-        ("ne", plugin_ne),
-    ];
-    for (name, body) in implemented {
-        map.insert(name.to_string(), Registration::Implemented(*body));
-    }
-    let completed: &[(&str, PluginBody)] = &[
-        ("add", plugin_add),
-        ("subtract", plugin_subtract),
-        ("multiply", plugin_multiply),
-        ("div", plugin_div),
-        ("mod", plugin_mod),
-        ("increment", plugin_increment),
-        ("decrement", plugin_decrement),
-        ("round", plugin_round),
-        ("now", plugin_now),
-        ("dateTime", plugin_date_time),
-        ("gt", plugin_gt),
-        ("lt", plugin_lt),
-        ("ternary", plugin_ternary),
-        ("startsWith", plugin_starts_with),
-        ("endsWith", plugin_ends_with),
-        ("includes", plugin_includes),
-        ("parseDate", plugin_parse_date),
-        ("parseDateTime", plugin_parse_date_time),
-        ("listOfMap", plugin_list_of_map),
-        ("updateListOfMap", plugin_update_list_of_map),
-        ("removeKey", plugin_remove_key),
-        ("uniqueSet", plugin_unique_set),
-        ("defaultValue", plugin_default_value),
-        ("validate", plugin_validate),
-        // Collection operators (Java PR #220 mirror)
-        ("isEmpty", plugin_is_empty),
-        ("getFirst", plugin_get_first),
-        ("getLast", plugin_get_last),
-    ];
-    for (name, body) in completed {
-        map.insert(name.to_string(), Registration::Implemented(*body));
-    }
-    map
-}
-
-include!("plugins_e8.rs");
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::plugins_e8::java_pattern_to_chrono;
 
     /// Twin of the Java `IsEmptyOperatorTest` (PR #220): positives across
     /// the supported types — incl. the byte-array analog of an empty /

--- a/crates/event-script/src/plugins_e8.rs
+++ b/crates/event-script/src/plugins_e8.rs
@@ -1,6 +1,30 @@
-// Included by plugins.rs — the increment E-8 built-in plugin bodies
-// (arithmetic, generators, dates, comparisons, list-of-map operations and
-// input validation), each a faithful port of its Java plugin class.
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! The increment E-8 built-in plugin bodies (arithmetic, generators, dates,
+//! comparisons, list-of-map operations and input validation), each a faithful
+//! port of its Java plugin class. Every plugin is a `#[simple_plugin]`
+//! declaration collected through the link-time inventory — the engine
+//! dogfoods its own extension point, exactly like Java's `@SimplePlugin`
+//! classes.
+
+use event_script_macros::simple_plugin;
+use rmpv::Value;
+
+use crate::conversions::{convert_boolean, get_text_value};
 
 /// Java-style numeric promotion for the plugin family: whole numbers stay
 /// exact `i64`, floating-point values are `f64`.
@@ -89,14 +113,17 @@ fn fold_numbers(
     }
 }
 
+#[simple_plugin("add")]
 fn plugin_add(args: &[Value]) -> Result<Value, String> {
     fold_numbers(args, "add", |a, b| a + b, |a, b| a + b)
 }
 
+#[simple_plugin("subtract")]
 fn plugin_subtract(args: &[Value]) -> Result<Value, String> {
     fold_numbers(args, "subtract", |a, b| a - b, |a, b| a - b)
 }
 
+#[simple_plugin("multiply")]
 fn plugin_multiply(args: &[Value]) -> Result<Value, String> {
     fold_numbers(args, "multiply", |a, b| a * b, |a, b| a * b)
 }
@@ -110,6 +137,7 @@ fn divide_by_zero_check(divisors: &[Value]) -> Result<(), String> {
     Ok(())
 }
 
+#[simple_plugin("div")]
 fn plugin_div(args: &[Value]) -> Result<Value, String> {
     if args.len() < 2 {
         return Err("Expected at least two Numbers to divide".to_string());
@@ -119,6 +147,7 @@ fn plugin_div(args: &[Value]) -> Result<Value, String> {
     fold_numbers(args, "divide", |a, b| a / b, |a, b| a / b)
 }
 
+#[simple_plugin("mod")]
 fn plugin_mod(args: &[Value]) -> Result<Value, String> {
     if args.len() != 2 {
         return Err("Modulus expects only two values".to_string());
@@ -127,6 +156,7 @@ fn plugin_mod(args: &[Value]) -> Result<Value, String> {
     fold_numbers(args, "modulus", |a, b| a % b, |a, b| a % b)
 }
 
+#[simple_plugin("increment")]
 fn plugin_increment(args: &[Value]) -> Result<Value, String> {
     match args {
         [one] => Ok(match promote_number(one)? {
@@ -137,6 +167,7 @@ fn plugin_increment(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+#[simple_plugin("decrement")]
 fn plugin_decrement(args: &[Value]) -> Result<Value, String> {
     match args {
         [one] => Ok(match promote_number(one)? {
@@ -203,17 +234,14 @@ fn round_half_up(value: f64, dp: usize) -> f64 {
     }
 }
 
+#[simple_plugin("round")]
 fn plugin_round(args: &[Value]) -> Result<Value, String> {
     let (number, dp) = match args {
         [one] => (promote_number(one)?, 0usize),
         [one, two] => {
             let dp = match promote_number(two)? {
                 Number::Long(l) if l >= 0 => l as usize,
-                _ => {
-                    return Err(
-                        "Decimal places for round must be a whole number >= 0".to_string()
-                    )
-                }
+                _ => return Err("Decimal places for round must be a whole number >= 0".to_string()),
             };
             (promote_number(one)?, dp)
         }
@@ -226,6 +254,7 @@ fn plugin_round(args: &[Value]) -> Result<Value, String> {
     })
 }
 
+#[simple_plugin("now")]
 fn plugin_now(args: &[Value]) -> Result<Value, String> {
     let command = args
         .first()
@@ -253,7 +282,7 @@ fn plugin_now(args: &[Value]) -> Result<Value, String> {
 /// render as `+0530` (no minute-less form), `XXX` renders UTC as `+00:00`
 /// where Java prints `Z`; `z` is format-only (chrono cannot parse zone
 /// abbreviations).
-fn java_pattern_to_chrono(pattern: &str) -> Result<String, String> {
+pub(crate) fn java_pattern_to_chrono(pattern: &str) -> Result<String, String> {
     let chars: Vec<char> = pattern.chars().collect();
     let mut out = String::new();
     let push_literal = |out: &mut String, c: char| {
@@ -317,8 +346,8 @@ fn java_pattern_to_chrono(pattern: &str) -> Result<String, String> {
                 ('S', 3) => "%3f",
                 ('S', _) => {
                     return Err(format!(
-                        "Unsupported fractional-second width in '{pattern}' - use SSS (milliseconds)"
-                    ))
+                    "Unsupported fractional-second width in '{pattern}' - use SSS (milliseconds)"
+                ))
                 }
                 ('a', _) => "%p",
                 ('X', 3) => "%:z",
@@ -341,6 +370,7 @@ fn java_pattern_to_chrono(pattern: &str) -> Result<String, String> {
     Ok(out)
 }
 
+#[simple_plugin("dateTime")]
 fn plugin_date_time(args: &[Value]) -> Result<Value, String> {
     // Java DateGenerator: ZonedDateTime.now(zone).format(pattern) — the
     // optional 2nd argument is the zone (ZoneId.of), previously silently
@@ -380,6 +410,7 @@ fn compare_numbers(a: &Value, b: &Value) -> Result<std::cmp::Ordering, String> {
     }
 }
 
+#[simple_plugin("gt")]
 fn plugin_gt(args: &[Value]) -> Result<Value, String> {
     match args {
         [a, b] => Ok(Value::Boolean(
@@ -389,6 +420,7 @@ fn plugin_gt(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+#[simple_plugin("lt")]
 fn plugin_lt(args: &[Value]) -> Result<Value, String> {
     match args {
         [a, b] => Ok(Value::Boolean(
@@ -398,6 +430,7 @@ fn plugin_lt(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+#[simple_plugin("ternary")]
 fn plugin_ternary(args: &[Value]) -> Result<Value, String> {
     match args {
         [condition, yes, no] => Ok(if convert_boolean(condition)? {
@@ -409,6 +442,7 @@ fn plugin_ternary(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+#[simple_plugin("startsWith")]
 fn plugin_starts_with(args: &[Value]) -> Result<Value, String> {
     match args {
         // case insensitive comparison (Java parity)
@@ -421,6 +455,7 @@ fn plugin_starts_with(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+#[simple_plugin("endsWith")]
 fn plugin_ends_with(args: &[Value]) -> Result<Value, String> {
     match args {
         [source, text] => Ok(Value::Boolean(
@@ -432,6 +467,7 @@ fn plugin_ends_with(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+#[simple_plugin("includes")]
 fn plugin_includes(args: &[Value]) -> Result<Value, String> {
     match args {
         // list membership uses value equality; text search is case-insensitive
@@ -479,6 +515,7 @@ fn parsed_date_output(
     }
 }
 
+#[simple_plugin("parseDate")]
 fn plugin_parse_date(args: &[Value]) -> Result<Value, String> {
     match args {
         [value, rule_text] => {
@@ -498,6 +535,7 @@ fn plugin_parse_date(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+#[simple_plugin("parseDateTime")]
 fn plugin_parse_date_time(args: &[Value]) -> Result<Value, String> {
     match args {
         [value, rule_text] => {
@@ -604,6 +642,7 @@ fn merge_lists(first: &[Value], additional: &[Vec<(Value, Value)>]) -> Value {
     Value::Array(copy)
 }
 
+#[simple_plugin("listOfMap")]
 fn plugin_list_of_map(args: &[Value]) -> Result<Value, String> {
     let Some(Value::Map(data)) = args.first() else {
         return Ok(Value::Array(Vec::new()));
@@ -622,6 +661,7 @@ fn plugin_list_of_map(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+#[simple_plugin("updateListOfMap")]
 fn plugin_update_list_of_map(args: &[Value]) -> Result<Value, String> {
     if args.len() > 1 {
         if let Some(Value::Array(first)) = args.first() {
@@ -650,6 +690,7 @@ fn drop_keys(map: &[(Value, Value)], keys: &[Value]) -> Value {
     Value::Map(dropped)
 }
 
+#[simple_plugin("removeKey")]
 fn plugin_remove_key(args: &[Value]) -> Result<Value, String> {
     if args.len() > 1 {
         match &args[0] {
@@ -670,6 +711,7 @@ fn plugin_remove_key(args: &[Value]) -> Result<Value, String> {
     Ok(Value::Nil)
 }
 
+#[simple_plugin("uniqueSet")]
 fn plugin_unique_set(args: &[Value]) -> Result<Value, String> {
     match args {
         [Value::Array(items)] => {
@@ -686,6 +728,7 @@ fn plugin_unique_set(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+#[simple_plugin("defaultValue")]
 fn plugin_default_value(args: &[Value]) -> Result<Value, String> {
     if args.len() > 1 && matches!(args[0], Value::Nil) {
         return Ok(args[1].clone());
@@ -695,6 +738,7 @@ fn plugin_default_value(args: &[Value]) -> Result<Value, String> {
 
 // ---- input validation (Java InputValidation) ----
 
+#[simple_plugin("validate")]
 fn plugin_validate(args: &[Value]) -> Result<Value, String> {
     let [value, rule_text] = args else {
         return Err("Validation syntax error. Expect 2 arguments where the second one is the validation rule.".to_string());
@@ -713,7 +757,11 @@ fn plugin_validate(args: &[Value]) -> Result<Value, String> {
         // when 'required' is not configured, the field is optional
         let required = rules.iter().any(|r| r.eq_ignore_ascii_case("required"));
         return if !required {
-            Ok(if evaluate { Value::Boolean(true) } else { Value::Nil })
+            Ok(if evaluate {
+                Value::Boolean(true)
+            } else {
+                Value::Nil
+            })
         } else if evaluate {
             Ok(Value::Boolean(false))
         } else {
@@ -753,7 +801,7 @@ fn plugin_validate(args: &[Value]) -> Result<Value, String> {
     }
 }
 
-fn value_type_name(value: &Value) -> &'static str {
+pub(crate) fn value_type_name(value: &Value) -> &'static str {
     match value {
         Value::String(_) => "String",
         Value::Integer(_) => "Integer",

--- a/crates/event-script/tests/registration_conflicts.rs
+++ b/crates/event-script/tests/registration_conflicts.rs
@@ -1,0 +1,127 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! The one conflict policy (D2, annotation→macro consistency round): within
+//! the simple-plugin registry a duplicate name = WARN + last-wins, matching
+//! the Java `SimplePluginLoader` wording — including a user
+//! `#[simple_plugin]` shadowing a built-in. A dedicated test binary: it
+//! installs a capturing logger (nothing else boots here) and deliberately
+//! shadows a built-in name, which must never leak into other suites.
+
+use std::sync::{Mutex, OnceLock};
+
+use event_script::plugins;
+use event_script::simple_plugin;
+use rmpv::Value;
+
+struct CaptureLogger;
+
+fn captured() -> &'static Mutex<Vec<String>> {
+    static LOGS: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+    LOGS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+impl log::Log for CaptureLogger {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        captured().lock().expect("capture log").push(format!(
+            "{}: {}",
+            record.level(),
+            record.args()
+        ));
+    }
+
+    fn flush(&self) {}
+}
+
+/// A user plugin that shadows the built-in `isEmpty` — the adversarial case
+/// the conflict policy must WARN about (Java: "Reloading SimplePlugin ...").
+/// Deliberately uses the `name = "..."` alias form: the regression that the
+/// alias grammar keeps working alongside the canonical positional form.
+#[simple_plugin(name = "isEmpty")]
+fn shadow_is_empty(_args: &[Value]) -> Result<Value, String> {
+    Ok(Value::from("shadowed"))
+}
+
+/// The canonical positional form (`#[simple_plugin("...")]` — the
+/// `#[fetch_feature]` grammar): the string is the registered name.
+#[simple_plugin("positionalDemo")]
+fn any_fn_name(_args: &[Value]) -> Result<Value, String> {
+    Ok(Value::from("positional"))
+}
+
+/// One sequential test fn: the capture logger must be installed before the
+/// registry's one-time inventory fold, and the assertions read the shared
+/// captured log.
+#[test]
+fn duplicate_names_warn_and_last_wins() {
+    log::set_logger(&CaptureLogger).expect("no other logger in this binary");
+    log::set_max_level(log::LevelFilter::Debug);
+
+    // 1. the user shadow of a built-in warns during the inventory fold
+    //    (which body wins is link-order-dependent, exactly like a Java
+    //    classpath-scan order — the WARN is the contract, and the name
+    //    still resolves)
+    assert!(plugins::contains_simple_plugin("isEmpty"));
+    let warned = captured().lock().unwrap().iter().any(|line| {
+        line.contains("WARN")
+            && line.contains("Reloading SimplePlugin isEmpty - please check duplicated plugin name")
+    });
+    assert!(
+        warned,
+        "a user #[simple_plugin] shadowing a built-in must warn: {:?}",
+        captured().lock().unwrap()
+    );
+    assert!(plugins::calculate("isEmpty", &[Value::Array(vec![])]).is_ok());
+
+    // 2. explicit register_plugin: duplicate name warns + last-wins
+    plugins::register_plugin("dupTest", |_args| Ok(Value::from("first")));
+    plugins::register_plugin("dupTest", |_args| Ok(Value::from("second")));
+    assert_eq!(
+        plugins::calculate("dupTest", &[]),
+        Ok(Value::from("second")),
+        "last registration wins"
+    );
+    let warned = captured().lock().unwrap().iter().any(|line| {
+        line.contains("WARN")
+            && line.contains("Reloading SimplePlugin dupTest - please check duplicated plugin name")
+    });
+    assert!(
+        warned,
+        "an explicit duplicate registration must warn: {:?}",
+        captured().lock().unwrap()
+    );
+
+    // 3. the positional argument grammar registers under the given string
+    //    (the fn name is deliberately unrelated); the name= alias was proven
+    //    by the shadow plugin above, and the no-argument camelCase derivation
+    //    by the flow_runtime `shout` fixture
+    assert_eq!(
+        plugins::calculate("positionalDemo", &[]),
+        Ok(Value::from("positional"))
+    );
+    assert!(!plugins::contains_simple_plugin("anyFnName"));
+
+    // 4. the built-in floor: all 46 engine plugins arrived through the
+    //    inventory (the count the SimplePluginLoader hook asserts at boot)
+    assert!(
+        plugins::load_inventory_plugins() >= plugins::BUILTIN_PLUGIN_COUNT,
+        "the built-in #[simple_plugin] declarations must all be collected"
+    );
+}

--- a/crates/event-script/tests/ui.rs
+++ b/crates/event-script/tests/ui.rs
@@ -1,0 +1,26 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Compile-fail guards for the event-script macro surface: every deliberate
+//! compile-time error stays a compile-time error with its exact message.
+//! `.stderr` files track rustc's error formatting — regenerate with
+//! `TRYBUILD=overwrite cargo test --test ui` after a toolchain bump.
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/crates/event-script/tests/ui/simple_plugin_unknown_param.rs
+++ b/crates/event-script/tests/ui/simple_plugin_unknown_param.rs
@@ -1,0 +1,8 @@
+// #[simple_plugin] accepts a positional name literal or name = "..." and
+// nothing else; any other parameter is a compile error.
+#[event_script::simple_plugin(instances = 2)]
+fn fixture(_args: &[rmpv::Value]) -> Result<rmpv::Value, String> {
+    Ok(rmpv::Value::Nil)
+}
+
+fn main() {}

--- a/crates/event-script/tests/ui/simple_plugin_unknown_param.stderr
+++ b/crates/event-script/tests/ui/simple_plugin_unknown_param.stderr
@@ -1,0 +1,5 @@
+error: unknown simple_plugin parameter (expected a plugin name literal or name = "...")
+ --> tests/ui/simple_plugin_unknown_param.rs:3:31
+  |
+3 | #[event_script::simple_plugin(instances = 2)]
+  |                               ^^^^^^^^^

--- a/crates/knowledge-graph-macros/src/lib.rs
+++ b/crates/knowledge-graph-macros/src/lib.rs
@@ -25,19 +25,30 @@ use syn::{parse_macro_input, ItemStruct, LitStr};
 
 /// The Java `@FetchFeature(value)` analog: registers an API-fetcher feature
 /// declaratively. The annotated struct implements the `FeatureRunner` trait;
-/// a provider node lists the feature by name in its `feature` property.
+/// a provider node lists the feature by name in its `feature` property. The
+/// engine's own built-in features (`log-request-headers` /
+/// `log-response-headers`) are declared with this same macro — the engine
+/// dogfoods its extension point, like Java's `@FetchFeature` classes.
 ///
 /// Field installations use this for pre/post-processing of provider HTTP
 /// calls — e.g. an `oauth-bearer` feature that fetches/refreshes an OAuth
 /// 2.0 access token and inserts the bearer token into the outbound request.
 ///
+/// A stacked `#[optional_service("condition")]` marker (the Java
+/// `@OptionalService` analog, same grammar as on the platform macros) makes
+/// the feature conditional on application configuration — evaluated at boot,
+/// never at expansion time:
+///
 /// ```ignore
 /// #[fetch_feature("oauth-bearer")]
+/// #[optional_service("oauth.token.endpoint")]
 /// struct OAuthBearer;      // impl knowledge_graph::features::FeatureRunner
 /// ```
 ///
 /// The engine loads all declared features during startup (the Java
-/// `PlaygroundLoader` scan analog), before any graph executes.
+/// `PlaygroundLoader` scan analog), before any graph executes. Note:
+/// `#[simple_plugin]` deliberately has NO optional_service — plugins are
+/// Event Script capabilities (flow vocabulary), never conditionally on/off.
 #[proc_macro_attribute]
 pub fn fetch_feature(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut name: Option<LitStr> = None;
@@ -58,7 +69,7 @@ pub fn fetch_feature(args: TokenStream, input: TokenStream) -> TokenStream {
         });
         parse_macro_input!(args with parser);
     }
-    let item = parse_macro_input!(input as ItemStruct);
+    let mut item = parse_macro_input!(input as ItemStruct);
     let Some(name) = name else {
         return syn::Error::new_spanned(
             &item.ident,
@@ -66,6 +77,12 @@ pub fn fetch_feature(args: TokenStream, input: TokenStream) -> TokenStream {
         )
         .to_compile_error()
         .into();
+    };
+    // stacked #[optional_service("...")] marker (the platform-macro pattern)
+    let optional_service = strip_optional_service(&mut item);
+    let optional_service = match &optional_service {
+        Some(cond) => quote!(::core::option::Option::Some(#cond)),
+        None => quote!(::core::option::Option::None),
     };
     let ident = &item.ident;
     let construct = match item.fields {
@@ -77,9 +94,29 @@ pub fn fetch_feature(args: TokenStream, input: TokenStream) -> TokenStream {
         ::knowledge_graph::inventory::submit! {
             ::knowledge_graph::features::FetchFeatureEntry {
                 name: #name,
+                optional_service: #optional_service,
                 factory: || ::std::sync::Arc::new(#construct),
             }
         }
     };
     expanded.into()
+}
+
+/// Consume a stacked `#[optional_service("condition")]` marker (Java
+/// `@OptionalService`), returning its condition string literal — the same
+/// strip/fold pattern the platform macros use. Removes the attribute so it
+/// does not reach the compiler.
+fn strip_optional_service(item: &mut ItemStruct) -> Option<LitStr> {
+    let mut found = None;
+    item.attrs.retain(|attr| {
+        if attr.path().is_ident("optional_service") {
+            if let Ok(lit) = attr.parse_args::<LitStr>() {
+                found = Some(lit);
+            }
+            false
+        } else {
+            true
+        }
+    });
+    found
 }

--- a/crates/knowledge-graph/Cargo.toml
+++ b/crates/knowledge-graph/Cargo.toml
@@ -24,5 +24,7 @@ getrandom = "0.4"
 thiserror = "1"
 
 [dev-dependencies]
+# compile-fail guards for the macro surfaces (tests/ui)
+trybuild = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/knowledge-graph/src/features.rs
+++ b/crates/knowledge-graph/src/features.rs
@@ -27,13 +27,19 @@
 //! refreshing an OAuth 2.0 access token and inserting the bearer token into
 //! the outbound request) or explicitly through [`register`]. The two
 //! built-in demonstration features — `log-request-headers` and
-//! `log-response-headers` — are registered by the engine itself.
+//! `log-response-headers` — are themselves `#[fetch_feature]` declarations:
+//! the engine dogfoods its extension point, like Java's `@FetchFeature`
+//! classes. A stacked `#[optional_service("condition")]` marker gates a
+//! declared feature on application configuration (Java `@OptionalService`,
+//! evaluated at boot).
 
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, RwLock};
 
 use event_script::mlm::MultiLevelMap;
+use knowledge_graph_macros::fetch_feature;
 use platform_core::automation::AsyncHttpRequest;
+use platform_core::AppConfigReader;
 use rmpv::Value;
 
 /// The observable parts of an HTTP response for after-features.
@@ -57,24 +63,34 @@ pub trait FeatureRunner: Send + Sync {
 }
 
 /// A `#[fetch_feature]`-annotated feature (Java `@FetchFeature`) collected
-/// from the link-time inventory.
+/// from the link-time inventory. `optional_service` carries a stacked
+/// `#[optional_service("condition")]` marker (Java `@OptionalService`),
+/// evaluated at boot by [`load_declared_features`].
 pub struct FetchFeatureEntry {
     pub name: &'static str,
+    pub optional_service: Option<&'static str>,
     pub factory: fn() -> Arc<dyn FeatureRunner>,
 }
 
 platform_core::inventory::collect!(FetchFeatureEntry);
 
 /// Load every `#[fetch_feature]` from the link-time inventory (the Java
-/// `PlaygroundLoader` classpath-scan analog). Runs once at startup;
-/// idempotent — a name already registered explicitly is left untouched, and
-/// a later explicit [`register`] call may still replace any feature.
-pub fn load_declared_features() {
+/// `PlaygroundLoader` classpath-scan analog). Runs at startup, before any
+/// graph executes. An `optional_service` condition that does not hold skips
+/// the feature (Java `Feature.isRequired`); a duplicate name warns +
+/// last-wins (the one conflict policy) — and a later explicit [`register`]
+/// call still replaces any feature (explicit wins over declarative). Returns
+/// how many feature names are registered.
+pub fn load_declared_features() -> usize {
+    let config = AppConfigReader::get_instance();
     for entry in platform_core::inventory::iter::<FetchFeatureEntry> {
-        if get_feature(entry.name).is_none() {
-            register(entry.name, (entry.factory)());
+        if !platform_core::util::feature::is_required(entry.optional_service, config) {
+            log::info!("Skip optional FetchFeature - {}", entry.name);
+            continue;
         }
+        register(entry.name, (entry.factory)());
     }
+    registry().read().expect("feature registry poisoned").len()
 }
 
 fn registry() -> &'static RwLock<HashMap<String, Arc<dyn FeatureRunner>>> {
@@ -82,12 +98,19 @@ fn registry() -> &'static RwLock<HashMap<String, Arc<dyn FeatureRunner>>> {
     FEATURES.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
-/// Register a feature by name (the Java `@FetchFeature` value).
+/// Register a feature by name (the Java `@FetchFeature` value). A duplicate
+/// name warns + last-wins (the one conflict policy, D2 — Java
+/// `PlaygroundLoader` wording); explicit registration wins over declarative
+/// because it runs later and replaces.
 pub fn register(name: &str, feature: Arc<dyn FeatureRunner>) {
-    registry()
+    if registry()
         .write()
         .expect("feature registry poisoned")
-        .insert(name.to_string(), feature);
+        .insert(name.to_string(), feature)
+        .is_some()
+    {
+        log::warn!("Reloading FetchFeature {name} - please check duplicated feature name");
+    }
     log::info!("Feature {name} loaded as API fetcher feature");
 }
 
@@ -101,6 +124,7 @@ pub fn get_feature(name: &str) -> Option<Arc<dyn FeatureRunner>> {
 
 /// Java `LogRequestHeaders` (`log-request-headers`): saves outbound request
 /// headers into the state machine under `{node}.header.request.*`.
+#[fetch_feature("log-request-headers")]
 struct LogRequestHeaders;
 
 impl FeatureRunner for LogRequestHeaders {
@@ -128,6 +152,7 @@ impl FeatureRunner for LogRequestHeaders {
 
 /// Java `LogResponseHeaders` (`log-response-headers`): saves response
 /// headers under `{node}.header.response.*`.
+#[fetch_feature("log-response-headers")]
 struct LogResponseHeaders;
 
 impl FeatureRunner for LogResponseHeaders {
@@ -150,15 +175,5 @@ impl FeatureRunner for LogResponseHeaders {
                 );
             }
         }
-    }
-}
-
-/// Register the built-in demonstration features (idempotent).
-pub fn register_builtins() {
-    if get_feature("log-request-headers").is_none() {
-        register("log-request-headers", Arc::new(LogRequestHeaders));
-    }
-    if get_feature("log-response-headers").is_none() {
-        register("log-response-headers", Arc::new(LogResponseHeaders));
     }
 }

--- a/crates/knowledge-graph/src/lib.rs
+++ b/crates/knowledge-graph/src/lib.rs
@@ -47,6 +47,12 @@ pub mod skills;
 pub mod traveler;
 pub mod ws_ui;
 
+// The #[fetch_feature] macro expands to `::knowledge_graph::...` paths; the
+// engine's own built-in features are declared with the same macro (the
+// engine dogfoods its extension point), so the crate must resolve its public
+// name from within.
+extern crate self as knowledge_graph;
+
 // the annotation layer (Java @FetchFeature analog)
 pub use knowledge_graph_macros::fetch_feature;
 // re-exported so the macro's generated `submit!` resolves without the user
@@ -75,10 +81,20 @@ impl EntryPoint for GraphResources {
             env!("CARGO_MANIFEST_DIR"),
             "/resources"
         ));
-        // built-in API-fetcher features (Java ships them in the engine jar)
-        features::register_builtins();
-        // declarative #[fetch_feature] entries (the PlaygroundLoader scan analog)
-        features::load_declared_features();
+        // declarative #[fetch_feature] entries (the PlaygroundLoader scan
+        // analog) — the two built-in demonstration features are themselves
+        // #[fetch_feature] declarations, so the count doubles as the
+        // linker-elision guard: discovery must fail loudly when a registry
+        // that should be populated is empty (registration-metadata contract)
+        let features = features::load_declared_features();
+        if features < 2 {
+            return Err(AppError::new(
+                500,
+                format!(
+                    "FetchFeature registry incomplete: {features} feature(s) collected,                      expected at least the 2 built-ins - check that the knowledge-graph                      inventory was not elided at link time"
+                ),
+            ));
+        }
         Ok(())
     }
 }

--- a/crates/knowledge-graph/tests/feature_registration.rs
+++ b/crates/knowledge-graph/tests/feature_registration.rs
@@ -1,0 +1,169 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Fetch-feature registration semantics (annotation→macro consistency round):
+//! the built-ins are `#[fetch_feature]` declarations, a duplicate name =
+//! WARN + last-wins (D2, Java `PlaygroundLoader` wording), and a stacked
+//! `#[optional_service]` marker gates a declared feature on configuration
+//! (D3a, Java `@OptionalService` + `Feature.isRequired`). A dedicated test
+//! binary: it installs a capturing logger and manipulates config overrides
+//! before the `AppConfigReader` singleton freezes.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use knowledge_graph::features::{self, FeatureRunner, HttpResponseView};
+use knowledge_graph::fetch_feature;
+use platform_core::automation::AsyncHttpRequest;
+use platform_core::overrides;
+
+struct CaptureLogger;
+
+fn captured() -> &'static Mutex<Vec<String>> {
+    static LOGS: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+    LOGS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+impl log::Log for CaptureLogger {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        captured().lock().expect("capture log").push(format!(
+            "{}: {}",
+            record.level(),
+            record.args()
+        ));
+    }
+
+    fn flush(&self) {}
+}
+
+struct NoOp(bool);
+
+impl FeatureRunner for NoOp {
+    fn run_before(&self) -> bool {
+        self.0
+    }
+
+    fn execute(
+        &self,
+        _request: Option<&mut AsyncHttpRequest>,
+        _response: Option<&HttpResponseView>,
+        _state: &mut event_script::mlm::MultiLevelMap,
+        _node_name: &str,
+    ) {
+    }
+}
+
+/// Gated on a config key this test sets: must LOAD.
+#[fetch_feature("gated-present")]
+#[optional_service("test.feature.present.key")]
+struct GatedPresent;
+
+impl FeatureRunner for GatedPresent {
+    fn run_before(&self) -> bool {
+        true
+    }
+
+    fn execute(
+        &self,
+        _request: Option<&mut AsyncHttpRequest>,
+        _response: Option<&HttpResponseView>,
+        _state: &mut event_script::mlm::MultiLevelMap,
+        _node_name: &str,
+    ) {
+    }
+}
+
+/// Gated on a config key nothing sets: must be SKIPPED.
+#[fetch_feature("gated-absent")]
+#[optional_service("test.feature.absent.key")]
+struct GatedAbsent;
+
+impl FeatureRunner for GatedAbsent {
+    fn run_before(&self) -> bool {
+        true
+    }
+
+    fn execute(
+        &self,
+        _request: Option<&mut AsyncHttpRequest>,
+        _response: Option<&HttpResponseView>,
+        _state: &mut event_script::mlm::MultiLevelMap,
+        _node_name: &str,
+    ) {
+    }
+}
+
+/// One sequential test fn: logger + config overrides must be in place before
+/// the first `load_declared_features()` call, and the warn assertions read
+/// the shared captured log.
+#[test]
+fn feature_registration_policy_matches_java() {
+    log::set_logger(&CaptureLogger).expect("no other logger in this binary");
+    log::set_max_level(log::LevelFilter::Debug);
+    // the optional-service condition reads application config: satisfy the
+    // "present" gate before the AppConfigReader singleton freezes
+    overrides::set("test.feature.present.key", "true");
+
+    // 1. declarative load: built-ins + gated features
+    let count = features::load_declared_features();
+    assert!(
+        count >= 3,
+        "built-ins + gated-present expected, got {count}"
+    );
+    assert!(
+        features::get_feature("log-request-headers").is_some(),
+        "built-in #[fetch_feature] declarations must be collected"
+    );
+    assert!(features::get_feature("log-response-headers").is_some());
+    assert!(
+        features::get_feature("gated-present").is_some(),
+        "a satisfied #[optional_service] condition loads the feature"
+    );
+    assert!(
+        features::get_feature("gated-absent").is_none(),
+        "an unsatisfied #[optional_service] condition skips the feature"
+    );
+    let skipped = captured()
+        .lock()
+        .unwrap()
+        .iter()
+        .any(|line| line.contains("Skip optional FetchFeature - gated-absent"));
+    assert!(
+        skipped,
+        "the skip must be logged with the Java wording: {:?}",
+        captured().lock().unwrap()
+    );
+
+    // 2. duplicate name: WARN + last-wins (explicit register wins over
+    //    declarative because it runs later and replaces)
+    features::register("log-request-headers", Arc::new(NoOp(false)));
+    let replaced = features::get_feature("log-request-headers").expect("still registered");
+    assert!(!replaced.run_before(), "last registration wins");
+    let warned = captured().lock().unwrap().iter().any(|line| {
+        line.contains("WARN")
+            && line.contains(
+                "Reloading FetchFeature log-request-headers - please check duplicated feature name",
+            )
+    });
+    assert!(
+        warned,
+        "a duplicate feature name must warn: {:?}",
+        captured().lock().unwrap()
+    );
+}

--- a/crates/knowledge-graph/tests/ui.rs
+++ b/crates/knowledge-graph/tests/ui.rs
@@ -1,0 +1,26 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Compile-fail guards for the knowledge-graph macro surface: every deliberate
+//! compile-time error stays a compile-time error with its exact message.
+//! `.stderr` files track rustc's error formatting — regenerate with
+//! `TRYBUILD=overwrite cargo test --test ui` after a toolchain bump.
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/crates/knowledge-graph/tests/ui/fetch_feature_missing_name.rs
+++ b/crates/knowledge-graph/tests/ui/fetch_feature_missing_name.rs
@@ -1,0 +1,6 @@
+// #[fetch_feature] requires an explicit feature name (Java @FetchFeature's
+// required String value()).
+#[knowledge_graph::fetch_feature]
+struct Fixture;
+
+fn main() {}

--- a/crates/knowledge-graph/tests/ui/fetch_feature_missing_name.stderr
+++ b/crates/knowledge-graph/tests/ui/fetch_feature_missing_name.stderr
@@ -1,0 +1,5 @@
+error: #[fetch_feature] requires a feature name, e.g. #[fetch_feature("oauth-bearer")]
+ --> tests/ui/fetch_feature_missing_name.rs:4:8
+  |
+4 | struct Fixture;
+  |        ^^^^^^^

--- a/crates/knowledge-graph/tests/ui/fetch_feature_unknown_param.rs
+++ b/crates/knowledge-graph/tests/ui/fetch_feature_unknown_param.rs
@@ -1,0 +1,7 @@
+// #[fetch_feature] rejects anything beyond the feature name — the D3a
+// boundary guard: #[optional_service("...")] STACKS as a separate marker
+// attribute, it is not an inline parameter.
+#[knowledge_graph::fetch_feature(name = "guarded", optional_service = "app.env=dev")]
+struct Fixture;
+
+fn main() {}

--- a/crates/knowledge-graph/tests/ui/fetch_feature_unknown_param.stderr
+++ b/crates/knowledge-graph/tests/ui/fetch_feature_unknown_param.stderr
@@ -1,0 +1,5 @@
+error: unknown fetch_feature parameter (expected a feature name literal or name/value = "...")
+ --> tests/ui/fetch_feature_unknown_param.rs:4:52
+  |
+4 | #[knowledge_graph::fetch_feature(name = "guarded", optional_service = "app.env=dev")]
+  |                                                    ^^^^^^^^^^^^^^^^

--- a/crates/platform-core/Cargo.toml
+++ b/crates/platform-core/Cargo.toml
@@ -37,6 +37,8 @@ inventory = "0.3"
 platform-macros = { path = "../platform-macros" }
 
 [dev-dependencies]
+# compile-fail guards for the macro surfaces (tests/ui)
+trybuild = "1"
 # self-signed certificates for the HTTPS client integration test (increment 48)
 rcgen = "0.13"
 # decode the golden envelope wire-format vectors (increment 59)

--- a/crates/platform-core/src/automation/ws_server.rs
+++ b/crates/platform-core/src/automation/ws_server.rs
@@ -85,16 +85,23 @@ pub fn register_ws_service(
 }
 
 /// Namespace-aware registration (Java `@WebSocketService(value, namespace)`).
+/// A duplicate `/namespace/name` warns + last-wins — the one conflict policy
+/// shared by every registry (preload routes, simple plugins, fetch features).
 pub fn register_ws_service_with_namespace(
     namespace: &str,
     name: &str,
     factory: impl Fn() -> Arc<dyn ComposableFunction> + Send + Sync + 'static,
 ) {
-    services()
+    let path = format!("/{namespace}/{name}");
+    if services()
         .write()
         .expect("ws service registry poisoned")
-        .insert(format!("/{namespace}/{name}"), Arc::new(factory));
-    log::info!("Websocket service /{namespace}/{name} loaded");
+        .insert(path.clone(), Arc::new(factory))
+        .is_some()
+    {
+        log::warn!("Reloading WebSocketService {path} - please check duplicated service name");
+    }
+    log::info!("Websocket service {path} loaded");
 }
 
 /// True when any websocket service is registered.

--- a/crates/platform-core/src/lib.rs
+++ b/crates/platform-core/src/lib.rs
@@ -49,7 +49,8 @@ pub mod util;
 pub use app_starter::{AppStarter, AutoStart, EntryPoint};
 // the annotation layer (Java @PreLoad/@BeforeApplication/@MainApplication/@ZeroTracing)
 pub use platform_macros::{
-    before_application, main_application, optional_service, preload, websocket_service,
+    before_application, event_interceptor, main_application, optional_service, preload,
+    websocket_service, zero_tracing,
 };
 // re-exported so the macros' generated `submit!` resolves without the user
 // adding `inventory` as a direct dependency

--- a/crates/platform-core/tests/annotations.rs
+++ b/crates/platform-core/tests/annotations.rs
@@ -31,15 +31,17 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use platform_core::{
-    before_application, main_application, optional_service, overrides, preload, resources, trace,
-    AppError, AutoStart, ComposableFunction, EntryPoint, EventEnvelope, Platform, PostOffice,
-    TypedFunction,
+    before_application, event_interceptor, main_application, optional_service, overrides, preload,
+    resources, trace, zero_tracing, AppError, AutoStart, ComposableFunction, EntryPoint,
+    EventEnvelope, Platform, PostOffice, TypedFunction,
 };
 
 static JOURNAL: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
 static TYPED_HAD_TRACE: AtomicBool = AtomicBool::new(false);
 static ZERO_TRACED_HAD_TRACE: AtomicBool = AtomicBool::new(false);
 static ZERO_TRACED_RAN: AtomicBool = AtomicBool::new(false);
+static ZERO_ABOVE_HAD_TRACE: AtomicBool = AtomicBool::new(false);
+static ZERO_ABOVE_RAN: AtomicBool = AtomicBool::new(false);
 
 fn journal() -> &'static Mutex<Vec<String>> {
     JOURNAL.get_or_init(|| Mutex::new(Vec::new()))
@@ -118,6 +120,61 @@ impl ComposableFunction for ZeroTracedFn {
             Ordering::SeqCst,
         );
         EventEnvelope::new().set_body("ok")
+    }
+}
+
+/// Stacking is ORDER-INSENSITIVE, matching Java annotation semantics: the
+/// same `#[zero_tracing]` marker written ABOVE the primary attribute (a real
+/// proc-macro that re-attaches itself below, where `#[preload]` consumes it
+/// — the `#[optional_service]` self-reattachment pattern).
+#[zero_tracing]
+#[preload(route = "anno.zero.above")]
+struct ZeroTracedAbove;
+
+#[async_trait]
+impl ComposableFunction for ZeroTracedAbove {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        _input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        ZERO_ABOVE_RAN.store(true, Ordering::SeqCst);
+        ZERO_ABOVE_HAD_TRACE.store(
+            trace::with_current(|state| !state.zero_traced).unwrap_or(false),
+            Ordering::SeqCst,
+        );
+        EventEnvelope::new().set_body("ok")
+    }
+}
+
+/// Mixed stacking order — one marker ABOVE the primary, one condition BELOW
+/// — must behave exactly like any other order (Java does not require a
+/// stacking order and neither does this port).
+#[event_interceptor]
+#[preload(route = "anno.mixed.order")]
+#[optional_service("profile.indicator=base")]
+struct MixedOrderInterceptor;
+
+#[async_trait]
+impl ComposableFunction for MixedOrderInterceptor {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        if let (Some(reply_to), Some(cid)) = (input.reply_to(), input.correlation_id()) {
+            let po = PostOffice::new(&Platform::get_instance());
+            po.send(
+                EventEnvelope::new()
+                    .set_to(reply_to)
+                    .set_correlation_id(cid)
+                    .set_body("mixed manual")?,
+            )
+            .await?;
+        }
+        EventEnvelope::new().set_body("ignored by the worker")
     }
 }
 
@@ -415,6 +472,47 @@ async fn annotation_macros_end_to_end() {
     assert!(
         !ZERO_TRACED_HAD_TRACE.load(Ordering::SeqCst),
         "zero-traced route must run with a telemetry-suppressed trace bracket"
+    );
+
+    // stacking is ORDER-INSENSITIVE (Java annotation semantics): the marker
+    // written ABOVE #[preload] behaves identically to the below-order twin
+    let reply = po
+        .request(
+            EventEnvelope::new()
+                .set_to("anno.zero.above")
+                .set_trace(&trace::new_trace_id(), "TEST /zero/above")
+                .set_body("go")
+                .expect("body"),
+            Duration::from_secs(2),
+        )
+        .await
+        .expect("zero-traced (above-order) rpc");
+    assert_eq!(reply.body_as::<String>().expect("zero reply"), "ok");
+    assert!(ZERO_ABOVE_RAN.load(Ordering::SeqCst));
+    assert!(
+        !ZERO_ABOVE_HAD_TRACE.load(Ordering::SeqCst),
+        "the marker above the primary must be consumed identically"
+    );
+
+    // mixed order: #[event_interceptor] above + #[optional_service] below —
+    // the condition registered the route AND the interceptor semantics hold
+    assert!(
+        platform.has_route("anno.mixed.order"),
+        "mixed-order stacking"
+    );
+    let reply = po
+        .request(
+            EventEnvelope::new()
+                .set_to("anno.mixed.order")
+                .set_body("ping")
+                .expect("body"),
+            Duration::from_secs(2),
+        )
+        .await
+        .expect("mixed-order interceptor manual reply");
+    assert_eq!(
+        reply.body_as::<String>().expect("manual reply"),
+        "mixed manual"
     );
 
     // the stacked #[event_interceptor] marker: the manual reply arrives and

--- a/crates/platform-core/tests/ui.rs
+++ b/crates/platform-core/tests/ui.rs
@@ -1,0 +1,26 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Compile-fail guards for the platform macro surface: every deliberate
+//! compile-time error stays a compile-time error with its exact message.
+//! `.stderr` files track rustc's error formatting — regenerate with
+//! `TRYBUILD=overwrite cargo test --test ui` after a toolchain bump.
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/crates/platform-core/tests/ui/event_interceptor_no_primary.rs
+++ b/crates/platform-core/tests/ui/event_interceptor_no_primary.rs
@@ -1,0 +1,6 @@
+// The #[event_interceptor] marker with no #[preload] on the item is a
+// compile error pointing at the inline equivalent.
+#[platform_core::event_interceptor]
+struct Fixture;
+
+fn main() {}

--- a/crates/platform-core/tests/ui/event_interceptor_no_primary.stderr
+++ b/crates/platform-core/tests/ui/event_interceptor_no_primary.stderr
@@ -1,0 +1,5 @@
+error: #[event_interceptor] must be stacked with #[preload] (or use the inline form #[preload(..., interceptor)])
+ --> tests/ui/event_interceptor_no_primary.rs:4:8
+  |
+4 | struct Fixture;
+  |        ^^^^^^^

--- a/crates/platform-core/tests/ui/optional_service_empty_condition.rs
+++ b/crates/platform-core/tests/ui/optional_service_empty_condition.rs
@@ -1,0 +1,6 @@
+// #[optional_service] requires a non-empty condition string.
+#[platform_core::optional_service("")]
+#[platform_core::preload(route = "ui.test")]
+struct Fixture;
+
+fn main() {}

--- a/crates/platform-core/tests/ui/optional_service_empty_condition.stderr
+++ b/crates/platform-core/tests/ui/optional_service_empty_condition.stderr
@@ -1,0 +1,7 @@
+error: #[optional_service] requires a condition string, e.g. #[optional_service("app.env=dev")]
+ --> tests/ui/optional_service_empty_condition.rs:2:1
+  |
+2 | #[platform_core::optional_service("")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `platform_core::optional_service` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/platform-core/tests/ui/optional_service_no_primary.rs
+++ b/crates/platform-core/tests/ui/optional_service_no_primary.rs
@@ -1,0 +1,6 @@
+// #[optional_service] must be stacked with one of the four primary
+// attributes; alone it is a compile error.
+#[platform_core::optional_service("app.env=dev")]
+struct Fixture;
+
+fn main() {}

--- a/crates/platform-core/tests/ui/optional_service_no_primary.stderr
+++ b/crates/platform-core/tests/ui/optional_service_no_primary.stderr
@@ -1,0 +1,5 @@
+error: #[optional_service] must be stacked with #[preload], #[websocket_service], #[before_application] or #[main_application]
+ --> tests/ui/optional_service_no_primary.rs:4:8
+  |
+4 | struct Fixture;
+  |        ^^^^^^^

--- a/crates/platform-core/tests/ui/preload_empty_route_segment.rs
+++ b/crates/platform-core/tests/ui/preload_empty_route_segment.rs
@@ -1,0 +1,6 @@
+// A comma-separated route list with an empty segment must fail at compile
+// time (validate_route_list).
+#[platform_core::preload(route = "a.b, ,c.d")]
+struct Fixture;
+
+fn main() {}

--- a/crates/platform-core/tests/ui/preload_empty_route_segment.stderr
+++ b/crates/platform-core/tests/ui/preload_empty_route_segment.stderr
@@ -1,0 +1,5 @@
+error: invalid #[preload] route list 'a.b, ,c.d' - each comma-separated route name must be non-empty
+ --> tests/ui/preload_empty_route_segment.rs:3:34
+  |
+3 | #[platform_core::preload(route = "a.b, ,c.d")]
+  |                                  ^^^^^^^^^^^

--- a/crates/platform-core/tests/ui/preload_missing_route.rs
+++ b/crates/platform-core/tests/ui/preload_missing_route.rs
@@ -1,0 +1,5 @@
+// #[preload] without a route is a compile error.
+#[platform_core::preload(instances = 2)]
+struct Fixture;
+
+fn main() {}

--- a/crates/platform-core/tests/ui/preload_missing_route.stderr
+++ b/crates/platform-core/tests/ui/preload_missing_route.stderr
@@ -1,0 +1,5 @@
+error: #[preload] requires route = "..."
+ --> tests/ui/preload_missing_route.rs:3:8
+  |
+3 | struct Fixture;
+  |        ^^^^^^^

--- a/crates/platform-core/tests/ui/preload_unknown_param.rs
+++ b/crates/platform-core/tests/ui/preload_unknown_param.rs
@@ -1,0 +1,6 @@
+// An unknown #[preload] parameter must fail compilation with the list of
+// valid parameters (and the pointer to #[optional_service]).
+#[platform_core::preload(route = "ui.test", nonsense = 1)]
+struct Fixture;
+
+fn main() {}

--- a/crates/platform-core/tests/ui/preload_unknown_param.stderr
+++ b/crates/platform-core/tests/ui/preload_unknown_param.stderr
@@ -1,0 +1,5 @@
+error: unknown preload parameter (expected route, instances, env_instances, typed, zero_tracing, interceptor, is_private; a conditional registration is declared with the separate #[optional_service("...")] attribute)
+ --> tests/ui/preload_unknown_param.rs:3:45
+  |
+3 | #[platform_core::preload(route = "ui.test", nonsense = 1)]
+  |                                             ^^^^^^^^

--- a/crates/platform-core/tests/ui/websocket_service_missing_name.rs
+++ b/crates/platform-core/tests/ui/websocket_service_missing_name.rs
@@ -1,0 +1,5 @@
+// #[websocket_service] without a service name is a compile error.
+#[platform_core::websocket_service]
+struct Fixture;
+
+fn main() {}

--- a/crates/platform-core/tests/ui/websocket_service_missing_name.stderr
+++ b/crates/platform-core/tests/ui/websocket_service_missing_name.stderr
@@ -1,0 +1,5 @@
+error: #[websocket_service] requires a service name, e.g. #[websocket_service("graph")]
+ --> tests/ui/websocket_service_missing_name.rs:3:8
+  |
+3 | struct Fixture;
+  |        ^^^^^^^

--- a/crates/platform-core/tests/ui/zero_tracing_no_primary.rs
+++ b/crates/platform-core/tests/ui/zero_tracing_no_primary.rs
@@ -1,0 +1,6 @@
+// The #[zero_tracing] marker with no #[preload] on the item is a compile
+// error pointing at the inline equivalent.
+#[platform_core::zero_tracing]
+struct Fixture;
+
+fn main() {}

--- a/crates/platform-core/tests/ui/zero_tracing_no_primary.stderr
+++ b/crates/platform-core/tests/ui/zero_tracing_no_primary.stderr
@@ -1,0 +1,5 @@
+error: #[zero_tracing] must be stacked with #[preload] (or use the inline form #[preload(..., zero_tracing)])
+ --> tests/ui/zero_tracing_no_primary.rs:4:8
+  |
+4 | struct Fixture;
+  |        ^^^^^^^

--- a/crates/platform-macros/src/lib.rs
+++ b/crates/platform-macros/src/lib.rs
@@ -324,6 +324,69 @@ pub fn optional_service(args: TokenStream, input: TokenStream) -> TokenStream {
     quote!(#item).into()
 }
 
+/// The Java `@ZeroTracing` analog as a first-class marker attribute:
+/// suppresses the function's own telemetry (no dataset, no span) while the
+/// trace context still flows through for continuity. Order-insensitive —
+/// Java does not require a stacking order and neither does this port: write
+/// it above or below `#[preload]`, or inline as
+/// `#[preload(..., zero_tracing)]`.
+#[proc_macro_attribute]
+pub fn zero_tracing(args: TokenStream, input: TokenStream) -> TokenStream {
+    marker_attribute(args, input, "zero_tracing")
+}
+
+/// The Java `@EventInterceptor` analog as a first-class marker attribute:
+/// the function receives the raw envelope and replies manually; the worker
+/// ignores its returned envelope. Order-insensitive — write it above or
+/// below `#[preload]`, or inline as `#[preload(..., interceptor)]`.
+#[proc_macro_attribute]
+pub fn event_interceptor(args: TokenStream, input: TokenStream) -> TokenStream {
+    marker_attribute(args, input, "event_interceptor")
+}
+
+/// Shared mechanics for the stackable markers (the `#[optional_service]`
+/// self-reattachment pattern): written ABOVE the primary attribute, the
+/// marker expands first, verifies a primary is still on the item and
+/// re-attaches itself below, where the primary consumes it; written BELOW,
+/// the primary strips it before the compiler ever resolves it, so this macro
+/// never runs. A marker with no primary on the item is a compile error.
+fn marker_attribute(args: TokenStream, input: TokenStream, name: &str) -> TokenStream {
+    if !args.is_empty() {
+        return syn::Error::new(
+            proc_macro2::Span::call_site(),
+            format!("#[{name}] takes no arguments"),
+        )
+        .to_compile_error()
+        .into();
+    }
+    let mut item = parse_macro_input!(input as ItemStruct);
+    let has_primary = item.attrs.iter().any(|attr| {
+        attr.path()
+            .segments
+            .last()
+            .is_some_and(|seg| seg.ident == "preload")
+    });
+    if !has_primary {
+        return syn::Error::new_spanned(
+            &item.ident,
+            format!(
+                "#[{name}] must be stacked with #[preload] \
+                 (or use the inline form #[preload(..., {inline})])",
+                inline = if name == "event_interceptor" {
+                    "interceptor"
+                } else {
+                    name
+                }
+            ),
+        )
+        .to_compile_error()
+        .into();
+    }
+    let marker = syn::Ident::new(name, proc_macro2::Span::call_site());
+    item.attrs.push(syn::parse_quote!(#[#marker]));
+    quote!(#item).into()
+}
+
 fn entry_point_attribute(
     args: TokenStream,
     input: TokenStream,

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2084,6 +2084,72 @@ pre-existing header-hygiene asymmetries. Mirrored from the Java reference (branc
 
 ---
 
+## Increment 70 — Annotation→macro consistency: the engine dogfoods its extension points (2026-07-25)
+
+P1 of the ratified annotation→macro arc (design:
+`draft-design-specs/annotation-macro-interop-design.md` in the Java repo, verified by an
+8-agent survey; the Rust port is the template for future Python/Node ports). Java's
+lock-step half (Platform javadoc fix + PlaygroundLoader duplicate WARN) rides the
+same-named Java branch.
+
+- **D1 — dogfooding:** all 46 built-in mapping plugins converted from
+  `builtin_registrations()` to `#[simple_plugin("...")]` declarations (bodies VERBATIM —
+  the isEmpty/getFirst/getLast twin tests pass unchanged; an explicit name on all 46 is
+  necessary: the `plugin_*` fn prefix means camelCase derivation never equals the plugin
+  name, and keyword-named plugins like `mod`/`not`/`and` never become fn idents).
+  **Syntax harmonization (Eric):** `#[simple_plugin]` accepts the positional string form,
+  mirroring `#[fetch_feature]`'s grammar — the string is the registered name (the
+  `getName()` override analog), `name = "..."` stays as an alias, no argument keeps the
+  camelCase derivation; one visual grammar across both extension points, portable
+  verbatim to Python/Node decorators. `plugins_e8.rs` became a proper module (textual `include!` retired);
+  `extern crate self as event_script` lets the macro's `::event_script::` expansion
+  resolve in-crate. Registry = one link-time inventory fold (OnceLock); the
+  `SimplePluginLoader` hook (seq 3) forces the fold before flows compile and asserts
+  `>= BUILTIN_PLUGIN_COUNT (46)`. Both built-in fetch features converted to
+  `#[fetch_feature]`; `register_builtins()` deleted; the GraphResources hook asserts
+  `>= 2`. Linker elision now fails the boot loudly (registration-metadata contract).
+- **D2 — one conflict policy:** explicit register wins over declarative; duplicate name =
+  WARN + last-wins everywhere — plugins + features use Java's exact wording
+  (`Reloading SimplePlugin/FetchFeature {name} - please check duplicated ...`), websocket
+  services gain the same-style WARN, preload routes already had it (F10). Features flip
+  from skip-if-present to warn+replace. Regressions in two dedicated test binaries with a
+  capturing logger: duplicate plugin warns + last-wins, user `#[simple_plugin]` shadowing
+  a built-in warns (link-order decides the winner, like a Java classpath scan), duplicate
+  feature warns + last-wins.
+- **Order-insensitive marker stacking (Eric: "Java does not require stack order of
+  annotations"):** `#[zero_tracing]` / `#[event_interceptor]` promoted to real attribute
+  macros using the `#[optional_service]` self-reattachment pattern — written above the
+  primary they re-attach themselves below where `#[preload]` consumes them; below-order
+  and the inline-args form unchanged; no primary = compile error with a pointer to the
+  inline form. Regressions: above-order zero_tracing twin (telemetry-suppression
+  identical), mixed order (marker above + condition below) registers AND intercepts.
+  **Trybuild adoption (Eric upgraded the flag from P2-candidate to this round):** three
+  `tests/ui` compile-fail suites hosted in the RUNTIME crates (platform-core 8 fixtures,
+  event-script 1, knowledge-graph 2 — no dev-dependency cycles; fixtures need the runtime
+  crates as expansion targets anyway), one `ui()` runner each via
+  `trybuild::TestCases::compile_fail("tests/ui/*.rs")`, `.stderr` files committed. Every
+  deliberate macro compile error is now pinned: preload unknown-param/missing-route/
+  empty-route-segment, optional_service no-primary/empty-condition, the two marker
+  no-primary errors, websocket_service missing-name, simple_plugin unknown-param, and
+  fetch_feature missing-name/unknown-param (the D3a boundary guard: optional_service
+  STACKS, it is not an inline parameter). Toolchain note: the repo pins NO rust-toolchain
+  (CI tracks stable); `.stderr` files track rustc's error formatting, so a toolchain bump
+  that reshapes diagnostics is regenerated with `TRYBUILD=overwrite cargo test --test ui`
+  in each of the three crates.
+- **D3a — fetch_feature parity:** stacked `#[optional_service("condition")]` marker
+  (platform-macro strip/fold pattern) + `optional_service` on `FetchFeatureEntry`,
+  evaluated via `util::feature::is_required` with the `Skip optional FetchFeature - {name}`
+  log; regression: absent key skips, present key loads. Per Eric's ruling
+  `#[simple_plugin]` takes NO optional_service — plugins are flow vocabulary, never
+  conditionally on/off (stated in the macro docs).
+- **Docs:** macros-reference (built-ins-use-the-macros + real examples + conflict policy +
+  the optional_service marker), two stale claims fixed (syntax.md: `#[preload]` DOES take
+  comma-separated aliases; api-overview.md: public/private IS ported), design-doc notes
+  (event-script-port §5h, knowledge-graph-port), CHANGELOG Unreleased.
+  Workspace 262 (260+2) / clippy 0 / fmt.
+
+---
+
 ## Deferred backlog (as of increment 10)
 
 See `docs/design/platform-core-port.md` §7 for the authoritative list: broadcast delivery,

--- a/docs/design/event-script-port.md
+++ b/docs/design/event-script-port.md
@@ -383,6 +383,15 @@ reactive back-pressure.*
   the body carries REAL bytes from `f:binary`, Java `byte[]` parity), string-util,
   parse-date/parse-date-time, input-validation-1/-2; plus a user-defined `shout`
   plugin registered via the macro and resolved through `f:shout(...)`.
+- **Consistency round (2026-07-25, annotation→macro arc):** the E-8
+  `builtin_registrations()` seeding is gone — **all 46 built-ins are themselves
+  `#[simple_plugin]` declarations** (the engine dogfoods its extension point, like
+  Java's `@SimplePlugin` classes), folded from the link-time inventory exactly once;
+  `plugins_e8.rs` became a proper module (no more textual `include!`); the
+  `SimplePluginLoader` hook asserts the registered count against the built-in floor
+  so linker elision fails the boot loudly; a duplicate name — including a user
+  plugin shadowing a built-in — warns with Java's `SimplePluginLoader` wording and
+  the last registration wins (the one conflict policy, D2).
 
 ## 5i. Increment E-9 — HTTP adapter, resilience, mock, hello-flow (implemented 2026-07-17)
 

--- a/docs/design/knowledge-graph-port.md
+++ b/docs/design/knowledge-graph-port.md
@@ -160,7 +160,12 @@ changes).
    > maintainer-directed: the declarative `#[fetch_feature]` macro** (new
    > `knowledge-graph-macros` crate) — Java `@FetchFeature` parity for
    > field-installation cases like OAuth 2.0 bearer injection; proven E2E with the
-   > DemoAuth pattern on the wire. **K-7b shipped 2026-07-17 (increment 28):** the
+   > DemoAuth pattern on the wire. *(Consistency round, 2026-07-25: the two built-in
+   > features are themselves `#[fetch_feature]` declarations — `register_builtins()`
+   > removed; the loader asserts the ≥2 count against linker elision; a stacked
+   > `#[optional_service]` marker now gates a declared feature on configuration,
+   > Java `@OptionalService` parity; duplicate names warn + last-wins with Java's
+   > `PlaygroundLoader` wording.)* **K-7b shipped 2026-07-17 (increment 28):** the
    > Playground — `GraphUserInterface` + `GraphSession`, `GraphCommandService`
    > (`commands.rs`, the 1,494-line grammar), `GraphTraveler`, `JsonPathHandler`,
    > the AI-companion REST hop (`POST /api/companion/{id}`) + the K-6-deferred dev

--- a/docs/guides/api-overview.md
+++ b/docs/guides/api-overview.md
@@ -30,10 +30,12 @@ let reply = po
     parallel RPC** (`request(List<EventEnvelope>, timeout)`), **event-over-HTTP**
     (`asyncRequest` against a remote instance), the `exists()` multi-route check
     (use `Platform::has_route` per route), journaling helpers, and the `Kv` convenience
-    class. Java `Platform` extras not ported: `waitForProvider`, `setSelf`/personality,
-    and the public/private function distinction (there is no service mesh, so every
-    function is local). The port adds nothing that Java lacks — absent here means
-    deferred or out of scope, never renamed.
+    class. Java `Platform` extras not ported: `waitForProvider` and `setSelf`/personality.
+    The **public/private function distinction IS ported**: functions are private by
+    default (`is_private = true` on `#[preload]`, `register` vs `register_public`), and a
+    private function is not reachable through the `/api/event` endpoint (403), exactly as
+    in Java. The port adds nothing that Java lacks — absent here means deferred or out of
+    scope, never renamed.
 
 ## Platform
 

--- a/docs/guides/event-script/syntax.md
+++ b/docs/guides/event-script/syntax.md
@@ -353,11 +353,17 @@ The above event flow configuration uses "my.first.task" as a named route for "gr
 
 ## Assigning multiple route names to a single function
 
-> **Not in this Rust port.** The Java engine accepts a comma-separated route list in `@PreLoad` to
-> register the same function under several route names; this port's `#[preload]` takes a **single**
-> route. Use the **unique task naming** method above (which the Java docs recommend as more
-> memory-efficient anyway) — or, when separate route names are genuinely needed, declare two thin
-> unit structs that delegate to shared logic, each with its own `#[preload]`.
+Exactly like Java's `@PreLoad(route = "a.b, c.d")`, this port's `#[preload]` accepts a
+**comma-separated route list** — the same function registers under several route names
+(each segment compile-validated; see the hello-world example's alias demo):
+
+```rust
+#[preload(route = "hello.world, hello.alias")]
+struct HelloWorld;
+```
+
+The **unique task naming** method above remains the more memory-efficient choice when the
+routes exist only to disambiguate flow tasks.
 
 ## Preload overrides
 

--- a/docs/guides/macros-reference.md
+++ b/docs/guides/macros-reference.md
@@ -99,8 +99,12 @@ mistakes never reach runtime.
 
 ### Stacked markers
 
-Three marker attributes stack **below** `#[preload]`, mirroring Java's annotation stacking;
-`#[preload]` consumes them at expansion time:
+Three marker attributes stack with `#[preload]`, mirroring Java's annotation stacking —
+and, exactly like Java annotations, **stacking is order-insensitive**: a marker may be
+written above or below `#[preload]` (each marker is a real attribute macro that detects
+the primary and re-attaches itself where `#[preload]` consumes it). The inline-args form
+(`#[preload(..., zero_tracing, interceptor)]`) is equivalent. Using a marker with no
+primary attribute on the item is a compile error.
 
 `#[zero_tracing]`
 :   The Java `@ZeroTracing`: this route's executions are excluded from distributed-trace
@@ -112,12 +116,11 @@ Three marker attributes stack **below** `#[preload]`, mirroring Java's annotatio
     automatic reply on success. A failure still routes to `reply_to`.
 
 `#[optional_service("condition")]`
-:   Conditional registration — a first-class attribute in its own right (next section) that
-    also works stacked above.
+:   Conditional registration — a first-class attribute in its own right (next section).
 
 ```rust
+#[zero_tracing]                          // above or below - both work
 #[preload(route = "anno.zero.traced")]
-#[zero_tracing]
 struct QuietService;
 
 #[preload(route = "anno.interceptor")]
@@ -246,8 +249,12 @@ service is registered (Java parity).
 The Java `@SimplePlugin` analog for the flow engine: registers a mapping-language plugin so
 `f:name(...)` expressions validate at flow-compile time and resolve at runtime. The target
 is a **function** with the signature `fn(&[rmpv::Value]) -> Result<rmpv::Value, String>`.
-The plugin name defaults to the camelCase form of the function name; override with
-`name = "..."`.
+The **positional string is the registered plugin name** — the analog of overriding Java's
+`PluginFunction.getName()` — e.g. `#[simple_plugin("getFirst")]`; `name = "..."` is an
+equivalent alias. Omitting the argument derives the name as the camelCase form of the
+function name (the Java class-name-to-camelCase convention). The argument grammar is
+identical to `#[fetch_feature]` where the two macros overlap: the string is the registered
+name; omit it to derive from the declaration.
 
 ```rust
 #[event_script::simple_plugin]
@@ -264,6 +271,21 @@ fn shout(args: &[rmpv::Value]) -> Result<rmpv::Value, String> {
 The plugin loader (a before-application hook at sequence 3) collects every entry before
 flows compile, so a flow mapping `f:shout(model.word)` resolves to this function.
 
+The engine dogfoods this extension point: **all 46 built-in mapping plugins are
+`#[simple_plugin]` declarations** (exactly like Java's 47 `@SimplePlugin` classes),
+collected from the same inventory as user plugins — e.g. the built-in `f:isEmpty`:
+
+```rust
+#[simple_plugin("isEmpty")]
+fn plugin_is_empty(args: &[Value]) -> Result<Value, String> { /* ... */ }
+```
+
+A duplicate plugin name — including a user plugin shadowing a built-in — warns
+(`Reloading SimplePlugin {name} - please check duplicated plugin name`) and the last
+registration wins, the same conflict policy as every other registry. Note:
+`#[simple_plugin]` deliberately takes **no** `#[optional_service]` marker — plugins are
+Event Script capabilities (flow vocabulary), never conditionally on/off.
+
 ## `#[fetch_feature]` (knowledge-graph)
 
 The Java `@FetchFeature(value)` analog: registers an API-fetcher feature for pre/post
@@ -275,6 +297,11 @@ provider node lists the feature by name in its `feature` property.
 | Parameter | Meaning |
 |---|---|
 | `"name"` or `name = "..."` | **Required.** The feature name providers reference. |
+
+A stacked `#[optional_service("condition")]` marker (the Java `@OptionalService` analog —
+same grammar as on the platform macros: comma = OR, `!` = NOT, `key=value`, bare `key`
+means `key=true`) makes the feature conditional on application configuration, evaluated at
+boot; a skipped feature logs `Skip optional FetchFeature - {name}`.
 
 ```rust
 #[knowledge_graph::fetch_feature("demo-auth")]
@@ -297,9 +324,13 @@ impl knowledge_graph::features::FeatureRunner for DemoAuth {
 }
 ```
 
-The engine loads all declared features during startup, before any graph executes. Two
-built-in demonstration features — `log-request-headers` and `log-response-headers` — are
-registered by the engine itself.
+The engine loads all declared features during startup, before any graph executes. The
+engine dogfoods this extension point too: the two built-in demonstration features —
+`log-request-headers` and `log-response-headers` — are themselves `#[fetch_feature]`
+declarations, like Java's `@FetchFeature` classes. A duplicate feature name warns
+(`Reloading FetchFeature {name} - please check duplicated feature name`) and the last
+registration wins; an explicit `features::register()` call wins over a declarative entry
+because it runs later and replaces.
 
 ## `auto_start_main!()`
 

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.10.5**: tracks the canonical mercury-composable line (Java 4.10.5 in lock-step — one version, two languages; security patch: playground webapp on react-router 8.3.0, dependabot #16 remediated).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-24 | agent: Claude Code (2026-07-24-191554)
+- **last_session:** 2026-07-26 | agent: Claude Code (2026-07-26-002157)
 - **last_review:** 2026-07-24 | through 2026-07-24-025820.md
 - **last_invariant_check:** 2026-07-21 | through 2026-07-21-023208 (confirmed — inv-never-couple-functions + Vision both hold; Vision context refreshed post-graduation)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -111,6 +111,47 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
 
 > Mark completed items `- [x]` and leave them in place — the review sweeps them to
 > the archive once older than `archive_window` sessions. Don't archive them by hand.
+
+- [ ] (in flight — 2026-07-26; branch `feature/annotation-macro-consistency`, 1 commit, NOT
+  pushed — Eric gates) **Annotation→macro consistency P1 (ratified arc; design:
+  Java repo `draft-design-specs/annotation-macro-interop-design.md`; goal: the Rust macro
+  surface reads like the Java annotation surface — the template for future Python/Node
+  ports). Java's lock-step half (Platform javadoc + PlaygroundLoader WARN) rides the
+  same-named Java branch.** (D1) The engine dogfoods its extension points: all 46 built-in
+  mapping plugins converted to `#[simple_plugin(name = "...")]` declarations (bodies
+  VERBATIM, twin tests pass unchanged; explicit name= on all 46 — the plugin_* fn prefix
+  means camelCase derivation never matches, and keyword-named plugins never become fn
+  idents); both built-in fetch features converted to `#[fetch_feature]`;
+  builtin_registrations()/register_builtins() deleted; plugins_e8.rs is a proper module
+  (include! retired); `extern crate self as ...` in both crates so the macros' absolute
+  paths resolve in-crate; registry = one link-time inventory fold (OnceLock) + startup
+  count assertions (>= 46 plugins at SimplePluginLoader seq 3, >= 2 features at
+  GraphResources) so linker elision fails the boot loudly. (D2) One conflict policy:
+  explicit register wins over declarative; duplicate name = WARN + last-wins everywhere —
+  Java's exact wordings (Reloading SimplePlugin/FetchFeature {name} - please check
+  duplicated ...); websocket adds the same-style WARN; features flip from skip-if-present
+  to warn+replace; regressions in 2 dedicated test binaries with a capturing logger (incl.
+  user #[simple_plugin] shadowing a built-in — the winner is link-order-dependent like a
+  Java classpath scan, the WARN is the contract). (D3a) #[fetch_feature] accepts a stacked
+  #[optional_service] (platform strip/fold pattern; FetchFeatureEntry.optional_service;
+  is_required at boot; "Skip optional FetchFeature - {name}"); per Eric's ruling
+  #[simple_plugin] takes NO optional_service (plugins are flow vocabulary — stated in
+  macro docs). Stale docs fixed: syntax.md (#[preload] DOES take comma aliases),
+  api-overview.md (public/private IS ported). Docs: macros-reference, design notes,
+  CHANGELOG Unreleased, increment 70. Gate: workspace 262 (260+2) / clippy 0 / fmt.
+  Two Eric-approved addenda folded in: POSITIONAL #[simple_plugin("name")] form (mirrors
+  fetch_feature's grammar; all 46 built-ins flipped; name= stays as alias; no-arg keeps
+  camelCase derivation — one grammar, portable to Python/Node decorators) and
+  ORDER-INSENSITIVE marker stacking (#[zero_tracing]/#[event_interceptor] are real macros
+  via the optional_service self-reattachment pattern — above/below/inline all equivalent,
+  Java annotation semantics; no compile-fail harness in the workspace, behavioral
+  regressions only at first — Eric then upgraded trybuild to THIS round: 3 tests/ui
+  compile-fail suites in the runtime crates, 11 fixtures pinning every deliberate macro
+  compile error, .stderr committed; no rust-toolchain pin, so a diagnostics-reshaping
+  bump regenerates via TRYBUILD=overwrite). Final gate: 265 (262+3) / clippy 0 / fmt.
+  P2 (same arc, gated separately): yaml.preload.override port + contract spec/ADR pair.
+  Close when merged (+ released). Relates [[port-bottom-up-faithful]].
+  <!-- id: thread-annotation-macro-consistency | created: 2026-07-26 | last_used: 2026-07-26 | uses: 1 | tier: working | origin: 2026-07-26-002157.md -->
 
 - [x] (release — 2026-07-24; CLOSED same day) **v4.10.5 SHIPPED AND PUBLISHED in lock-step
   (both repos) — tag `v4.10.5` on merge commit `5ae307c2` (PR

--- a/memory/sessions/2026-07-26-002157.md
+++ b/memory/sessions/2026-07-26-002157.md
@@ -1,0 +1,121 @@
+# Session (2026-07-26T00:21:57.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+P1 of the ratified annotation→macro consistency arc on branch
+`feature/annotation-macro-consistency` (1 commit, NOT pushed — Eric gates).
+Design ground truth: the Java repo's
+`draft-design-specs/annotation-macro-interop-design.md` (8-agent survey).
+Java's small lock-step half (Platform javadoc fix + PlaygroundLoader duplicate
+WARN) rides the same-named Java branch.
+
+## What was built
+
+- **D1 — the engine dogfoods its extension points.** All 46 built-in mapping
+  plugins converted from `builtin_registrations()` to
+  `#[simple_plugin(name = "...")]` declarations with bodies VERBATIM — the
+  isEmpty/getFirst/getLast twin tests pass unchanged. Explicit `name=` on all
+  46: the `plugin_*` fn-name prefix means the macro's camelCase derivation
+  never equals the plugin name, so explicit naming is necessary, not just
+  uniform; keyword-collision worry (mod/not/and/or/...) dissolves the same way
+  — reserved words never become fn idents. `plugins_e8.rs` became a proper
+  module (`include!` retired; one helper made pub(crate) for the test module).
+  Both built-in fetch features are `#[fetch_feature]` declarations;
+  `register_builtins()` and its lib.rs call site deleted. Mechanic note for
+  future ports: a macro whose expansion references the defining crate's public
+  name needs `extern crate self as <name>` in that crate (added to
+  event-script and knowledge-graph).
+- **Registry mechanics + linker-elision guard:** the plugin registry performs
+  ONE link-time inventory fold in its OnceLock initializer (built-ins + user
+  plugins alike; keeps every unit test passing untouched); the
+  SimplePluginLoader hook (seq 3, before flows compile) forces the fold and
+  fails the boot loudly below `BUILTIN_PLUGIN_COUNT` (46); GraphResources
+  asserts >= 2 features. Discovery must fail loudly when a registry that
+  should be populated is empty (registration-metadata contract).
+- **D2 — one conflict policy:** explicit register wins over declarative;
+  duplicate name = WARN + last-wins in every registry. Plugins + features use
+  Java's exact wordings (`Reloading SimplePlugin {name} - please check
+  duplicated plugin name` / `Reloading FetchFeature {name} - please check
+  duplicated feature name`); websocket services gain the same-style WARN;
+  features flip from skip-if-present (first-wins) to warn+replace; preload
+  routes already warned (F10). Regressions in two dedicated test binaries
+  (each installs a capturing logger — safe because nothing boots the platform
+  logger there): duplicate plugin warns + last-wins; user `#[simple_plugin]`
+  shadowing the built-in `isEmpty` warns during the fold (which body wins is
+  link-order-dependent, exactly like a Java classpath-scan order — the WARN
+  is the contract); duplicate feature warns + last-wins.
+- **D3a — fetch_feature parity:** stacked `#[optional_service("condition")]`
+  marker (the platform-macros strip/fold pattern copied into
+  knowledge-graph-macros), `optional_service: Option<&'static str>` on
+  `FetchFeatureEntry`, evaluated at boot via `util::feature::is_required`,
+  skip logged as `Skip optional FetchFeature - {name}` (Java PlaygroundLoader
+  wording). Regression: gated-absent key skips, gated-present key loads. Per
+  Eric's ruling, `#[simple_plugin]` takes NO optional_service — plugins are
+  Event Script capabilities (flow vocabulary), never conditionally on/off
+  (stated in both macro docs).
+- **Stale docs fixed (survey findings):** event-script/syntax.md wrongly said
+  `#[preload]` takes a single route (comma aliases ARE implemented and used in
+  production); api-overview.md wrongly said the public/private distinction is
+  not ported (is_private exists, private-by-default, /api/event 403).
+- **Docs for the round:** macros-reference (`#[simple_plugin]` /
+  `#[fetch_feature]` sections state the engine's built-ins use these macros,
+  with real examples; conflict policy; the optional_service marker + the
+  plugins-never-conditional principle), design-doc notes (event-script-port
+  §5h, knowledge-graph-port), CHANGELOG Unreleased (Added ×2 / Fixed ×2),
+  INCREMENTS §70.
+
+## Gate
+
+Workspace 262 passed / 0 failed (260 + 2 new regression binaries), clippy 0,
+fmt clean. Every plugin/feature behaves identically after conversion — same
+names, same bodies, same error messages, proven by the untouched suites.
+
+## Memory References
+
+- referenced: `port-bottom-up-faithful`, `conventions-rust-baseline`,
+  `inv-telemetry-presentation-parity` (error-text parity for the plugin trio)
+- created: `thread-annotation-macro-consistency` (born tier: working)
+
+## Also: two Eric-approved addenda folded into the same commit
+
+1. **Positional #[simple_plugin] form** (syntax harmonization): the macro
+   accepts `#[simple_plugin("getFirst")]` exactly like `#[fetch_feature]` —
+   the string is the registered name (the `getName()` override analog),
+   `name = "..."` stays as an alias, no argument keeps camelCase derivation.
+   All 46 built-ins flipped to positional; macros-reference shows it as
+   canonical; regressions: positional (new user plugin under an unrelated fn
+   name), alias (the shadow fixture stays on name=), derivation (the
+   flow_runtime `shout` fixture). Rationale on record: one positional grammar
+   across both extension points, portable verbatim to Python/Node decorators.
+2. **Order-insensitive marker stacking** (Eric: "Java does not require stack
+   order of annotations"): `#[zero_tracing]` / `#[event_interceptor]`
+   promoted to real attribute macros using the `#[optional_service]`
+   self-reattachment pattern — above-order re-attaches below where
+   `#[preload]` consumes it; below-order and inline-args unchanged; no
+   primary = compile error pointing at the inline form. Re-exported from
+   platform_core. Regressions in annotations.rs: above-order zero_tracing
+   twin (telemetry suppression identical), mixed order (interceptor above +
+   optional_service below) registers AND intercepts. NOTE: no compile-fail
+   harness exists in the workspace (optional_service's error is untested
+   too) — behavioral regressions only at first; Eric then upgraded the
+   trybuild flag to THIS round (see below).
+
+3. **Trybuild compile-fail guards** (Eric upgraded from P2-candidate): three
+   `tests/ui` suites hosted in the RUNTIME crates (no dev-dependency cycles;
+   fixtures need the runtime crates as expansion targets anyway) —
+   platform-core 8 fixtures (preload unknown-param / missing-route /
+   empty-route-segment, optional_service no-primary / empty-condition, the
+   two marker no-primary errors, websocket_service missing-name),
+   event-script 1 (simple_plugin unknown-param), knowledge-graph 2
+   (fetch_feature missing-name + unknown-param — the D3a boundary guard:
+   optional_service stacks, it is not an inline parameter). One `ui()`
+   runner per suite via trybuild::TestCases::compile_fail; `.stderr` files
+   committed, each verified to carry exactly the intended macro error.
+   trybuild = "1" dev-dependency in all three crates. Toolchain note: the
+   repo pins NO rust-toolchain (CI tracks stable) — a diagnostics-reshaping
+   toolchain bump regenerates via TRYBUILD=overwrite (documented in the
+   runners + INCREMENTS).
+
+Final gate: workspace 265 (262 + the 3 ui runners) / clippy 0 / fmt clean.


### PR DESCRIPTION
## What

P1 of the annotation → macro consistency arc (lock-step with the Java reference; the
Rust port is the template for future Python/Node ports). One commit, 51 files:

1. **All 46 built-in mapping plugins are now `#[simple_plugin("...")]` declarations**
   and both built-in fetch features are `#[fetch_feature]` declarations, discovered
   through the same link-time inventory as user code — exactly like Java's 47
   `@SimplePlugin` / 2 `@FetchFeature` classes. The hard-wired registries are deleted;
   startup guards fail the boot loudly if linker elision ever drops the inventory.
   Behavior is provably identical: same names, bodies and error messages (the
   isEmpty/getFirst/getLast Java-message twins pass unchanged).
2. **One positional grammar for both extension points** — `#[simple_plugin("getFirst")]`
   mirrors `#[fetch_feature("log-response-headers")]`; `name = "..."` remains a
   compatibility alias; omitting the name keeps camelCase derivation.
3. **Order-insensitive marker stacking** — `#[zero_tracing]` and `#[event_interceptor]`
   are real attributes now (the `#[optional_service]` self-reattachment pattern) and may
   be written above or below `#[preload]`, exactly like Java annotations; a marker with
   no primary is a compile error pointing at the inline equivalent.
4. **One conflict policy** — explicit registration wins over declarative; duplicates are
   warned (Java's exact wordings) and last-wins, uniformly across plugins, features and
   websocket services.
5. **`#[fetch_feature]` honors stacked `#[optional_service]`** (Java-parity: the
   PlaygroundLoader gates features through `Feature.isRequired`). Per maintainer ruling,
   `#[simple_plugin]` deliberately takes none — plugins are Event Script capabilities
   (flow vocabulary), never conditionally on/off; the principle is stated in the docs.
6. **11 trybuild compile-fail fixtures** across three `tests/ui` suites guard every
   deliberate macro compile error — including `#[fetch_feature]` rejecting inline
   parameters, the executable form of the optional-service-stacks-only boundary.
7. Two stale doc claims fixed (comma-separated route aliases ARE supported; the
   public/private function distinction IS ported).

Gate: workspace 265 passed, clippy 0, fmt clean.

## Why

Two deliberately context-free external reviews assessed the annotation-to-macro port;
their claims were verified line-by-line against both codebases. The confirmed core gap:
Java's engine dogfoods its own extension points while the Rust engine bypassed its
macros with hard-wired registries, leaving `#[simple_plugin]`/`#[fetch_feature]`
test-only. This round closes that gap and removes every developer-visible inconsistency
the survey found — grammar asymmetry between the two extension points, an attribute
stack-order requirement Java doesn't have, divergent conflict semantics, and unguarded
compile-time error contracts — so a developer reads the same declarative, decoupled,
order-free registration style in both engines, and the rules now proven here (name
grammar, order-freedom, conflict policy, misuse guards) become the registration-metadata
contract for the Python and Node ports.

Co-Authored-By: Claude Code <noreply@anthropic.com>