### PR TITLE
Typed AsyncHttpRequest, /info/routes actuator, single-source HTTP dataset + ops-tunable instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,63 @@ the design rationale in [`docs/design/`](docs/design/).
    no such marker — plugins are Event Script capabilities (flow vocabulary), never
    conditionally on/off.
 
+5. **`yaml.preload.override` is ported (P2 of the annotation→macro consistency arc, D4).**
+   The Java operational surface with identical semantics: config files named by the key
+   rename, fan out, or re-tune the `instances` of any `#[preload]` route at deploy time
+   without recompiling — `original` / `routes` / optional `instances` / optional
+   `keep-original`, comma-separated locations with missing files logged and skipped,
+   multi-file merge (route-set union; the first file to set `instances` wins), applied at
+   boot between inventory collection and registration (after `env_instances` resolution,
+   Java's order). An override entry matches when ANY of a function's declared
+   comma-separated routes appears as an `original`, and the declared list is replaced by
+   the override's sorted route set. Seven-scenario regression suite mirrors Java's
+   `PreloadOverrideTest`.
+6. **The registration-metadata contract, with golden conformance vectors (P2/D5).** The
+   cross-language contract behind `#[preload]` and its family is now a spec page
+   (`docs/guides/registration-metadata-contract.md`, adapted from the Java reference) with
+   **golden vectors shared verbatim** between repositories
+   (`registration-vectors/{core,plugin,feature}.json`, byte-identical to the Java copies)
+   and three conformance suites that declare the same fixture set through the Rust macro
+   carrier and assert declared metadata + boot-resolved registration against the golden
+   entries — including env-instances resolution, marker order-freedom, name derivation
+   (`fn vector_derived` and Java's `class VectorDerived` register the same
+   "vectorDerived") and optional-service gating. ADR-0008 records the decision (the twin
+   of the Java ledger's ADR-0009).
+
+7. **Typed `AsyncHttpRequest` functions** (field gap report — the Rust port could not type
+   a function's input as `AsyncHttpRequest`): the request model now implements
+   `Serialize` / `Deserialize` as thin delegates onto its own map-shape builder/parser,
+   so `#[preload(..., typed)]` + `TypedFunction<AsyncHttpRequest, O>` flows through the
+   ordinary typed adapter with no engine special case (Java, by contrast, special-cases
+   the class inside `WorkerHandler.getMapBody`) — the template rule for Python/Node
+   ports: a request class constructible from the request map makes typed signatures just
+   work. `from_value` now parses the full SERVER-side dataset (`ip`, `https`, `timeout`,
+   raw `query`) with round-trip integrity, and the accessor surface reaches Java parity
+   (`path_parameter`, `query_parameter`/`query_parameters`, `cookie`, `session_info`,
+   `remote_ip`, `is_secure`, `query_string`, `body_as` — with full fluent-builder
+   symmetry: `set_remote_ip`, `set_secure`, `set_query_string`, `set_cookie`,
+   `set_session_info`, `set_query_parameter_values`, `set_route_timeout_seconds`). The
+   REST automation server now constructs the request dataset THROUGH the struct at both
+   assembly sites (the main dispatch and the static-content filter), so the wire shape
+   has exactly one definition — `AsyncHttpRequest::to_value()` — and server↔struct drift
+   is impossible by construction. The hello-world `greeting.api` is rewritten in the
+   typed form as the living example.
+
+8. **The `/info/routes` actuator is ported** (`routes.actuator.service`, a default
+   rest.yaml endpoint like its siblings): the app block plus the local routing table
+   split by visibility — `routing.public` / `routing.private`, route → instance count,
+   sorted for deterministic output. Java's optional `journal` / `route_substitution` /
+   mesh `network` blocks are omitted when empty, and those subsystems do not exist in
+   this port, so the response is `{app, routing}`. Only `/info/lib` remains deferred
+   (a Rust binary has no runtime dependency manifest). The endpoint's first payoff: the
+   actuator family now runs 5 workers each (rule of thumb) with ONE ops knob —
+   `worker.instances.actuator.services`, the same key as the Java engine — and the
+   hello-world demo sizes its I/O-shaped fixtures accordingly (`event.api.auth` 30 with
+   `worker.instances.event.api.auth` — a real deployment verifies bearer tokens against
+   an OAuth2 authority; `http.request.filter` 20 with
+   `worker.instances.http.request.filter`), so operations teams can fine-tune in QA/Perf
+   before promoting to production.
+
 ### Fixed
 
 1. **One conflict policy across every registry** (matching the Java engine's actual
@@ -60,37 +117,16 @@ the design rationale in [`docs/design/`](docs/design/).
    function distinction IS ported (private by default; a private function is not
    reachable through `/api/event`).
 
----
-## Unreleased
-
-### Added
-
-1. **`yaml.preload.override` is ported (P2 of the annotation→macro consistency arc, D4).**
-   The Java operational surface with identical semantics: config files named by the key
-   rename, fan out, or re-tune the `instances` of any `#[preload]` route at deploy time
-   without recompiling — `original` / `routes` / optional `instances` / optional
-   `keep-original`, comma-separated locations with missing files logged and skipped,
-   multi-file merge (route-set union; the first file to set `instances` wins), applied at
-   boot between inventory collection and registration (after `env_instances` resolution,
-   Java's order). An override entry matches when ANY of a function's declared
-   comma-separated routes appears as an `original`, and the declared list is replaced by
-   the override's sorted route set. Seven-scenario regression suite mirrors Java's
-   `PreloadOverrideTest`.
-2. **The registration-metadata contract, with golden conformance vectors (P2/D5).** The
-   cross-language contract behind `#[preload]` and its family is now a spec page
-   (`docs/guides/registration-metadata-contract.md`, adapted from the Java reference) with
-   **golden vectors shared verbatim** between repositories
-   (`registration-vectors/{core,plugin,feature}.json`, byte-identical to the Java copies)
-   and three conformance suites that declare the same fixture set through the Rust macro
-   carrier and assert declared metadata + boot-resolved registration against the golden
-   entries — including env-instances resolution, marker order-freedom, name derivation
-   (`fn vector_derived` and Java's `class VectorDerived` register the same
-   "vectorDerived") and optional-service gating. ADR-0008 records the decision (the twin
-   of the Java ledger's ADR-0009).
-
 ### Changed
 
-1. **The `length` and `substring` string plugins use Unicode scalar values** (maintainer
+1. **JSON response bodies render pretty-printed** (presentation parity with the Java
+   engine, whose `async.http.response` writes through SimpleMapper's default —
+   pretty-printing — mapper): one shared render rule for every JSON response the REST
+   automation server writes, function responses and the `/info` / `/health` / `/env`
+   actuators alike (2-space indentation; the HTML `<pre>` shell wraps the same pretty
+   text). The Event-over-HTTP `/api/event` path is unaffected — it responds with a
+   MsgPack envelope, not rendered JSON.
+2. **The `length` and `substring` string plugins use Unicode scalar values** (maintainer
    ruling, superseding the earlier UTF-16 retrofit): indexes and counts address whole
    characters (code points) — modern ports use Unicode-native semantics, and Java's
    UTF-16 code units are a JVM legacy that must not propagate to future Python/Node/Go

--- a/crates/platform-core/resources/default-rest.yaml
+++ b/crates/platform-core/resources/default-rest.yaml
@@ -1,0 +1,36 @@
+#
+# The built-in default REST endpoints (Java platform-core `default-rest.yaml`):
+# merged only when the application's rest.yaml does not already claim the URL —
+# user entries always win. Embedded at compile time (include_str! in
+# automation/server.rs, the default-log-context.yaml pattern), so a library
+# consumer cannot shadow it by classpath accident.
+#
+# /info/lib is the one deferred Java default (a Rust binary has no runtime
+# dependency manifest) — see the actuator module doc.
+#
+rest:
+  - service: "event.api.service"
+    methods: ['POST']
+    url: "/api/event"
+    timeout: 60s
+    tracing: true
+  - service: "info.actuator.service"
+    methods: ['GET']
+    url: "/info"
+    timeout: 10s
+  - service: "routes.actuator.service"
+    methods: ['GET']
+    url: "/info/routes"
+    timeout: 10s
+  - service: "env.actuator.service"
+    methods: ['GET']
+    url: "/env"
+    timeout: 10s
+  - service: "health.actuator.service"
+    methods: ['GET']
+    url: "/health"
+    timeout: 30s
+  - service: "liveness.actuator.service"
+    methods: ['GET']
+    url: "/livenessprobe"
+    timeout: 10s

--- a/crates/platform-core/src/actuator.rs
+++ b/crates/platform-core/src/actuator.rs
@@ -17,10 +17,17 @@
 //! Actuator endpoints — Rust port of the Java `ActuatorServices`
 //! (`org.platformlambda.core.services.ActuatorServices`), registered by the
 //! lifecycle's essential-services phase and exposed over REST automation via
-//! the default endpoints (`/info`, `/env`, `/health`, `/livenessprobe`).
+//! the default endpoints (`/info`, `/info/routes`, `/env`, `/health`,
+//! `/livenessprobe`).
 //!
 //! - **`/info`** — application identity (name, version, description), runtime,
 //!   origin, start/current time, uptime.
+//! - **`/info/routes`** — the app block plus the local routing table split by
+//!   visibility (`routing.public` / `routing.private`, route → instance
+//!   count; Java `handleInfoRoute`). Java's optional blocks (`journal`,
+//!   `route_substitution`) and the mesh `network` table are omitted when
+//!   empty — subsystems this port does not have, so the response is
+//!   `{app, routing}` here.
 //! - **`/env`** — selected environment variables (`show.env.variables`) and
 //!   selected base-configuration parameters (`show.application.properties`) —
 //!   opt-in lists, so secrets are never dumped wholesale (Java parity).
@@ -36,8 +43,7 @@
 //! Deferred (maintainer-approved): `/info/lib` — Java lists JAR dependencies
 //! from the archive manifest; a Rust binary has no runtime dependency
 //! manifest (a build-script–embedded cargo metadata could provide it later).
-//! Also deferred: `/info/routes`, XML responses, and the Java per-route info
-//! cache.
+//! Also deferred: XML responses and the Java per-route info cache.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -54,9 +60,25 @@ use crate::trace;
 use crate::util::app_config_reader::AppConfigReader;
 
 pub const INFO_ACTUATOR: &str = "info.actuator.service";
+pub const ROUTES_ACTUATOR: &str = "routes.actuator.service";
 pub const ENV_ACTUATOR: &str = "env.actuator.service";
 pub const HEALTH_ACTUATOR: &str = "health.actuator.service";
 pub const LIVENESS_ACTUATOR: &str = "liveness.actuator.service";
+
+/// The worker-instance count for the actuator family (default 5 — a rule of
+/// thumb, like every initial instance count): operations teams fine-tune it
+/// via `worker.instances.actuator.services` in QA/Perf environments before
+/// promoting to production. ONE family key covers all five actuator routes —
+/// and it is the SAME key the Java engine carries: its actuators are one
+/// aliased class whose primary route is `actuator.services` (that route
+/// itself is unported here), so a single runbook line tunes both engines.
+/// Numeric value wins, anything else falls back (env_instances semantics).
+pub fn actuator_instances(config: &AppConfigReader) -> usize {
+    config
+        .get_property("worker.instances.actuator.services")
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .unwrap_or(5)
+}
 
 const SHOW_ENV: &str = "show.env.variables";
 const SHOW_PROPERTIES: &str = "show.application.properties";
@@ -69,6 +91,7 @@ const OPTIONAL_SERVICES: &str = "optional.health.dependencies";
 #[derive(Clone, Copy)]
 pub enum ActuatorKind {
     Info,
+    Routes,
     Env,
     Health,
     Liveness,
@@ -164,6 +187,32 @@ impl ComposableFunction for ActuatorServices {
                         .set_header("content-type", "text/plain")
                         .set_body("Unhealthy. Please check '/health' endpoint.")?)
                 }
+            }
+            ActuatorKind::Routes => {
+                // Java handleInfoRoute: the app block plus the local routing
+                // table split by visibility, route → instance count. Java's
+                // optional blocks — "journal" (journaling), "route_substitution"
+                // and the mesh "network" table — are omitted when empty, and
+                // none of those subsystems exist in this port, so the response
+                // is exactly {app, routing}. BTreeMap keeps the output
+                // deterministic (Java's HashMap ordering is arbitrary; JSON
+                // object order is not contractual, but stable beats random).
+                let mut public = std::collections::BTreeMap::new();
+                let mut private = std::collections::BTreeMap::new();
+                for route in context.platform.routes() {
+                    let instances = context.platform.instances(&route).unwrap_or(1);
+                    if context.platform.is_private(&route).unwrap_or(true) {
+                        private.insert(route, instances);
+                    } else {
+                        public.insert(route, instances);
+                    }
+                }
+                EventEnvelope::new()
+                    .set_header("content-type", "application/json")
+                    .set_body(serde_json::json!({
+                        "app": context.app_block(),
+                        "routing": {"public": public, "private": private},
+                    }))
             }
             ActuatorKind::Info => {
                 let now = std::time::SystemTime::now();

--- a/crates/platform-core/src/app_starter.rs
+++ b/crates/platform-core/src/app_starter.rs
@@ -202,15 +202,18 @@ impl AppStarter {
             let context = ActuatorContext::new(&platform);
             let actuators = [
                 (crate::actuator::INFO_ACTUATOR, ActuatorKind::Info),
+                (crate::actuator::ROUTES_ACTUATOR, ActuatorKind::Routes),
                 (crate::actuator::ENV_ACTUATOR, ActuatorKind::Env),
                 (crate::actuator::HEALTH_ACTUATOR, ActuatorKind::Health),
                 (crate::actuator::LIVENESS_ACTUATOR, ActuatorKind::Liveness),
             ];
+            // one ops knob for the whole family (see actuator_instances)
+            let instances = crate::actuator::actuator_instances(config);
             for (route, kind) in actuators {
                 if let Err(e) = platform.register_private(
                     route,
                     Arc::new(ActuatorServices::new(kind, context.clone())),
-                    1,
+                    instances,
                 ) {
                     if !platform.has_route(route) {
                         return Err(e);

--- a/crates/platform-core/src/automation/http_client.rs
+++ b/crates/platform-core/src/automation/http_client.rs
@@ -75,21 +75,65 @@ const HEADERS_TO_IGNORE: &[&str] = &[
 
 /// The HTTP request contract (Java `AsyncHttpRequest`): a map-backed model
 /// with `method`, `url`, `host`, `headers`, `body`, `parameters.query`,
-/// `parameters.path`, `cookies` and `session`. Programmatic callers build it
+/// `parameters.path`, `cookies`, `session` and the server-side dataset keys
+/// (`ip`, `https`, `timeout`, raw `query`). Programmatic callers build it
 /// with the fluent setters; declarative callers (flow data mapping) build
-/// the same map shape directly.
+/// the same map shape directly; a **typed function**
+/// (`TypedFunction<AsyncHttpRequest, O>` + `#[preload(..., typed)]`) receives
+/// it deserialized from the REST edge's request dataset — see the
+/// `Deserialize` impl below.
 #[derive(Clone, Debug)]
 pub struct AsyncHttpRequest {
     method: Option<String>,
     url: Option<String>,
     target_host: Option<String>,
     headers: Vec<(String, String)>,
-    body: Value,
+    // Option distinguishes "never set" (key omitted) from "set to null"
+    // (the REST edge emits an explicit null body for byte/form payloads)
+    body: Option<Value>,
     query_parameters: Vec<(String, Value)>,
     path_parameters: Vec<(String, String)>,
     cookies: Vec<(String, String)>,
     session: Vec<(String, String)>,
-    trust_all_cert: bool,
+    // Option: emitted only when explicitly set — a service-target dataset
+    // carries `host` (the Host header) WITHOUT a trust flag, while a relay
+    // caller that sets the flag keeps it on the wire
+    trust_all_cert: Option<bool>,
+    // server-side dataset keys (the REST edge emits them into the function's
+    // body; see automation::server process())
+    ip: Option<String>,
+    https: Option<bool>,
+    timeout: Option<u64>,
+    query_string: Option<String>,
+}
+
+/// Typed-function support (the maintainer-agreed design, 2026-07-26): the
+/// two serde traits are thin delegates onto the existing map-shape parser
+/// and builder, so `#[preload(..., typed)]` +
+/// `TypedFunction<AsyncHttpRequest, O>` flows through the ordinary
+/// `TypedAdapter` (`body_as::<I>()`) with ZERO worker special-casing — the
+/// knowledge lives on the type, not in the engine (Java, by contrast,
+/// special-cases `AsyncHttpRequest.class` inside `WorkerHandler.getMapBody`).
+/// This is the template rule for the Python/Node ports: their request
+/// classes must be constructible from the request map so typed signatures
+/// just work.
+impl<'de> serde::Deserialize<'de> for AsyncHttpRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        Ok(AsyncHttpRequest::from_value(&value))
+    }
+}
+
+impl serde::Serialize for AsyncHttpRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.to_value().serialize(serializer)
+    }
 }
 
 impl Default for AsyncHttpRequest {
@@ -106,12 +150,16 @@ impl AsyncHttpRequest {
             url: None,
             target_host: None,
             headers: Vec::new(),
-            body: Value::Nil,
+            body: None,
             query_parameters: Vec::new(),
             path_parameters: Vec::new(),
             cookies: Vec::new(),
             session: Vec::new(),
-            trust_all_cert: false,
+            trust_all_cert: None,
+            ip: None,
+            https: None,
+            timeout: None,
+            query_string: None,
         }
     }
 
@@ -131,10 +179,13 @@ impl AsyncHttpRequest {
         request.method = get("method").and_then(|v| v.as_str()).map(str::to_string);
         request.url = get("url").and_then(|v| v.as_str()).map(str::to_string);
         request.target_host = get("host").and_then(|v| v.as_str()).map(str::to_string);
-        request.trust_all_cert = get("trust_all_cert")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-        request.body = get("body").cloned().unwrap_or(Value::Nil);
+        request.trust_all_cert = get("trust_all_cert").and_then(|v| v.as_bool());
+        request.body = get("body").cloned();
+        // server-side dataset keys (REST edge → service-target function)
+        request.ip = get("ip").and_then(|v| v.as_str()).map(str::to_string);
+        request.https = get("https").and_then(|v| v.as_bool());
+        request.timeout = get("timeout").and_then(|v| v.as_u64());
+        request.query_string = get("query").and_then(|v| v.as_str()).map(str::to_string);
         if let Some(Value::Map(headers)) = get("headers") {
             for (k, v) in headers {
                 if let Some(key) = k.as_str() {
@@ -193,17 +244,32 @@ impl AsyncHttpRequest {
         }
         if let Some(host) = &self.target_host {
             map.push((Value::from("host"), Value::from(host.as_str())));
+        }
+        if let Some(trust_all_cert) = self.trust_all_cert {
             // Java toMap: trust_all_cert travels with the relay target
-            map.push((
-                Value::from("trust_all_cert"),
-                Value::from(self.trust_all_cert),
-            ));
+            map.push((Value::from("trust_all_cert"), Value::from(trust_all_cert)));
         }
         if !self.headers.is_empty() {
             map.push((Value::from("headers"), string_pairs(&self.headers)));
         }
-        if !matches!(self.body, Value::Nil) {
-            map.push((Value::from("body"), self.body.clone()));
+        if let Some(body) = &self.body {
+            // an explicit null body stays on the wire (the REST edge emits
+            // body: null for byte/form payloads; an UNSET body is omitted)
+            map.push((Value::from("body"), body.clone()));
+        }
+        // server-side dataset keys, emitted when set (round-trip integrity:
+        // to_value emits exactly what from_value parses)
+        if let Some(ip) = &self.ip {
+            map.push((Value::from("ip"), Value::from(ip.as_str())));
+        }
+        if let Some(https) = self.https {
+            map.push((Value::from("https"), Value::from(https)));
+        }
+        if let Some(timeout) = self.timeout {
+            map.push((Value::from("timeout"), Value::from(timeout)));
+        }
+        if let Some(query) = &self.query_string {
+            map.push((Value::from("query"), Value::from(query.as_str())));
         }
         if !self.cookies.is_empty() {
             map.push((Value::from("cookies"), string_pairs(&self.cookies)));
@@ -211,25 +277,26 @@ impl AsyncHttpRequest {
         if !self.session.is_empty() {
             map.push((Value::from("session"), string_pairs(&self.session)));
         }
-        if !self.query_parameters.is_empty() || !self.path_parameters.is_empty() {
-            let query: Vec<(Value, Value)> = self
-                .query_parameters
-                .iter()
-                .map(|(k, v)| (Value::from(k.as_str()), v.clone()))
-                .collect();
-            let path: Vec<(Value, Value)> = self
-                .path_parameters
-                .iter()
-                .map(|(k, v)| (Value::from(k.as_str()), Value::from(v.as_str())))
-                .collect();
-            map.push((
-                Value::from("parameters"),
-                Value::Map(vec![
-                    (Value::from("query"), Value::Map(query)),
-                    (Value::from("path"), Value::Map(path)),
-                ]),
-            ));
-        }
+        // "parameters" is always present with both sub-maps — the REST
+        // edge's dataset shape (a paramless request still carries the empty
+        // maps, exactly like today's server emission)
+        let query: Vec<(Value, Value)> = self
+            .query_parameters
+            .iter()
+            .map(|(k, v)| (Value::from(k.as_str()), v.clone()))
+            .collect();
+        let path: Vec<(Value, Value)> = self
+            .path_parameters
+            .iter()
+            .map(|(k, v)| (Value::from(k.as_str()), Value::from(v.as_str())))
+            .collect();
+        map.push((
+            Value::from("parameters"),
+            Value::Map(vec![
+                (Value::from("query"), Value::Map(query)),
+                (Value::from("path"), Value::Map(path)),
+            ]),
+        ));
         Value::Map(map)
     }
 
@@ -251,7 +318,7 @@ impl AsyncHttpRequest {
     /// Java `setTrustAllCert`: skip certificate-chain validation for an
     /// `https` target (self-signed endpoints). Ignored for plain `http`.
     pub fn set_trust_all_cert(mut self, trust_all_cert: bool) -> Self {
-        self.trust_all_cert = trust_all_cert;
+        self.trust_all_cert = Some(trust_all_cert);
         self
     }
 
@@ -263,19 +330,78 @@ impl AsyncHttpRequest {
     }
 
     pub fn set_body(mut self, body: Value) -> Self {
-        self.body = body;
+        self.body = Some(body);
         self
     }
 
+    /// Set (or replace — Java `setQueryParameter` put semantics) a
+    /// single-value query parameter.
     pub fn set_query_parameter(mut self, key: &str, value: &str) -> Self {
+        self.query_parameters.retain(|(k, _)| k != key);
         self.query_parameters
             .push((key.to_string(), Value::from(value)));
+        self
+    }
+
+    /// Set a REPEATED query parameter (the list shape the REST edge produces
+    /// for `?q=a&q=b` — Java `setQueryParameter` with a List value).
+    pub fn set_query_parameter_values(mut self, key: &str, values: &[&str]) -> Self {
+        self.query_parameters.retain(|(k, _)| k != key);
+        self.query_parameters.push((
+            key.to_string(),
+            Value::Array(values.iter().map(|v| Value::from(*v)).collect()),
+        ));
         self
     }
 
     pub fn set_path_parameter(mut self, key: &str, value: &str) -> Self {
         self.path_parameters
             .push((key.to_string(), value.to_string()));
+        self
+    }
+
+    /// Set (or replace) a cookie (Java `setCookie`).
+    pub fn set_cookie(mut self, key: &str, value: &str) -> Self {
+        self.cookies.retain(|(k, _)| k != key);
+        self.cookies.push((key.to_string(), value.to_string()));
+        self
+    }
+
+    /// Set (or replace) a session-info entry (Java `setSessionInfo`) — on the
+    /// server side these arrive from the authentication service's verdict.
+    pub fn set_session_info(mut self, key: &str, value: &str) -> Self {
+        self.session.retain(|(k, _)| k != key);
+        self.session.push((key.to_string(), value.to_string()));
+        self
+    }
+
+    /// The caller's IP address (Java `setRemoteIp`) — the REST edge stamps it
+    /// on the request dataset.
+    pub fn set_remote_ip(mut self, ip: &str) -> Self {
+        self.ip = Some(ip.to_string());
+        self
+    }
+
+    /// Whether the original request arrived over HTTPS (Java `setSecure`).
+    pub fn set_secure(mut self, https: bool) -> Self {
+        self.https = Some(https);
+        self
+    }
+
+    /// The raw query string (Java `setQueryString`).
+    pub fn set_query_string(mut self, query: &str) -> Self {
+        self.query_string = Some(query.to_string());
+        self
+    }
+
+    /// The ROUTE timeout in seconds — the REST edge's `timeout` dataset key
+    /// (rest.yaml endpoint timeout). Distinct from [`set_timeout_seconds`],
+    /// which writes the caller's TTL as the `x-ttl` header (milliseconds,
+    /// Java `setTimeoutSeconds`); on read, `timeout_seconds()` prefers a
+    /// caller-sent x-ttl and falls back to this field — the ingress
+    /// precedence.
+    pub fn set_route_timeout_seconds(mut self, seconds: u64) -> Self {
+        self.timeout = Some(seconds);
         self
     }
 
@@ -299,7 +425,7 @@ impl AsyncHttpRequest {
     }
 
     pub fn trust_all_cert(&self) -> bool {
-        self.trust_all_cert
+        self.trust_all_cert.unwrap_or(false)
     }
 
     /// All request headers in insertion order.
@@ -322,7 +448,8 @@ impl AsyncHttpRequest {
     }
 
     pub fn body(&self) -> &Value {
-        &self.body
+        static NIL: Value = Value::Nil;
+        self.body.as_ref().unwrap_or(&NIL)
     }
 
     /// Java `AsyncHttpRequest.getTimeoutSeconds()`: the x-ttl header is in
@@ -333,7 +460,95 @@ impl AsyncHttpRequest {
         self.header("x-ttl")
             .and_then(|v| v.parse::<u64>().ok())
             .map(|ms| ms.max(1).div_ceil(1000))
+            // the REST edge also carries the route timeout as the dataset's
+            // "timeout" key (seconds); a caller-sent x-ttl wins, matching
+            // the ingress precedence
+            .or(self.timeout)
             .unwrap_or(DEFAULT_TTL_SECONDS)
+    }
+
+    /// Deserialize the request body into a typed value (Java
+    /// `AsyncHttpRequest.getBody(Class<T>)`).
+    pub fn body_as<T: serde::de::DeserializeOwned>(&self) -> Result<T, AppError> {
+        rmpv::ext::from_value(self.body().clone())
+            .map_err(|e| AppError::new(500, format!("unable to deserialize body: {e}")))
+    }
+
+    /// The caller's IP address (Java `AsyncHttpRequest.getRemoteIp`) — set
+    /// by the REST edge on the request dataset.
+    pub fn remote_ip(&self) -> Option<&str> {
+        self.ip.as_deref()
+    }
+
+    /// Whether the original request arrived over HTTPS (Java
+    /// `AsyncHttpRequest.isSecure`; the REST edge derives it from
+    /// `x-forwarded-proto`).
+    pub fn is_secure(&self) -> bool {
+        self.https.unwrap_or(false)
+    }
+
+    /// The raw query string (Java `AsyncHttpRequest.getQueryString`).
+    pub fn query_string(&self) -> Option<&str> {
+        self.query_string.as_deref()
+    }
+
+    /// One `{path}` parameter by name (Java `getPathParameter`).
+    pub fn path_parameter(&self, key: &str) -> Option<&str> {
+        self.path_parameters
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    /// All `{path}` parameters (Java `getPathParameters`).
+    pub fn path_parameters(&self) -> &[(String, String)] {
+        &self.path_parameters
+    }
+
+    /// One query parameter as text (Java `getQueryParameter`): a repeated
+    /// parameter (list value) yields its FIRST occurrence.
+    pub fn query_parameter(&self, key: &str) -> Option<String> {
+        self.query_parameters
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| match v {
+                Value::Array(values) => values.first().map(display_text).unwrap_or_default(),
+                other => display_text(other),
+            })
+    }
+
+    /// Every value of a query parameter (Java `getQueryParameters`): one
+    /// occurrence is a one-element list, repeats keep every value.
+    pub fn query_parameters(&self, key: &str) -> Vec<String> {
+        self.query_parameters
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| match v {
+                Value::Array(values) => values.iter().map(display_text).collect(),
+                other => vec![display_text(other)],
+            })
+            .unwrap_or_default()
+    }
+
+    /// One cookie by name (Java `getCookie`).
+    pub fn cookie(&self, key: &str) -> Option<&str> {
+        self.cookies
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    /// All cookies as parsed by the REST edge (Java `getCookies`).
+    pub fn cookies(&self) -> &[(String, String)] {
+        &self.cookies
+    }
+
+    /// One session-info entry by name (Java `getSessionInfo(String)`).
+    pub fn session_info(&self, key: &str) -> Option<&str> {
+        self.session
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
     }
 
     /// Java `getFinalizedUrl`: substitute `{path}` parameters, merge query
@@ -914,5 +1129,108 @@ impl crate::function::ComposableFunction for AsyncHttpClientService {
         // manual reply must reach THAT platform's temporary.inbox listener
         // (the global instance may live on another runtime in tests)
         handle(&self.platform, headers, input).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The server-side request dataset, FLUENT-BUILT (the maintainer's
+    /// requirement: the test setup creates a new AsyncHttpRequest and sets
+    /// every value through the fluent API — the test doubles as living
+    /// documentation of the builder surface, exercising every setter).
+    fn server_dataset_request() -> AsyncHttpRequest {
+        AsyncHttpRequest::new()
+            .set_method("POST")
+            .set_url("/api/typed/alice")
+            .set_remote_ip("127.0.0.1")
+            .set_secure(true)
+            .set_target_host("localhost:8085")
+            .set_header("accept", "application/json")
+            .set_header("x-api-key", "open-sesame")
+            .set_header("x-ttl", "5000")
+            .set_path_parameter("user", "alice")
+            .set_query_parameter_values("q", &["a", "b"])
+            .set_query_parameter("single", "1")
+            .set_query_string("q=a&q=b&single=1")
+            .set_route_timeout_seconds(30)
+            .set_cookie("first", "alpha")
+            .set_session_info("user_id", "u-1")
+            .set_body(Value::Map(vec![(
+                Value::from("note"),
+                Value::from("hello"),
+            )]))
+    }
+
+    /// Round-trip integrity of the typed contract: every fluent-set field is
+    /// visible through its accessor, survives to_value → from_value, and the
+    /// serde impls delegate to exactly that pair.
+    ///
+    /// Division of labor: this fluent-built round-trip proves INTERNAL
+    /// consistency (builder ↔ accessors ↔ map shape ↔ serde). The REAL
+    /// server-shape contract is pinned by the end-to-end test
+    /// `typed_async_http_request_function_serves_a_real_request` in
+    /// tests/rest_automation.rs (a typed function behind /api/typed/{user}
+    /// over the live automation server) — do not "simplify" that e2e away
+    /// in favor of this unit test.
+    #[test]
+    fn server_dataset_round_trips_through_the_typed_contract() {
+        let request = server_dataset_request();
+        // every field is visible through the typed accessors
+        assert_eq!(request.method(), "POST");
+        assert_eq!(request.url(), "/api/typed/alice");
+        assert_eq!(request.remote_ip(), Some("127.0.0.1"));
+        assert!(request.is_secure());
+        assert_eq!(request.target_host(), Some("localhost:8085"));
+        assert_eq!(request.path_parameter("user"), Some("alice"));
+        assert_eq!(request.query_parameter("single").as_deref(), Some("1"));
+        assert_eq!(request.query_parameter("q").as_deref(), Some("a"));
+        assert_eq!(request.query_parameters("q"), vec!["a", "b"]);
+        assert_eq!(request.query_parameters("single"), vec!["1"]);
+        assert_eq!(request.query_string(), Some("q=a&q=b&single=1"));
+        assert_eq!(
+            request.header("Accept"),
+            Some("application/json"),
+            "case-insensitive"
+        );
+        assert_eq!(request.cookie("first"), Some("alpha"));
+        assert_eq!(request.session_info("user_id"), Some("u-1"));
+        // caller-sent x-ttl (5000 ms -> 5 s) wins over the route timeout (30)
+        assert_eq!(request.timeout_seconds(), 5);
+        #[derive(serde::Deserialize)]
+        struct Note {
+            note: String,
+        }
+        assert_eq!(request.body_as::<Note>().expect("typed body").note, "hello");
+        // to_value emits what from_value parses: a second pass is identical
+        let round = AsyncHttpRequest::from_value(&request.to_value());
+        assert_eq!(round.to_value(), request.to_value());
+        // the serde impls are thin delegates onto the same pair
+        let deserialized: AsyncHttpRequest =
+            rmpv::ext::from_value(request.to_value()).expect("serde deserialize");
+        assert_eq!(deserialized.to_value(), request.to_value());
+        let serialized = rmpv::ext::to_value(&request).expect("serde serialize");
+        assert_eq!(
+            AsyncHttpRequest::from_value(&serialized).to_value(),
+            request.to_value()
+        );
+    }
+
+    /// The route timeout (`set_route_timeout_seconds` / the REST edge's
+    /// "timeout" dataset key) is the fallback when no x-ttl header rides
+    /// the request.
+    #[test]
+    fn route_timeout_is_the_fallback_without_x_ttl() {
+        let request = AsyncHttpRequest::new()
+            .set_method("GET")
+            .set_url("/x")
+            .set_route_timeout_seconds(30);
+        assert_eq!(request.timeout_seconds(), 30);
+        // and it round-trips through the map shape
+        assert_eq!(
+            AsyncHttpRequest::from_value(&request.to_value()).timeout_seconds(),
+            30
+        );
     }
 }

--- a/crates/platform-core/src/automation/server.rs
+++ b/crates/platform-core/src/automation/server.rs
@@ -449,38 +449,59 @@ async fn process(
             query.insert(name.clone(), serde_json::Value::String(value.clone()));
         }
     }
-    let body_value = match &parsed {
-        ParsedBody::Value(value) => value.clone(),
-        // a binary body can't ride the JSON shape — substituted as a
-        // MsgPack binary in build_event (Java: byte[] on AsyncHttpRequest)
-        ParsedBody::Form(_) | ParsedBody::Bytes(_) => serde_json::Value::Null,
-    };
-    let binary_body = match &parsed {
-        ParsedBody::Bytes(bytes) => Some(bytes.as_slice()),
-        _ => None,
-    };
-    let mut http_request = serde_json::json!({
-        "method": method,
-        "url": path,
-        "ip": peer.ip().to_string(),
+    // ONE definition of the wire shape: the dataset is constructed through
+    // AsyncHttpRequest's fluent API and rendered by its to_value() — the
+    // same builder/parser pair a typed function deserializes through, so
+    // server↔struct drift is impossible by construction (previously this
+    // was a hand-assembled JSON literal, which is exactly how the server
+    // came to emit keys from_value never parsed).
+    let mut http_request = crate::automation::AsyncHttpRequest::new()
+        .set_method(&method)
+        .set_url(&path)
+        .set_remote_ip(&peer.ip().to_string())
         // Java: setSecure(x-forwarded-proto == "https") — increment 56,
         // parity F14d (previously hardcoded false)
-        "https": headers.get("x-forwarded-proto").map(String::as_str) == Some("https"),
-        "host": headers.get("host").cloned().unwrap_or_default(),
-        "headers": headers,
-        "parameters": {"path": path_params, "query": query},
-        "body": body_value,
+        .set_secure(headers.get("x-forwarded-proto").map(String::as_str) == Some("https"))
+        .set_target_host(&headers.get("host").cloned().unwrap_or_default())
         // Java AsyncHttpRequest.getTimeoutSeconds (the flow adapter derives
         // the flow TTL from it)
-        "timeout": info.timeout.as_secs(),
-    });
+        .set_route_timeout_seconds(info.timeout.as_secs());
+    for (key, value) in &headers {
+        http_request = http_request.set_header(key, value);
+    }
+    for (key, value) in &path_params {
+        http_request = http_request.set_path_parameter(key, value);
+    }
+    for (key, value) in &query {
+        http_request = match value {
+            serde_json::Value::Array(values) => {
+                let values: Vec<&str> = values
+                    .iter()
+                    .map(|v| v.as_str().unwrap_or_default())
+                    .collect();
+                http_request.set_query_parameter_values(key, &values)
+            }
+            serde_json::Value::String(value) => http_request.set_query_parameter(key, value),
+            other => http_request.set_query_parameter(key, &other.to_string()),
+        };
+    }
+    // the request body: a JSON-shaped payload rides as-is; a binary body
+    // (unknown content type) rides as MsgPack binary (Java: byte[] on the
+    // AsyncHttpRequest); a form body already became query parameters, so
+    // the body key stays an explicit null — exactly the previous shape
+    http_request = match &parsed {
+        ParsedBody::Value(value) => http_request
+            .set_body(rmpv::ext::to_value(value).map_err(|e| AppError::new(500, e.to_string()))?),
+        ParsedBody::Bytes(bytes) => http_request.set_body(rmpv::Value::Binary(bytes.clone())),
+        ParsedBody::Form(_) => http_request.set_body(rmpv::Value::Nil),
+    };
     // the raw query string rides as Java's top-level "query" key; cookies
     // appear only when present (Java toMap omits empty)
     if !query_text.is_empty() {
-        http_request["query"] = serde_json::Value::String(query_text.clone());
+        http_request = http_request.set_query_string(&query_text);
     }
-    if !cookies.is_empty() {
-        http_request["cookies"] = serde_json::to_value(&cookies).unwrap_or_default();
+    for (key, value) in &cookies {
+        http_request = http_request.set_cookie(key, value);
     }
     let po = PostOffice::new(&state.platform);
     // Java appends the query string to the trace path (HttpRouter)
@@ -495,7 +516,6 @@ async fn process(
         let auth_event = build_event(
             auth_route,
             &http_request,
-            binary_body,
             &cid,
             &trace_id,
             &trace_path,
@@ -516,13 +536,8 @@ async fn process(
         // headers on the auth verdict become SESSION INFO that rides to the
         // target function as read-only headers (Java HttpRouter parity —
         // e.g. the event.api.auth demo injects `user: demo`)
-        if !verdict.headers().is_empty() {
-            let session: serde_json::Map<String, serde_json::Value> = verdict
-                .headers()
-                .iter()
-                .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
-                .collect();
-            http_request["session"] = serde_json::Value::Object(session);
+        for (key, value) in verdict.headers() {
+            http_request = http_request.set_session_info(key, value);
         }
     }
     // CALLBACK dispatch (Java HttpRouter parity): the endpoint service is
@@ -539,7 +554,6 @@ async fn process(
     let event = build_event(
         &info.service,
         &http_request,
-        binary_body,
         &cid,
         &trace_id,
         &trace_path,
@@ -651,8 +665,7 @@ async fn process(
 
 fn build_event(
     to: &str,
-    http_request: &serde_json::Value,
-    binary_body: Option<&[u8]>,
+    http_request: &crate::automation::AsyncHttpRequest,
     cid: &str,
     trace_id: &Option<String>,
     trace_path: &str,
@@ -667,22 +680,10 @@ fn build_event(
         // the HTTP context id, and the worker injects my_correlation_id into
         // the target function's input copy at delivery (Java parity)
         .add_tag(crate::post_office::BUSINESS_CID_TAG, cid)
-        .set_body(http_request)?;
-    // a binary body (unknown content type) rides as MsgPack binary — the
-    // JSON-shaped request map can't carry bytes (Java: byte[] on the
-    // AsyncHttpRequest), so it is substituted after the map conversion
-    if let Some(bytes) = binary_body {
-        let mut root = event.body().clone();
-        if let rmpv::Value::Map(entries) = &mut root {
-            for (key, value) in entries.iter_mut() {
-                if key.as_str() == Some("body") {
-                    *value = rmpv::Value::Binary(bytes.to_vec());
-                    break;
-                }
-            }
-        }
-        event = event.set_raw_body(root);
-    }
+        // the struct's to_value() IS the wire shape (single source of truth)
+        // — a binary body rides natively as MsgPack binary (Java: byte[] on
+        // the AsyncHttpRequest)
+        .set_raw_body(http_request.to_value());
     if let Some(trace_id) = trace_id {
         event = event.set_trace(trace_id, trace_path);
         if let Some(parent) = parent_span {
@@ -802,31 +803,11 @@ fn url_decode(text: &str) -> String {
 
 /// The built-in default endpoints (Java `default-rest.yaml`): added only when
 /// `rest.yaml` does not already claim the URL — user entries always win.
-/// `/info/lib` and `/info/routes` are deferred (see the actuator module doc).
-const DEFAULT_REST_YAML: &str = r#"
-rest:
-  - service: "event.api.service"
-    methods: ['POST']
-    url: "/api/event"
-    timeout: 60s
-    tracing: true
-  - service: "info.actuator.service"
-    methods: ['GET']
-    url: "/info"
-    timeout: 10s
-  - service: "env.actuator.service"
-    methods: ['GET']
-    url: "/env"
-    timeout: 10s
-  - service: "health.actuator.service"
-    methods: ['GET']
-    url: "/health"
-    timeout: 30s
-  - service: "liveness.actuator.service"
-    methods: ['GET']
-    url: "/livenessprobe"
-    timeout: 10s
-"#;
+/// Shipped as a real resource file embedded at compile time (the
+/// default-log-context.yaml pattern), so it is discoverable where a Java
+/// developer expects it and byte-diffable against the Java repo's copy.
+/// `/info/lib` is the one deferred Java default (see the actuator module doc).
+const DEFAULT_REST_YAML: &str = include_str!("../../resources/default-rest.yaml");
 
 fn merge_default_endpoints(table: &mut RoutingTable) -> Result<(), AppError> {
     let defaults = RoutingTable::from_yaml_text(DEFAULT_REST_YAML)?;
@@ -989,24 +970,26 @@ async fn run_static_filter(
     headers: &HashMap<String, String>,
     peer: SocketAddr,
 ) -> Result<EventEnvelope, AppError> {
-    let mut query: HashMap<String, String> = HashMap::new();
+    // the same single source of truth as the main dispatch: the filter's
+    // request dataset is constructed through AsyncHttpRequest and rendered
+    // by its to_value()
+    let mut request = crate::automation::AsyncHttpRequest::new()
+        .set_method("GET")
+        .set_url(path)
+        .set_remote_ip(&peer.ip().to_string())
+        .set_secure(false)
+        .set_target_host(&headers.get("host").cloned().unwrap_or_default())
+        .set_body(rmpv::Value::Nil);
+    for (key, value) in headers {
+        request = request.set_header(key, value);
+    }
     for pair in query_text.split('&').filter(|p| !p.is_empty()) {
         let (name, value) = pair.split_once('=').unwrap_or((pair, ""));
-        query.insert(url_decode(name), url_decode(value));
+        request = request.set_query_parameter(&url_decode(name), &url_decode(value));
     }
-    let request = serde_json::json!({
-        "method": "GET",
-        "url": path,
-        "ip": peer.ip().to_string(),
-        "https": false,
-        "host": headers.get("host").cloned().unwrap_or_default(),
-        "headers": headers,
-        "parameters": {"path": {}, "query": query},
-        "body": serde_json::Value::Null,
-    });
     let event = EventEnvelope::new()
         .set_to(&filter.service)
-        .set_body(&request)?;
+        .set_raw_body(request.to_value());
     let po = PostOffice::new(&state.platform);
     // Java FILTER_TIMEOUT = 10 seconds
     po.request(event, std::time::Duration::from_secs(10)).await
@@ -1048,12 +1031,19 @@ fn render_payload(body: &rmpv::Value, content_type: Option<&str>) -> Bytes {
             // Omit Nil map entries unless serializer.null.transport=true (Java Gson parity).
             let stripped = crate::serializer::strip_nulls(body);
             let json = serde_json::to_value(&stripped).unwrap_or_default();
+            // PRETTY-printed (presentation parity, 2026-07-26): Java renders
+            // map/list bodies through SimpleMapper's default mapper, a
+            // pretty-printing Gson (2-space indent) — interop drives showed
+            // Java echoes multi-line and Rust echoes single-line. serde_json's
+            // pretty writer matches the Gson shape. The HTML shell wraps the
+            // same pretty text (Java AsyncHttpResponse HTML_START + text).
+            let text = serde_json::to_string_pretty(&json).unwrap_or_default();
             if content_type.is_some_and(|t| t.starts_with("text/html"))
                 && matches!(body, rmpv::Value::Map(_) | rmpv::Value::Array(_))
             {
-                Bytes::from(format!("<html><body><pre>\n{json}\n</pre></body></html>"))
+                Bytes::from(format!("<html><body><pre>\n{text}\n</pre></body></html>"))
             } else {
-                Bytes::from(json.to_string())
+                Bytes::from(text)
             }
         }
     }
@@ -1073,7 +1063,11 @@ fn envelope_payload(result: &EventEnvelope) -> (Option<&'static str>, Bytes) {
             // Omit Nil map entries unless serializer.null.transport=true (Java Gson parity).
             let body = crate::serializer::strip_nulls(result.body());
             let json = serde_json::to_value(&body).unwrap_or_default();
-            (Some("application/json"), Bytes::from(json.to_string()))
+            // pretty-printed like render_payload (Java SimpleMapper parity)
+            (
+                Some("application/json"),
+                Bytes::from(serde_json::to_string_pretty(&json).unwrap_or_default()),
+            )
         }
     }
 }

--- a/crates/platform-core/tests/actuator.rs
+++ b/crates/platform-core/tests/actuator.rs
@@ -68,6 +68,10 @@ fn setup_config() {
         let holding =
             std::env::temp_dir().join(format!("mercury-actuator-test-{}", std::process::id()));
         overrides::set("transient.data.store", &holding.display().to_string());
+        // the actuator-family ops knob, set BEFORE the config freezes: the
+        // /info/routes e2e asserts the overridden count — proving the knob
+        // live end-to-end through the very endpoint that displays it
+        overrides::set("worker.instances.actuator.services", "7");
         // a rest.yaml with one app endpoint; actuators come from the default merge
         let rest_file =
             std::env::temp_dir().join(format!("rest-actuator-{}.yaml", std::process::id()));
@@ -114,8 +118,16 @@ async fn server(healthy_dep: Option<bool>) -> (u16, Platform) {
     let platform = Platform::new();
     platform.register("noop.demo", Arc::new(Noop), 1).unwrap();
     let context = ActuatorContext::new(&platform);
+    // the same family-key resolution the lifecycle uses (default 5; the
+    // suite-wide override above tunes it to 7)
+    let instances =
+        platform_core::actuator::actuator_instances(platform_core::AppConfigReader::get_instance());
     for (route, kind) in [
         (platform_core::actuator::INFO_ACTUATOR, ActuatorKind::Info),
+        (
+            platform_core::actuator::ROUTES_ACTUATOR,
+            ActuatorKind::Routes,
+        ),
         (platform_core::actuator::ENV_ACTUATOR, ActuatorKind::Env),
         (
             platform_core::actuator::HEALTH_ACTUATOR,
@@ -130,7 +142,7 @@ async fn server(healthy_dep: Option<bool>) -> (u16, Platform) {
             .register(
                 route,
                 Arc::new(ActuatorServices::new(kind, context.clone())),
-                1,
+                instances,
             )
             .unwrap();
     }
@@ -174,12 +186,50 @@ static HEALTH_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 // ---- actuator endpoints (default merge puts them on the server) ----
 
+/// `/info/routes` (Java `handleInfoRoute`): the app block + the local
+/// routing table split by visibility, route → instance count, sorted for
+/// deterministic output. The port has no journal / route-substitution /
+/// mesh subsystems, so — with Java's omit-when-empty — the response is
+/// exactly {app, routing}.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn info_routes_reports_the_local_routing_table() {
+    let (port, _platform) = server(None).await;
+    let (status, headers, body) = http_get(port, "/info/routes").await;
+    assert_eq!(status, 200);
+    assert_eq!(headers["content-type"], "application/json");
+    // pretty-printed like every actuator (Java SimpleMapper parity)
+    assert!(
+        body.contains('\n'),
+        "/info/routes must render pretty-printed JSON"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(json["app"]["name"], "actuator-test", "the shared app block");
+    // a known PUBLIC route with its instance count (this test server
+    // registers noop.demo publicly with 1 instance)
+    assert_eq!(json["routing"]["public"]["noop.demo"], 1);
+    // the ops knob is LIVE end to end: the suite config overrides the
+    // actuator-family key (worker.instances.actuator.services=7, default 5)
+    // and the endpoint reports the tuned count for its whole family
+    assert_eq!(json["routing"]["public"]["routes.actuator.service"], 7);
+    assert_eq!(json["routing"]["public"]["info.actuator.service"], 7);
+    // a known PRIVATE route: the reserved RPC reply listener every platform
+    // carries (500 instances, temporary.inbox)
+    assert_eq!(json["routing"]["private"]["temporary.inbox"], 500);
+    // the port's optional blocks do not exist — Java's omit-when-empty
+    assert!(json.get("journal").is_none());
+    assert!(json.get("route_substitution").is_none());
+    assert!(json.get("network").is_none());
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn info_reports_app_identity_and_uptime() {
     let (port, _platform) = server(None).await;
     let (status, headers, body) = http_get(port, "/info").await;
     assert_eq!(status, 200);
     assert_eq!(headers["content-type"], "application/json");
+    // presentation parity: actuator JSON is PRETTY-printed, exactly like
+    // Java's actuators through the SimpleMapper default (multi-line output)
+    assert!(body.contains('\n'), "/info must render pretty-printed JSON");
     let json: serde_json::Value = serde_json::from_str(&body).unwrap();
     assert_eq!(json["app"]["name"], "actuator-test");
     assert_eq!(json["app"]["description"], "actuator test app");

--- a/crates/platform-core/tests/rest_automation.rs
+++ b/crates/platform-core/tests/rest_automation.rs
@@ -304,6 +304,41 @@ impl ComposableFunction for EchoChainCaller {
     }
 }
 
+/// A TYPED HTTP-facing function (`TypedFunction<AsyncHttpRequest, _>`): the
+/// REST edge's request dataset deserializes into `AsyncHttpRequest` through
+/// the ordinary typed adapter — no engine special case (the Java engine
+/// special-cases `AsyncHttpRequest.class` in `WorkerHandler.getMapBody`;
+/// here the knowledge lives on the type).
+struct TypedHttpProbe;
+
+#[async_trait]
+impl platform_core::TypedFunction<automation::AsyncHttpRequest, serde_json::Value>
+    for TypedHttpProbe
+{
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        request: automation::AsyncHttpRequest,
+        _instance: usize,
+    ) -> Result<serde_json::Value, AppError> {
+        #[derive(serde::Deserialize, Default)]
+        struct Note {
+            note: Option<String>,
+        }
+        Ok(serde_json::json!({
+            "method": request.method(),
+            "url": request.url(),
+            "user": request.path_parameter("user"),
+            "q": request.query_parameter("q"),
+            "q_all": request.query_parameters("q"),
+            "accept": request.header("Accept"),
+            "note": request.body_as::<Note>().unwrap_or_default().note,
+            "ip_present": request.remote_ip().is_some(),
+            "timeout": request.timeout_seconds(),
+        }))
+    }
+}
+
 const REST_YAML: &str = r#"
 rest:
   - service: "http.echo"
@@ -360,6 +395,10 @@ rest:
     methods: ['GET']
     url: "/api/echo/headers"
     timeout: 5s
+  - service: "typed.http.probe"
+    methods: ['POST']
+    url: "/api/typed/{user}"
+    timeout: 7s
   - service: "plain.text"
     methods: ['GET']
     url: "/api/text"
@@ -457,6 +496,13 @@ async fn server() -> TestServer {
         .unwrap();
     platform
         .register("trace.header.echo", Arc::new(TraceHeaderEcho), 1)
+        .unwrap();
+    platform
+        .register(
+            "typed.http.probe",
+            platform_core::TypedAdapter::arc(TypedHttpProbe),
+            1,
+        )
         .unwrap();
     platform
         .register(
@@ -1168,6 +1214,55 @@ async fn async_http_client_stamps_trace_context_under_both_names() {
         json["headers"]["x-trace-context"].as_str(),
         Some(stamped),
         "the same W3C value must be stamped under the custom traceparent header name"
+    );
+}
+
+/// End to end: a typed `AsyncHttpRequest` function behind a rest.yaml route
+/// receives a real HTTP request over the automation server and reads method,
+/// path parameter, query parameters (single + repeated), header, typed body
+/// and the server-side dataset keys through the typed accessors.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn typed_async_http_request_function_serves_a_real_request() {
+    let server = server().await;
+    let (status, _, body) = http(
+        server.port,
+        "POST",
+        "/api/typed/alice?q=a&q=b",
+        &[
+            ("Accept", "application/json"),
+            ("Content-Type", "application/json"),
+        ],
+        "{\"note\": \"hello\"}",
+    )
+    .await;
+    assert_eq!(status, 200, "typed probe body: {body}");
+    // presentation parity: JSON response bodies are PRETTY-printed, matching
+    // Java's SimpleMapper default rendering (interop drives read identically)
+    assert!(
+        body.contains('\n'),
+        "JSON responses must render pretty-printed"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(json["method"], "POST");
+    assert_eq!(json["url"], "/api/typed/alice");
+    assert_eq!(
+        json["user"], "alice",
+        "path parameter through the typed accessor"
+    );
+    assert_eq!(
+        json["q"], "a",
+        "single-value view of a repeated query parameter"
+    );
+    assert_eq!(json["q_all"], serde_json::json!(["a", "b"]));
+    assert_eq!(
+        json["accept"], "application/json",
+        "case-insensitive header"
+    );
+    assert_eq!(json["note"], "hello", "typed body deserialization");
+    assert_eq!(json["ip_present"], true, "server-side dataset key");
+    assert_eq!(
+        json["timeout"], 7,
+        "route timeout via the x-ttl/timeout contract"
     );
 }
 

--- a/docs/guides/actuators-and-http-client.md
+++ b/docs/guides/actuators-and-http-client.md
@@ -20,11 +20,24 @@ GET /livenessprobe
 ```
 
 !!! note "Rust port"
-    Two Java defaults are not ported: **`/info/lib`** (Java lists JAR dependencies from the
-    archive manifest — a Rust binary has no runtime dependency manifest) and **`/info/routes`**
-    (the route listing). XML actuator responses are also not supported — actuators answer in
-    JSON. **`POST /api/event` (Event over HTTP) IS ported** (increment 61) and ships in the
-    default rest.yaml — see [Event over HTTP](event-over-http.md).
+    One Java default is not ported: **`/info/lib`** (Java lists JAR dependencies from the
+    archive manifest — a Rust binary has no runtime dependency manifest). **`/info/routes`
+    IS ported**: the app block plus the local routing table split by visibility
+    (`routing.public` / `routing.private`, route → instance count, sorted); Java's optional
+    `journal` / `route_substitution` / mesh `network` blocks are omitted when empty, and
+    those subsystems do not exist here. XML actuator responses are not supported —
+    actuators answer in JSON. **`POST /api/event` (Event over HTTP) IS ported**
+    (increment 61) and ships in the default rest.yaml — see
+    [Event over HTTP](event-over-http.md).
+
+#### Tuning worker instances
+
+Each actuator route runs 5 worker instances by default — a **rule of thumb**, like every
+initial instance count in the platform. Operations teams fine-tune it with ONE family key,
+`worker.instances.actuator.services` (the same key the Java engine uses, so one runbook
+line covers both engines), typically in QA/Perf environments before promoting the number
+to production. `/info/routes` displays the effective counts, so the tuning loop is
+observable through the actuators themselves.
 
 #### `GET /info`
 

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -373,6 +373,21 @@ without failing it. Read by `crates/platform-core` (actuator).
 
 ## Performance and back-pressure
 
+#### `worker.instances.actuator.services`
+
+| Type | Default |
+|---|---|
+| int | `5` |
+
+Worker-instance count for the whole actuator family (`/info`, `/info/routes`, `/env`,
+`/health`, `/livenessprobe`). The default is a rule of thumb; operations teams fine-tune
+it in QA/Perf environments before promoting to production, and `/info/routes` displays the
+effective counts. The key name is shared with the Java engine (whose actuators are one
+aliased class keyed by its primary route `actuator.services` — that route itself is not
+ported), so one runbook line tunes both engines. A non-numeric value falls back to the
+default (`env_instances` semantics). Read by `crates/platform-core` at boot.
+
+
 #### `worker.instances.no.op`
 
 | Type | Default |

--- a/docs/guides/event-driven/write-your-first-function.md
+++ b/docs/guides/event-driven/write-your-first-function.md
@@ -58,32 +58,32 @@ impl TypedFunction<GreetingRequest, GreetingResponse> for Greetings {
 }
 ```
 
-**Untyped** — implement `ComposableFunction` to work directly with the raw `EventEnvelope`
-(useful for HTTP-facing functions, pass-through, and free-form payloads). This is the
-example's HTTP-facing function: it receives the request event from the REST edge, composes
-with the typed `greeting.demo` through the `PostOffice` (step 4 explains the call), and
-shapes the JSON response:
+**HTTP-facing** — an HTTP-facing function is a typed function too: its input type is
+`AsyncHttpRequest`, exactly like the Java guide's
+`TypedLambdaFunction<AsyncHttpRequest, Object>` pattern. The REST edge's request dataset
+deserializes straight into the model, so path/query parameters, headers, cookies and the
+typed body arrive through accessors instead of raw `Value` digging. This is the example's
+HTTP-facing function: it receives the request from the REST edge, composes with the typed
+`greeting.demo` through the `PostOffice` (step 4 explains the call), and shapes the JSON
+response:
 
 ```rust
 use std::time::Duration;
-use platform_core::{ComposableFunction, EventEnvelope, Platform, PostOffice};
+use platform_core::automation::AsyncHttpRequest;
+use platform_core::{EventEnvelope, Platform, PostOffice, TypedFunction};
 
-#[preload(route = "greeting.api", instances = 5)]
+#[preload(route = "greeting.api", instances = 5, typed)]
 struct GreetingApi;
 
 #[async_trait]
-impl ComposableFunction for GreetingApi {
+impl TypedFunction<AsyncHttpRequest, serde_json::Value> for GreetingApi {
     async fn handle_event(
         &self,
         _headers: HashMap<String, String>,
-        input: EventEnvelope,
+        request: AsyncHttpRequest,
         _instance: usize,
-    ) -> Result<EventEnvelope, AppError> {
-        let request: serde_json::Value = input.body_as()?;
-        let user = request["parameters"]["path"]["user"]
-            .as_str()
-            .unwrap_or("world")
-            .to_string();
+    ) -> Result<serde_json::Value, AppError> {
+        let user = request.path_parameter("user").unwrap_or("world").to_string();
         let po = PostOffice::new(&Platform::get_instance());
         let reply = po
             .request(
@@ -94,7 +94,7 @@ impl ComposableFunction for GreetingApi {
             )
             .await?;
         let body: GreetingResponse = reply.body_as()?;
-        EventEnvelope::new().set_body(serde_json::json!({
+        Ok(serde_json::json!({
             "message": body.message,
             "handled_by_instance": body.handled_by_instance,
             "trace_id": po.my_trace_id(),
@@ -103,6 +103,10 @@ impl ComposableFunction for GreetingApi {
     }
 }
 ```
+
+**Untyped** — implement `ComposableFunction` to work directly with the raw `EventEnvelope`
+(pass-through, free-form payloads, interceptors, or digging the request map by hand when
+you prefer it).
 
 In both forms, `handle_event` receives the event **headers** (`HashMap<String, String>`),
 the **input**, and the 1-based worker **instance** number. Returning `Err(AppError)` becomes
@@ -160,9 +164,11 @@ rest.server.port: 8085
 ```
 
 The HTTP edge delivers an `AsyncHttpRequest`-shaped event to your function: the body carries
-`method`, `url`, `ip`, `headers`, `parameters.path` / `parameters.query`, and `body` — which
-is how `GreetingApi` above reads its `{user}` path parameter
-(`request["parameters"]["path"]["user"]`).
+`method`, `url`, `ip`, `https`, `headers`, `parameters.path` / `parameters.query`, `body`,
+`timeout` and the raw `query` string. A typed function receives it AS an `AsyncHttpRequest`
+— which is how `GreetingApi` above reads its `{user}` path parameter
+(`request.path_parameter("user")`); an untyped function sees the same map on the raw
+envelope.
 
 ## 4. Call it from another function
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -73,18 +73,18 @@ rest:
 attribute; the runtime registers it at the route with a pool of worker instances:
 
 ```rust
-#[preload(route = "greeting.api", instances = 5)]
+#[preload(route = "greeting.api", instances = 5, typed)]
 struct GreetingApi;
 
 #[async_trait]
-impl ComposableFunction for GreetingApi {
+impl TypedFunction<AsyncHttpRequest, serde_json::Value> for GreetingApi {
     async fn handle_event(
         &self,
         _headers: HashMap<String, String>,
-        input: EventEnvelope,
+        request: AsyncHttpRequest,
         _instance: usize,
-    ) -> Result<EventEnvelope, AppError> {
-        // …
+    ) -> Result<serde_json::Value, AppError> {
+        // request.path_parameter("user"), request.header("accept"), …
     }
 }
 ```

--- a/docs/guides/macros-reference.md
+++ b/docs/guides/macros-reference.md
@@ -36,7 +36,10 @@ Registers a composable function at startup and binds it to a route — the Java
 | `is_private = false` | Opt into **public** visibility — callable from another application instance through Event over HTTP. Preloaded functions are **private by default**, exactly like Java `@PreLoad` (`isPrivate` defaults to `true`); private functions stay reachable by everything inside the instance (REST automation, flows, graphs) and are rejected only at the `/api/event` boundary. The programmatic pair is `platform.register_private(...)` — plain `register(...)` creates public functions (Java parity). |
 
 Without `typed`, the struct must implement `ComposableFunction` (raw `EventEnvelope` in and
-out). With `typed`, it implements `TypedFunction<I, O>` with your own `serde` types and the
+out). With `typed`, it implements `TypedFunction<I, O>` with your own `serde` types — and
+`I` may be **`AsyncHttpRequest`** for an HTTP-facing function (the REST edge's request
+dataset deserializes into the model; Java `TypedLambdaFunction<AsyncHttpRequest, Object>`
+parity, with the knowledge on the type instead of an engine special case) — and the
 platform bridges it with an adapter:
 
 ```rust

--- a/docs/guides/reserved-names-and-headers.md
+++ b/docs/guides/reserved-names-and-headers.md
@@ -11,8 +11,8 @@ this port actually registers.
     and service-mesh routes (`cloud.connector`, `presence.*`, `system.service.*`,
     `*.multiplex.*`), the scheduler (`cron.scheduler`, `run.scheduled.job`), the Kafka and
     sync-over-async extensions,
-    `actuator.services` / `lib.actuator.service` / `routes.actuator.service`
-    (`/info/lib` and `/info/routes` are deferred), and `http.auth.handler` — a rest.yaml
+    `actuator.services` / `lib.actuator.service` (`/info/lib` is deferred —
+    `routes.actuator.service` / `/info/routes` IS ported), and `http.auth.handler` — a rest.yaml
     `authentication` entry names your authentication function's route directly here (the
     simple route form; the tag-based auth router is not ported).
 
@@ -25,6 +25,7 @@ this port actually registers.
 | `distributed.tracing` | Telemetry sink — traced executions send their performance-metrics dataset here (a deliberate singleton: serializes trace-record processing to preserve ordering) |
 | `temporary.inbox` | Event listener for RPC — the ONE reserved reply route: every `PostOffice::request` reply resolves through it by correlation id (private, zero-tracing, 500 instances) |
 | `info.actuator.service` | `/info` actuator endpoint |
+| `routes.actuator.service` | `/info/routes` actuator endpoint (the local routing table by visibility) |
 | `env.actuator.service` | `/env` actuator endpoint |
 | `health.actuator.service` | `/health` actuator endpoint |
 | `liveness.actuator.service` | `/livenessprobe` actuator endpoint |

--- a/docs/guides/rest-automation.md
+++ b/docs/guides/rest-automation.md
@@ -300,9 +300,16 @@ same shape the Java engine uses:
 ```
 
 Header names arrive lowercase. Path and query parameter values are percent-decoded (`+`
-becomes a space). `timeout` is the endpoint's timeout in seconds. See
-[Write Your First Function](event-driven/write-your-first-function.md) for handling this event
-in Rust.
+becomes a space). `timeout` is the endpoint's timeout in seconds.
+
+The idiomatic way to consume it is a **typed function**: declare
+`#[preload(..., typed)]` + `impl TypedFunction<AsyncHttpRequest, O>` and the dataset
+deserializes into the request model — `request.path_parameter("user")`,
+`request.query_parameter("lang")`, `request.header("accept")`, `request.cookie(...)`,
+`request.body_as::<T>()` (Java `TypedLambdaFunction<AsyncHttpRequest, Object>` parity). An
+untyped `ComposableFunction` sees the same map on the raw envelope. See
+[Write Your First Function](event-driven/write-your-first-function.md) for the full
+example.
 
 ### Content-type dispatch — how the body is parsed
 

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -48,6 +48,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use platform_core::automation::AsyncHttpRequest;
 use platform_core::{
     before_application, main_application, preload, trace, AppConfigReader, AppError,
     ComposableFunction, EntryPoint, EventEnvelope, Platform, PostOffice, TypedFunction,
@@ -104,23 +105,26 @@ impl TypedFunction<GreetingRequest, GreetingResponse> for Greetings {
 
 // ---- the HTTP-facing function (REST automation: /api/greeting/{user}) ----
 
-/// Receives the AsyncHttpRequest event from the HTTP edge, then composes with
-/// the typed greeting.demo function — the edge-started trace propagates
-/// automatically, producing a two-span tree (greeting.api → greeting.demo).
-#[preload(route = "greeting.api", instances = 5)]
+/// Receives the HTTP request from the REST edge as a TYPED
+/// `AsyncHttpRequest` (Java `TypedLambdaFunction<AsyncHttpRequest, Object>`
+/// parity — here without any engine special case: `AsyncHttpRequest`
+/// deserializes from the request dataset, so the ordinary typed adapter
+/// carries it), then composes with the typed greeting.demo function — the
+/// edge-started trace propagates automatically, producing a two-span tree
+/// (greeting.api → greeting.demo).
+#[preload(route = "greeting.api", instances = 5, typed)]
 struct GreetingApi;
 
 #[async_trait]
-impl ComposableFunction for GreetingApi {
+impl TypedFunction<AsyncHttpRequest, serde_json::Value> for GreetingApi {
     async fn handle_event(
         &self,
         _headers: HashMap<String, String>,
-        input: EventEnvelope,
+        request: AsyncHttpRequest,
         _instance: usize,
-    ) -> Result<EventEnvelope, AppError> {
-        let request: serde_json::Value = input.body_as()?;
-        let user = request["parameters"]["path"]["user"]
-            .as_str()
+    ) -> Result<serde_json::Value, AppError> {
+        let user = request
+            .path_parameter("user")
             .unwrap_or("world")
             .to_string();
         let po = PostOffice::new(&Platform::get_instance());
@@ -136,7 +140,7 @@ impl ComposableFunction for GreetingApi {
             )
             .await?;
         let body: GreetingResponse = reply.body_as()?;
-        EventEnvelope::new().set_body(serde_json::json!({
+        Ok(serde_json::json!({
             "message": body.message,
             "handled_by_instance": body.handled_by_instance,
             "trace_id": po.my_trace_id(),
@@ -279,8 +283,17 @@ impl ComposableFunction for HelloPoJo {
 /// to continue (`true`) or reject with HTTP-401 (`false`). Additional headers
 /// on the envelope become **session info** that rides to the target function
 /// as read-only headers — the `user` header in this demo. Replace this
-/// function with your own OAuth 2.0 bearer-token validation for production.
-#[preload(route = "event.api.auth", instances = 10)]
+/// function with your own OAuth 2.0 bearer-token validation for production:
+/// a real deployment verifies the bearer token against an OAuth2 security
+/// authority — an I/O-bound call, hence the higher rule-of-thumb instance
+/// count (30) and the `worker.instances.event.api.auth` ops knob (the same
+/// key the Java demo uses), so operations teams can fine-tune concurrency in
+/// QA/Perf environments before promoting to production.
+#[preload(
+    route = "event.api.auth",
+    instances = 30,
+    env_instances = "worker.instances.event.api.auth"
+)]
 struct EventApiAuth;
 
 #[async_trait]
@@ -311,8 +324,15 @@ impl ComposableFunction for EventApiAuth {
 /// A simple interceptor for static content (`static-content.filter`): inspects
 /// the HTTP headers of matching requests and lets them through (status 200).
 /// A real deployment would handle SSO here — inspect the session cookie and
-/// return 302 + Location to the identity provider when absent.
-#[preload(route = "http.request.filter", instances = 2)]
+/// return 302 + Location to the identity provider when absent. The instance
+/// count (20) is a rule of thumb sized for a static-content front door;
+/// operations teams tune it via `worker.instances.http.request.filter` in
+/// QA/Perf environments before promoting to production.
+#[preload(
+    route = "http.request.filter",
+    instances = 20,
+    env_instances = "worker.instances.http.request.filter"
+)]
 struct HttpRequestFilter;
 
 #[async_trait]

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -15,7 +15,7 @@
 - **project:** mercury
 - **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.10.5**: tracks the canonical mercury-composable line (Java 4.10.5 in lock-step — one version, two languages; security patch: playground webapp on react-router 8.3.0, dependabot #16 remediated).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-26 | agent: Claude Code (2026-07-26-024639)
+- **last_session:** 2026-07-26 | agent: Claude Code (2026-07-26-233047)
 - **last_review:** 2026-07-26 | through 2026-07-26-022229.md
 - **last_invariant_check:** 2026-07-26 | 2026-07-26-014908.md (all five confirmed against live code; two header drifts remedied; ui-fixture carve-out RATIFIED by Eric 2026-07-26)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -143,6 +143,77 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
 
 > Mark completed items `- [x]` and leave them in place — the review sweeps them to
 > the archive once older than `archive_window` sessions. Don't archive them by hand.
+
+- [ ] (in flight — 2026-07-26; branch `feature/typed-async-http-request`, 1 commit, NOT
+  pushed — Eric gates) **Typed AsyncHttpRequest functions (Eric-ratified fix for the gap
+  report: the Rust port could not type a function's input as AsyncHttpRequest).** Design
+  agreed with Eric — idiomatic, NO engine special case: `Serialize`/`Deserialize`
+  hand-implemented as thin delegates onto the existing to_value()/from_value(&Value)
+  pair, so `#[preload(..., typed)]` + `TypedFunction<AsyncHttpRequest, O>` flows through
+  the ordinary TypedAdapter (`body_as::<I>`) — the knowledge lives on the type (Java, by
+  contrast, special-cases AsyncHttpRequest.class in WorkerHandler.getMapBody). Template
+  rule for Python/Node ports recorded in the impl comment: request classes constructible
+  from the request map make typed signatures just work. Server-dataset diff closed:
+  from_value/struct gained ip, https, timeout (route seconds; caller x-ttl wins in
+  timeout_seconds()), raw query string — to_value emits what from_value parses
+  (round-trip pinned). Accessor audit to Java parity: path_parameter(s),
+  query_parameter/query_parameters (single/list), cookie(s), session_info, remote_ip,
+  is_secure, query_string, body_as::<T>. hello-world GreetingApi rewritten typed
+  (path_parameter replaces Value digging; behavior identical — its e2e passed unchanged).
+  Regressions: unit round-trip incl. serde-delegate equivalence + e2e typed probe over
+  the real automation server (method/path/query single+list/header/typed body/ip/
+  timeout) + client side unchanged (set_raw_body path green). Docs:
+  write-your-first-function + getting-started + rest-automation show the typed form as
+  canonical (Java SimpleDemoEndpoint pattern), macros-reference typed flag mentions
+  AsyncHttpRequest, CHANGELOG Added #7 (also merged the accidental duplicate
+  `## Unreleased` sections from the P1/P2 rounds into one). **Eric's review round folded
+  in: (1) full fluent-builder symmetry (set_remote_ip/set_secure/set_query_string/
+  set_cookie/set_session_info/set_query_parameter_values +
+  set_route_timeout_seconds — named distinctly from set_timeout_seconds which stays the
+  Java x-ttl mapping; set_query_parameter gains Java put/replace semantics); (2) the
+  unit test fluent-built per Eric's verbatim requirement (no serde_json in setup;
+  division-of-labor comment: the unit round-trip = internal consistency, the e2e = THE
+  server-shape pin); (3) single source of truth: BOTH server dataset-assembly sites
+  (main dispatch + static-content filter) now construct through
+  AsyncHttpRequest::new()+fluent+to_value() — build_event takes the struct, the binary
+  body rides natively (substitution dance deleted), auth session via set_session_info;
+  struct went tri-state where the wire distinguishes set-vs-absent (body
+  Option<Value> for explicit null, https/trust_all_cert Option<bool>, parameters always
+  emitted) so to_value reproduces the server shape EXACTLY — the full suite passed with
+  ZERO test churn (272/272).** **Pretty-print parity folded in (Eric): every JSON response
+  the automation server writes renders PRETTY (serde_json to_string_pretty = Gson's
+  2-space shape) — one shared rule at both render sites (render_payload +
+  envelope_payload), covering function responses AND the /info//health//env actuators by
+  design (Java's actuators go through the same SimpleMapper default); the HTML <pre>
+  shell wraps the same pretty text; /api/event untouched (MsgPack Binary arm). Test churn:
+  NONE — no Rust test pinned compact JSON (the suite parses everywhere); two can't-regress
+  newline assertions added (typed e2e + /info).** **/info/routes actuator PORTED (Eric;
+  his manual typed+pretty test PASSED matching Java's shape): routes.actuator.service
+  (exact Java name) + the default rest.yaml entry (GET /info/routes, 10s); response =
+  {app, routing.public/private route→instances, BTreeMap-sorted for determinism} — Java's
+  optional journal/route_substitution/network blocks omit-when-empty and none of those
+  subsystems exist in the port; /info/lib stays deferred (no dependency manifest in a Rust
+  binary, Eric concurs). E2E: 200 + pretty + app block + noop.demo public/1 +
+  temporary.inbox private/500 + optional blocks absent. Addendum (Eric's review): the
+  inline DEFAULT_REST_YAML const relocated to a real resource file
+  crates/platform-core/resources/default-rest.yaml embedded via include_str! (the
+  default-log-context.yaml pattern — discoverable + byte-diffable vs the Java copy); the
+  const's stale "/info/routes deferred" doc line fixed. Zero churn from the relocation.**
+  **Ops-tunability round (Eric, the endpoint's first payoff): actuator family 1→5 workers
+  with ONE family knob worker.instances.actuator.services (SAME key as Java, whose
+  actuators are one aliased class keyed by actuator.services — unported route; resolver
+  actuator_instances() shared by lifecycle + tests); hello-world event.api.auth 10→30 +
+  worker.instances.event.api.auth (doc: real deployments verify bearer tokens against an
+  OAuth2 authority — I/O-bound, higher rule of thumb) and http.request.filter 2→20 +
+  worker.instances.http.request.filter. Rules of thumb by design — ops teams tune in
+  QA/Perf before production. Knob proven LIVE end-to-end: the actuator suite overrides
+  the family key to 7 and /info/routes reports 7 for the family. Docs: actuators tuning
+  note + configuration-reference family-key entry (demo keys skipped — the page documents
+  no example-app keys); CHANGELOG extended.** Gate: workspace 273 / clippy 0 / fmt.
+  Close when merged. Relates [[registration-metadata-contract]]
+  (capability matrix: inputPojoClass N/A because typed I subsumes it — this delivers the
+  HTTP-facing half of that story), [[port-bottom-up-faithful]].
+  <!-- id: thread-typed-async-http-request | created: 2026-07-26 | last_used: 2026-07-26 | uses: 1 | tier: working | origin: 2026-07-26-233047.md -->
 
 - [x] **Re-verify invariants (due — 40 sessions since the last check ≥ verify_invariants_every
   40).** Raised by the 2026-07-26 review (cadence); **VERIFIED 2026-07-26 against live code,

--- a/memory/sessions/2026-07-26-233047.md
+++ b/memory/sessions/2026-07-26-233047.md
@@ -1,0 +1,155 @@
+# Session (2026-07-26T23:30:47.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+Typed AsyncHttpRequest functions on branch `feature/typed-async-http-request`
+(1 commit, NOT pushed — Eric gates). Eric-ratified fix: Java types HTTP
+functions as TypedLambdaFunction<AsyncHttpRequest, Object> via an engine
+special case (WorkerHandler.getMapBody); the Rust port required
+EventEnvelope + raw Value digging. The agreed design is idiomatic — no
+engine special case.
+
+## What was built
+
+- **Serde delegates on AsyncHttpRequest**: Deserialize = Value::deserialize
+  → from_value(&Value); Serialize = to_value().serialize — so
+  #[preload(..., typed)] + TypedFunction<AsyncHttpRequest, O> flows through
+  the EXISTING TypedAdapter (body_as::<I>) with zero worker special-casing.
+  The template rule for Python/Node ports is in the impl comment: a request
+  class constructible from the request map makes typed signatures just work.
+- **Server-dataset diff (what it found)**: from_value parsed only the
+  client-side outbound contract; the REST edge additionally emits `ip`,
+  `https`, `timeout` (route seconds) and the raw `query` string (session was
+  already parsed; upload/stream metadata is unported). Struct + parser +
+  emitter extended; round-trip integrity pinned (to_value emits exactly what
+  from_value parses; serde impls verified equivalent to the pair).
+- **Accessor audit → Java parity (snake_case)**: added path_parameter /
+  path_parameters, query_parameter (single; first-of-list) /
+  query_parameters (every value), cookie / cookies, session_info(name),
+  remote_ip, is_secure, query_string, body_as::<T>. timeout_seconds() now
+  falls back to the dataset's route timeout when no x-ttl header rides
+  (caller-sent x-ttl wins — the ingress precedence).
+- **GreetingApi rewritten typed** (examples/hello-world): path_parameter
+  replaces the serde_json Value digging; trace annotation + downstream call
+  identical; the example's e2e passed unchanged — the living proof.
+- **Regressions**: unit round-trip on the exact server dataset shape (all
+  accessors + serde-delegate equivalence + x-ttl-beats-timeout) + route
+  timeout fallback; e2e — a typed function behind rest.yaml serves a real
+  HTTP request over the automation server (method, path param, single+list
+  query, case-insensitive header, typed body, ip, timeout); client side
+  unchanged (set_raw_body(to_value()) suites green; set_body(request) also
+  works now via Serialize).
+- **Docs**: write-your-first-function's HTTP-facing example is now the typed
+  AsyncHttpRequest form (canonical, mirroring Java's SimpleDemoEndpoint
+  pattern; untyped stays documented for raw-envelope cases);
+  getting-started concept snippet flipped; rest-automation "What your
+  function receives" gains the typed-consumption paragraph;
+  macros-reference typed flag mentions AsyncHttpRequest; CHANGELOG Added #7
+  crediting the gap report — and the accidental DUPLICATE `## Unreleased`
+  sections (a P2-round oversight) merged into one.
+
+## Gate
+
+Workspace 272 passed / 0 failed (269 + 2 unit + 1 e2e), clippy 0, fmt clean.
+
+## Memory References
+
+- created: `thread-typed-async-http-request` (born tier: working)
+- referenced: `registration-metadata-contract` (the capability matrix's
+  inputPojoClass N/A disposition — typed I subsumes it; this delivers the
+  HTTP-facing half), `port-bottom-up-faithful`, `conventions-rust-baseline`
+
+## Also: Eric's review round (same working session, amended into the commit)
+
+1. **Fluent-builder symmetry**: setters added for every from_value-parsed
+   field — set_remote_ip, set_secure, set_query_string, set_cookie,
+   set_session_info, set_query_parameter_values (the repeated ?q=a&q=b
+   shape), set_route_timeout_seconds (named distinctly from
+   set_timeout_seconds, which keeps Java's x-ttl-header mapping; read-side
+   precedence documented on both). set_query_parameter gained Java
+   put/replace semantics (was push — duplicate keys possible).
+2. **Unit tests rewritten fluently** per Eric's verbatim requirement: the
+   dataset is built with new() + every fluent setter (living documentation
+   of the builder), zero serde_json in the test; division-of-labor comment
+   added so the e2e server-shape pin is never "simplified" away.
+3. **Single source of truth (Eric's root-cause finding)**: the server
+   hand-assembled the dataset as JSON literals at TWO sites — exactly why
+   the wire could drift from from_value. Both sites (main dispatch,
+   static-content filter) now construct through the struct's fluent API;
+   build_event takes &AsyncHttpRequest and set_raw_body(to_value()); the
+   binary-body substitution dance is deleted (Binary rides natively); the
+   auth verdict's session becomes set_session_info calls. To reproduce the
+   exact wire shape the struct went tri-state where set-vs-absent matters:
+   body Option<Value> (explicit null for byte/form payloads), https +
+   trust_all_cert Option<bool> (host without trust flag on the server
+   dataset; explicit false preserved on the TLS relay path), parameters
+   always emitted with both sub-maps. **Referee verdict: the FULL suite
+   passed with ZERO test churn — 272/272, clippy 0, fmt clean** (rest
+   automation, event-over-http, hygiene, traceparent, conformance, flows,
+   graph — no emitted-shape diff anywhere).
+
+## Also: pretty-print presentation parity (same working session, amended in)
+
+Eric's touch-up: Java renders JSON response bodies through SimpleMapper's
+DEFAULT mapper — a pretty-printing Gson (2-space) — so Java echoes come back
+multi-line while Rust's were compact. One shared render rule now: both
+automation render sites (render_payload for the main dispatch incl. the
+actuators' default endpoints, envelope_payload for the filter pass-through)
+serialize with serde_json::to_string_pretty; the HTML <pre> shell wraps the
+same pretty text (Java AsyncHttpResponse HTML_START + pretty body); the
+/api/event path is untouched (MsgPack Binary arm, not rendered JSON).
+Actuators included BY DESIGN per Eric's clarification. Test churn: NONE —
+no Rust test asserted raw compact JSON (everything parses); two
+can't-regress assertions added (the typed e2e's body and /info must contain
+a newline). Content-length already derives from rendered bytes. Gate
+unchanged: 272 / clippy 0 / fmt.
+
+## Also: /info/routes actuator (same working session, amended in)
+
+Eric's next item (his manual typed-endpoint + pretty-print test PASSED,
+output matching Java): the deferred /info/routes actuator is PORTED —
+`routes.actuator.service` (exact Java constant) as a fifth ActuatorKind,
+registered alongside /info//env//health//livenessprobe, mapped by the
+default rest.yaml (GET /info/routes, 10s, Eric's exact spec). Response
+shape: {app, routing} — routing.public/routing.private as route → instance
+count from the live Platform table, BTreeMap-sorted for deterministic
+output (Java's HashMap order is arbitrary; noted). Java's optional blocks
+(journal, route_substitution, mesh network) omit-when-empty and none of
+those subsystems exist in this port, so they are simply never emitted;
+/info/lib stays deferred (no runtime dependency manifest in a Rust binary —
+Eric concurs). E2E: 200, pretty (newline pin), app block, noop.demo
+public/1, temporary.inbox private/500, all three optional blocks absent.
+Docs: actuator module doc, actuators-and-http-client Rust-port note
+(only /info/lib deferred now), reserved-names (unported list corrected +
+actuator table row), CHANGELOG Added #8.
+
+Addendum from Eric's review: the inline DEFAULT_REST_YAML const is now a
+real resource file crates/platform-core/resources/default-rest.yaml
+embedded via include_str! (the default-log-context.yaml pattern) —
+discoverable where a Java developer expects it and byte-diffable against
+the Java repo's default-rest.yaml; the const's stale "/info/routes
+deferred" doc line fixed in the same stroke. Zero churn from the
+relocation. Gate: workspace 273 (272+1) / clippy 0 / fmt clean.
+
+## Also: ops-tunability round (same working session, amended in)
+
+Eric's /info/routes review — the endpoint's first payoff. Verbatim intent:
+initial instance counts are rules of thumb; operations teams must be able to
+fine-tune in QA/Perf before promoting to production. Adjustments: all five
+actuator services 1→5 via ONE family knob `worker.instances.actuator.services`
+(the SAME key the Java engine carries — its actuators are one aliased class
+whose primary route actuator.services is unported here; one runbook line, both
+engines) resolved by a shared `actuator_instances()` helper (env_instances
+semantics: numeric wins, else fallback); hello-world `event.api.auth` 10→30 +
+`worker.instances.event.api.auth` (doc comment now states the real-world
+shape: bearer-token verification against an OAuth2 security authority —
+I/O-bound, hence the higher rule of thumb) and `http.request.filter` 2→20 +
+`worker.instances.http.request.filter`. The knob is proven LIVE end to end:
+the actuator suite sets the family key to 7 before the config freezes and the
+/info/routes e2e asserts the endpoint reports 7 for the family — the tuning
+loop observable through the very endpoint that displays it. Docs: actuators
+"Tuning worker instances" note + configuration-reference family-key entry
+(the demo keys are not documented there — the page carries no example-app
+keys); CHANGELOG Added #8 extended. Gate: 273 / clippy 0 / fmt.


### PR DESCRIPTION
## What

- **Typed `AsyncHttpRequest` function input.** `AsyncHttpRequest` gains `Serialize`/`Deserialize`
  (thin delegates over its canonical `to_value()`/`from_value()` mapping) so a typed function can
  declare the HTTP request contract directly — `TypedFunction<AsyncHttpRequest, …>` — matching
  Java's `TypedLambdaFunction<AsyncHttpRequest, Object>`. The struct also gains the complete
  fluent setter surface (remote IP, HTTPS flags, query string, cookies, session info, route
  timeout), and hello-world's `greeting.api` is rewritten as the typed reference demo.
- **Single-source request dataset.** `HttpRouter` now builds the inbound request dataset through
  the same struct and fluent API that functions consume — both server sites — so the dataset keys
  have exactly one definition and drift is structurally impossible.
- **Pretty-printed JSON responses.** `async.http.response` renders JSON with pretty print
  (Java `SimpleMapper` parity), actuator endpoints included by design; the `/api/event` MsgPack
  leg is unaffected.
- **`/info/routes` actuator ported** (`routes.actuator.service`, GET, 10s, part of the embedded
  defaults): the shared `app` block plus the live routing table split by visibility
  (`routing.public` / `routing.private`, route → instance count, deterministically sorted).
  Java's optional `journal` / `route_substitution` / mesh `network` blocks belong to unported
  subsystems and are omitted-when-empty by the same semantics. `/info/lib` is now the only
  deferred default (a Rust binary has no dependency manifest).
- **`default-rest.yaml` is a real resource file** — relocated from an inline constant to
  `crates/platform-core/resources/default-rest.yaml`, embedded via `include_str!` (the
  `default-log-context.yaml` pattern): discoverable where a Java developer expects it and
  byte-diffable against the Java repo's copy. Merge semantics unchanged — an application
  `rest.yaml` entry always wins over a default.
- **Ops-tunable worker instances.** Actuator family 1 → 5, sharing ONE knob —
  `worker.instances.actuator.services`, the same key name as the Java engine; hello-world
  `event.api.auth` 10 → 30 (+ `worker.instances.event.api.auth`) and `http.request.filter`
  2 → 20 (+ `worker.instances.http.request.filter`). The e2e proves the loop live: it sets the
  family key and asserts `/info/routes` reports the overridden count — the tuning observable
  through the very endpoint that displays it.
- Docs: actuators guide (response shape + "Tuning worker instances"), configuration-reference,
  reserved-names, rest-automation, getting-started/first-function; CHANGELOG.

## Why

The Rust port previously forced every HTTP-facing function to take a raw `EventEnvelope` and
hand-extract the request shape — the port was missing Java's automatic object-mapping feature at
the function boundary. Closing that gap cascaded into architecture: once the struct is the typed
contract, the router should *produce* it (single source of truth), the output should present like
the reference engine (operators read both engines' JSON in one aggregation), and the registration
story should be inspectable — `/info/routes` gives DevOps the live routing table with zero setup.

The counts that endpoint revealed became the final item: declared instance counts are rules of
thumb, and operations teams tune them in QA and Perf environments before promoting to Production.
A real `event.api.auth` verifies bearer tokens against an OAuth2 security authority — I/O-bound
work that deserves both a higher default and a knob, on both engines, under the same key name.

Workspace gate: 273 tests green, clippy 0 warnings, fmt clean. Verified live: typed
`greeting.api`, pretty `/info`, and `/info/routes` reporting the full routing table.

Co-Authored-By: Claude Code <noreply@anthropic.com>