### PR TITLE
chore: release 4.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,16 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
-## Unreleased
+## Version 4.10.6, 7/26/2026
+
+Feature release. Version number re-aligned with the Java repo's 4.10.6 (whose contents —
+a Sonar-remediation patch — differ by design). Two arcs: the **annotation→macro
+consistency P2 leftovers already on main** (yaml.preload.override, the
+registration-metadata contract with golden conformance vectors, Unicode-scalar string
+plugins) and the **typed-AsyncHttpRequest arc** (typed HTTP functions with no engine
+special case, the single-source request dataset, pretty-printed JSON responses, the
+/info/routes actuator with ops-tunable worker instances) — merged as PR #183 after six
+review rounds on one commit.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.10.5"
+version = "4.10.6"
 dependencies = [
  "async-trait",
  "log",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "event-script"
-version = "4.10.5"
+version = "4.10.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "event-script-macros"
-version = "4.10.5"
+version = "4.10.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -374,7 +374,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.10.5"
+version = "4.10.6"
 dependencies = [
  "async-trait",
  "event-script",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.10.5"
+version = "4.10.6"
 dependencies = [
  "async-trait",
  "log",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph"
-version = "4.10.5"
+version = "4.10.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph-macros"
-version = "4.10.5"
+version = "4.10.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -587,7 +587,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minigraph-playground"
-version = "4.10.5"
+version = "4.10.6"
 dependencies = [
  "async-trait",
  "event-script",
@@ -692,7 +692,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "platform-core"
-version = "4.10.5"
+version = "4.10.6"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macros"
-version = "4.10.5"
+version = "4.10.6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.10.5"
+version = "4.10.6"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury-composable"

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -137,7 +137,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   2026-07-26: "ok with the tests/ui without license headers"): a header shifts every
   `.stderr` line and forces TRYBUILD regeneration; treated like Java's
   `src/test/resources` files. The ui RUNNERS (`tests/ui.rs`) do carry headers.
-  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-26 | uses: 94 | tier: active | origin: 2026-07-15-224707.md -->
+  <!-- id: conventions-rust-baseline | created: 2026-07-15 | last_used: 2026-07-27 | uses: 95 | tier: active | origin: 2026-07-15-224707.md -->
 
 ## Open Threads
 
@@ -233,7 +233,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Merged — CLOSED. Relates [[registration-metadata-contract]]
   (capability matrix: inputPojoClass N/A because typed I subsumes it — this delivers the
   HTTP-facing half of that story), [[port-bottom-up-faithful]].
-  <!-- id: thread-typed-async-http-request | created: 2026-07-26 | last_used: 2026-07-26 | uses: 1 | tier: working | origin: 2026-07-26-233047.md -->
+  <!-- id: thread-typed-async-http-request | created: 2026-07-26 | last_used: 2026-07-27 | uses: 2 | tier: active | origin: 2026-07-26-233047.md -->
 
 - [x] **Re-verify invariants (due — 40 sessions since the last check ≥ verify_invariants_every
   40).** Raised by the 2026-07-26 review (cadence); **VERIFIED 2026-07-26 against live code,
@@ -357,7 +357,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   (one unidentified single-test failure during the first post-bump compile-storm run; did
   not reproduce across 4 subsequent full runs incl. --no-fail-fast — noted for honesty).
   Tagged + published on both repos — CLOSED.
-  <!-- id: thread-release-4-10-5 | created: 2026-07-24 | last_used: 2026-07-24 | uses: 1 | tier: active | origin: 2026-07-24-191554.md -->
+  <!-- id: thread-release-4-10-5 | created: 2026-07-24 | last_used: 2026-07-24 | uses: 1 | tier: archive-candidate | origin: 2026-07-24-191554.md -->
 
 - [x] (release — 2026-07-24; CLOSED same day) **v4.10.4 SHIPPED AND PUBLISHED in lock-step
   (both repos) — tag `v4.10.4` on merge commit `03424582` (PR
@@ -374,7 +374,7 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   Cargo.toml only — members inherit; lock regenerated; continuity status line); CHANGELOG
   Unreleased → `## Version 4.10.4, 7/24/2026` + release summary. Gate: workspace 260 /
   clippy 0 / fmt. Tagged + published on both repos — CLOSED.
-  <!-- id: thread-release-4-10-4 | created: 2026-07-24 | last_used: 2026-07-24 | uses: 2 | tier: active | origin: 2026-07-24-183956.md -->
+  <!-- id: thread-release-4-10-4 | created: 2026-07-24 | last_used: 2026-07-24 | uses: 2 | tier: archive-candidate | origin: 2026-07-24-183956.md -->
 
 - [x] (in flight — 2026-07-24; RELEASED same day in v4.10.4, [[thread-release-4-10-4]])
   **Interop header-hygiene round, mirrored from the Java reference branch of the same

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -13,9 +13,9 @@
 ## Project State
 
 - **project:** mercury
-- **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.10.5**: tracks the canonical mercury-composable line (Java 4.10.5 in lock-step — one version, two languages; security patch: playground webapp on react-router 8.3.0, dependabot #16 remediated).
+- **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), same vision, delivered bottom-up. **All three in-scope layers are ported and milestone-closed** — platform-core (2026-07-16; benchmarked: RPC 155K ops/s @ 6µs, ~8.4× the Java record), event-script (2026-07-17; full engine validated on the canonical Java fixtures), active knowledge graph + Playground webapp (2026-07-18). Kafka service mesh + Spring out of scope. 49 increments — ledger: `docs/INCREMENTS.md`; designs: `docs/design/`; AI-companion validation sweep COMPLETE (all 13 tutorials passed, 2026-07-19; AI grammar self-sufficient — 10 consecutive zero-lookup first-attempt passes incl. two post-sweep drives). Companion surface byte-identical in both ports (Java upstream PRs #188–#199 merged). Human docs site COMPLETE (MkDocs, 20 pages, published via gh-deploy). **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs live at accenture.github.io/mercury; Rust CI gates in place) — regular PR process from here on. **Version 4.10.6**: re-aligned with the Java repo's version number (its 4.10.6 was the Sonar-remediation patch — contents differ by design, Eric's call); this release = the typed-AsyncHttpRequest arc (typed HTTP functions, single-source dataset, pretty-print parity, /info/routes, ops-tunable worker instances).
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-26 | agent: Claude Code (2026-07-26-233047)
+- **last_session:** 2026-07-27 | agent: Claude Code (2026-07-27-011116)
 - **last_review:** 2026-07-26 | through 2026-07-26-022229.md
 - **last_invariant_check:** 2026-07-26 | 2026-07-26-014908.md (all five confirmed against live code; two header drifts remedied; ui-fixture carve-out RATIFIED by Eric 2026-07-26)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -143,6 +143,20 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
 
 > Mark completed items `- [x]` and leave them in place — the review sweeps them to
 > the archive once older than `archive_window` sessions. Don't archive them by hand.
+
+- [ ] (release in flight — 2026-07-27; branch `chore/release-4.10.6`, 1 commit, pushed —
+  Eric creates the PR via web UI and merges; tag goes on the MERGE commit after merge,
+  verified before pushing per the 4.10.2 tag-race lesson) **v4.10.6 release prep — feature
+  release re-aligning the version number with the Java repo (its 4.10.6 = the Sonar
+  patch; contents differ by design, Eric's ruling).** Contents: the annotation→macro P2
+  leftovers already on main (yaml.preload.override, registration-metadata contract +
+  golden vectors, Unicode-scalar string plugins) + the typed-AsyncHttpRequest arc
+  (PR #183: typed HTTP functions, single-source dataset, pretty-print parity,
+  /info/routes, ops-tunable worker instances). Sweep 4.10.5→4.10.6 (root Cargo.toml —
+  count-asserted, no substring hazards; lock regenerated; continuity status line);
+  CHANGELOG Unreleased → `## Version 4.10.6, 7/26/2026` + release summary. Gate:
+  workspace 273 / clippy 0 / fmt. Close when tagged + published.
+  <!-- id: thread-release-4-10-6 | created: 2026-07-27 | last_used: 2026-07-27 | uses: 1 | tier: working | origin: 2026-07-27-011116.md -->
 
 - [x] (2026-07-26; **MERGED same day as PR
   [#183](https://github.com/Accenture/mercury/pull/183), merge commit `1c8fa91b` — the arc

--- a/memory/sessions/2026-07-27-011116.md
+++ b/memory/sessions/2026-07-27-011116.md
@@ -1,0 +1,33 @@
+# Session (2026-07-27T01:11:16.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+v4.10.6 release prep on branch `chore/release-4.10.6` (Eric's ruling: enough
+feature progression to promote a release; the version number re-aligns with
+the Java repo, whose 4.10.6 was the Sonar-remediation patch — contents
+differ by design). Branch cut from main AFTER the PR #183 merge + closeout.
+
+## What was done
+
+- **Sweep 4.10.5 → 4.10.6**: root `Cargo.toml` `[workspace.package] version`
+  (the only Cargo version surface, count-asserted exact match — no
+  dependency-version substring hazards); `Cargo.lock` regenerated (10 member
+  entries); continuity status line advanced with the re-alignment note.
+- **CHANGELOG**: `## Unreleased` → `## Version 4.10.6, 7/26/2026` with a
+  release summary; the arc's entries kept (typed AsyncHttpRequest,
+  single-source dataset, pretty-print parity, /info/routes +
+  default-rest.yaml resource, ops-tunable worker instances, plus the P2
+  leftovers: yaml.preload.override, the registration-metadata contract +
+  vectors, Unicode-scalar string plugins).
+- **Gate on the bumped version**: workspace 273 passed / 0 failed, clippy 0,
+  fmt clean.
+- Tag NOT pushed — it goes on the merge commit after Eric merges, verified
+  first (the 4.10.2 tag-race lesson).
+
+## Memory References
+
+- created: `thread-release-4-10-6` (born tier: working)
+- referenced: `thread-typed-async-http-request` (the release's main content),
+  `conventions-rust-baseline`


### PR DESCRIPTION
## What

Version bump 4.10.5 → 4.10.6 (root `Cargo.toml` + `Cargo.lock`, 10 member entries) and the
CHANGELOG dated as Version 4.10.6, 7/26/2026, consolidating the merged typed-AsyncHttpRequest
arc (#183): typed HTTP request input, single-source request dataset, pretty-printed JSON
responses, the `/info/routes` actuator, `default-rest.yaml` as a real resource file, and
ops-tunable worker instances.

## Why

The feature progression since 4.10.5 warrants a release. The version number re-aligns with
the Java repository — its v4.10.6 was a SonarQube-remediation patch; the two releases share
the number, not the content, by design. Gate on the bumped version: workspace 273 tests,
clippy 0 warnings, fmt clean.

Co-Authored-By: Claude Code <noreply@anthropic.com>