### PR TITLE
ManagedCache — the self-expiring in-memory cache (increment 71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,42 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
+## Unreleased
+
+### Added
+
+1. **`ManagedCache`** — the Java `org.platformlambda.core.util.ManagedCache` ported
+   (`platform_core::ManagedCache` / `CacheValue`; design record
+   `docs/design/managed-cache-port.md`, maintainer-gated): a named, self-expiring
+   (expire-after-write, 1 s floor), size-bounded (default 2000) in-memory cache with a
+   process-wide registry and a lifecycle-wired 10-minute housekeeper. Engine: moka
+   (Caffeine's Rust lineage), wrapped as an internal detail and built with
+   **deterministic LRU eviction** (`EvictionPolicy::lru`, maintainer ruling) — a
+   documented divergence from Java Caffeine's approximate W-TinyLFU (which also carries
+   deliberate HashDoS randomness; a refactoring note was handed to the Java team).
+   Java's `SimpleCache` is deliberately NOT ported: one cache type — any Java
+   `SimpleCache` site maps onto a `ManagedCache` instance.
+2. **`/health` per-dependency info cache** (Java parity, previously deferred): the
+   `type=info` lookup is now cached 5 s per dependency (`health.info`, map bodies only —
+   Java `isServiceUnhealthy` semantics); `type=health` still runs on every probe and the
+   `/health` result itself is never cached.
+
+### Fixed
+
+1. **WS duplicate-command suppression window is now ANCHORED like Java's** (knowledge
+   graph): the previous stand-in re-put on every duplicate — a sliding window under
+   which a continuous duplicate stream never let a command through; migrated to the Java
+   `last.ws.message` 1 s `ManagedCache` (no re-put on duplicate, one command per ~1 s,
+   Java's `Duplicated message` debug log — emitted once, at the comparison, like Java),
+   and the dedup memory is now bounded and self-expiring (entries previously survived
+   session close forever).
+2. **`/info` `up_time` renders exactly like Java's `Utility.elapsedTime`**: zero
+   components are omitted ("2 minutes", not "2 minutes 0 seconds"), Java's strict
+   boundary quirks are kept (exactly 1 minute → "60 seconds"), and a sub-second value
+   renders "N ms". The same shared formatter renders the `ManagedCache` create log, so
+   that new Java-parity log line is exact from day one.
+
+---
 ## Version 4.10.6, 7/26/2026
 
 Feature release. Version number re-aligned with the Java repo's 4.10.6 (whose contents —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,6 +592,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +638,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -655,6 +699,29 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "pem"
@@ -703,6 +770,7 @@ dependencies = [
  "hyper-util",
  "inventory",
  "log",
+ "moka",
  "platform-macros",
  "rcgen",
  "rmp-serde",
@@ -728,6 +796,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "powerfmt"
@@ -809,6 +883,15 @@ dependencies = [
  "rustls-pki-types",
  "time",
  "yasna",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -951,6 +1034,12 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -1182,6 +1271,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "target-triple"

--- a/crates/event-script/tests/flow_runtime.rs
+++ b/crates/event-script/tests/flow_runtime.rs
@@ -31,7 +31,7 @@ use event_script::conversions::from_json;
 use event_script::FlowExecutor;
 use platform_core::{
     main_application, preload, trace, AppError, AutoStart, ComposableFunction, EntryPoint,
-    EventEnvelope, Platform, PostOffice,
+    EventEnvelope, ManagedCache, Platform, PostOffice,
 };
 use rmpv::Value;
 
@@ -290,13 +290,30 @@ impl ComposableFunction for AbortRequest {
 /// Java `ExternalStateMachine` (`v1.ext.state.machine`): a trace-scoped
 /// key-value store honoring the ext-state-machine contract — headers
 /// `type` (put/get/remove) + `key`, body `{data}`; the `append` key appends
-/// to a list.
-#[preload(route = "v1.ext.state.machine", instances = 4)]
+/// to a list. A SINGLETON like the Java fixture (`@PreLoad` default
+/// instances=1 — its class doc: the singleton "would guarantee orderly
+/// execution of incoming requests"): serialized execution is the correctness
+/// precondition for the get→mutate→put pattern below — with multiple workers
+/// two concurrent first puts for one trace would each create their own map
+/// and the last re-put would drop the other's write.
+#[preload(route = "v1.ext.state.machine", instances = 1)]
 struct ExternalStateMachine;
 
-static EXT_STORE: std::sync::OnceLock<
-    std::sync::Mutex<HashMap<String, serde_json::Map<String, serde_json::Value>>>,
-> = std::sync::OnceLock::new();
+/// Java parity (increment 71): the Java fixture backs this store with
+/// `ManagedCache.createCache("state.machine", 10000)` — its comment:
+/// "ManagedCache with automatic expiry is used so that memory will be
+/// released" — where the previous Rust stand-in was an unbounded
+/// `OnceLock<Mutex<HashMap>>` whose per-trace entries were never evicted.
+/// Values are `Mutex<serde_json::Map>` handles: the `Arc` reference
+/// semantics mirror Java mutating the cached map in place; a PUT re-puts the
+/// same handle, refreshing the 10 s expire-after-write window exactly like
+/// the Java `store.put(traceId, map)`.
+type TraceState = std::sync::Mutex<serde_json::Map<String, serde_json::Value>>;
+
+fn ext_store() -> &'static std::sync::Arc<ManagedCache> {
+    static STORE: std::sync::OnceLock<std::sync::Arc<ManagedCache>> = std::sync::OnceLock::new();
+    STORE.get_or_init(|| ManagedCache::create_cache("state.machine", 10000))
+}
 
 #[async_trait]
 impl ComposableFunction for ExternalStateMachine {
@@ -310,36 +327,55 @@ impl ComposableFunction for ExternalStateMachine {
         let trace_id = po.my_trace_id().ok_or_else(|| {
             AppError::new(400, "Tracing must be enabled for external state machine")
         })?;
-        let store = EXT_STORE.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
+        let store = ext_store();
         let body: serde_json::Value = input.body_as().unwrap_or(serde_json::Value::Null);
         let action = headers.get("type").map(String::as_str).unwrap_or("");
         let key = headers.get("key").map(String::as_str).unwrap_or("*");
-        let mut guard = store.lock().expect("ext store");
-        let map = guard.entry(trace_id).or_default();
         match action {
             "put" if key != "*" => {
                 let data = body["data"].clone();
-                if key == "append" {
-                    let list = map
-                        .entry("append")
-                        .or_insert_with(|| serde_json::Value::Array(Vec::new()));
-                    if let serde_json::Value::Array(items) = list {
-                        items.push(data);
+                let state = store.get_as::<TraceState>(&trace_id).unwrap_or_else(|| {
+                    std::sync::Arc::new(std::sync::Mutex::new(serde_json::Map::new()))
+                });
+                {
+                    let mut map = state.lock().expect("ext store");
+                    if key == "append" {
+                        let list = map
+                            .entry("append")
+                            .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+                        if let serde_json::Value::Array(items) = list {
+                            items.push(data);
+                        }
+                    } else {
+                        map.insert(key.to_string(), data);
                     }
-                } else {
-                    map.insert(key.to_string(), data);
                 }
+                // Java parity: re-put refreshes the expire-after-write window
+                store.put_arc(&trace_id, state);
                 EventEnvelope::new().set_body(true)
             }
             "remove" if key != "*" => {
-                map.remove(key);
+                // Java mutates the cached map in place (no re-put) — the Arc
+                // handle gives the same reference semantics
+                if let Some(state) = store.get_as::<TraceState>(&trace_id) {
+                    state.lock().expect("ext store").remove(key);
+                }
                 EventEnvelope::new().set_body(true)
             }
             "get" => {
-                let value = if key == "*" {
-                    serde_json::Value::Object(map.clone())
-                } else {
-                    map.get(key).cloned().unwrap_or(serde_json::Value::Null)
+                let state = store.get_as::<TraceState>(&trace_id);
+                let value = match (&state, key) {
+                    (Some(s), "*") => {
+                        serde_json::Value::Object(s.lock().expect("ext store").clone())
+                    }
+                    (Some(s), k) => s
+                        .lock()
+                        .expect("ext store")
+                        .get(k)
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null),
+                    (None, "*") => serde_json::Value::Object(serde_json::Map::new()),
+                    (None, _) => serde_json::Value::Null,
                 };
                 Ok(EventEnvelope::new().set_raw_body(from_json(&value)))
             }

--- a/crates/knowledge-graph/src/commands.rs
+++ b/crates/knowledge-graph/src/commands.rs
@@ -26,7 +26,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock};
 
 use event_script::conversions::display;
 use event_script::converter;
@@ -34,7 +34,7 @@ use event_script::mapping::get_constant_value;
 use event_script::mlm::MultiLevelMap;
 use event_script::util::{split, str2int};
 use platform_core::graph::{MiniGraph, SimpleConnection, SimpleNode};
-use platform_core::{AppConfigReader, AppError, EventEnvelope, Platform, PostOffice};
+use platform_core::{AppConfigReader, AppError, EventEnvelope, ManagedCache, Platform, PostOffice};
 use rmpv::Value;
 
 use crate::common::{get_model_ttl, initialize_with_node_properties, invalid};
@@ -149,19 +149,29 @@ fn is_expired(entry: &std::fs::DirEntry, now: i64) -> bool {
     now - modified > EXPIRY_MS
 }
 
-/// Duplicate-command suppression (Java `ManagedCache("last.ws.message", 1000)`).
-fn last_message_cache() -> &'static Mutex<HashMap<String, (String, i64)>> {
-    static CACHE: OnceLock<Mutex<HashMap<String, (String, i64)>>> = OnceLock::new();
-    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+/// Duplicate-command suppression — the Java
+/// `ManagedCache.createCache("last.ws.message", 1000)` of
+/// `GraphCommandService`, same name + TTL (increment 71: the previous
+/// unbounded `Mutex<HashMap>` stand-in never evicted — the session-close arm
+/// cleans everything except it). The window is ANCHORED like Java's
+/// expire-after-write: a duplicate does NOT re-put, so one command passes per
+/// ~1 s even under a continuous duplicate stream (the old stand-in re-put on
+/// every duplicate — a sliding window that never let one through).
+fn last_message_cache() -> &'static Arc<ManagedCache> {
+    static CACHE: OnceLock<Arc<ManagedCache>> = OnceLock::new();
+    CACHE.get_or_init(|| ManagedCache::create_cache("last.ws.message", 1000))
 }
 
 fn is_duplicate(in_route: &str, command: &str) -> bool {
-    let now = session::now_ms();
-    let mut cache = last_message_cache().lock().expect("message cache");
-    let duplicate = matches!(cache.get(in_route),
-        Some((last, at)) if last == command && now - at < 1000);
-    cache.insert(in_route.to_string(), (command.to_string(), now));
-    duplicate
+    let cache = last_message_cache();
+    if let Some(last) = cache.get_as::<String>(in_route) {
+        if last.as_str() == command {
+            log::debug!("Duplicated message - {command} for {in_route}");
+            return true;
+        }
+    }
+    cache.put(in_route, command.to_string());
+    false
 }
 
 fn counter() -> u64 {
@@ -294,9 +304,10 @@ async fn handle_command(
         return single_or_multi_line(platform, po, command, in_route, out_route).await;
     }
     // the dedup guard protects the WS UI from double-submits; a synchronous
-    // companion RPC (`direct`) is a deliberate request — never dropped (#62)
+    // companion RPC (`direct`) is a deliberate request — never dropped (#62).
+    // The "Duplicated message" debug log lives INSIDE is_duplicate (Java
+    // parity — GraphCommandService logs once, at the comparison)
     if !direct && is_duplicate(in_route, command) {
-        log::debug!("Duplicated message - {command} for {in_route}");
         return Ok(());
     }
     let Some(me) = session::get_session(in_route) else {
@@ -2289,7 +2300,7 @@ pub fn download_graph(id: &str) -> Option<Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::{collect_path_tokens, convert_mapping_properties};
+    use super::{collect_path_tokens, convert_mapping_properties, is_duplicate};
     use event_script::mlm::MultiLevelMap;
     use rmpv::Value;
 
@@ -2388,5 +2399,32 @@ mod tests {
         assert!(convert_mapping_properties(&mut bad, Some("Dictionary")).is_err());
         let mut good = map_with("output", &["response.profile.name -> result.name"]);
         convert_mapping_properties(&mut good, Some("Dictionary")).expect("valid mapping ok");
+    }
+
+    #[test]
+    fn duplicate_window_is_anchored_not_sliding() {
+        // Java parity (increment 71): the "last.ws.message" window anchors on
+        // the LAST WRITE — a duplicate does NOT re-put, so a continuous
+        // duplicate stream still lets one command through per ~1 s. The old
+        // stand-in re-put on every duplicate (sliding window: the third send
+        // below would still be dropped, and a steady stream would never get
+        // through). Unique route: the cache is process-wide and unit tests
+        // run in parallel.
+        let route = "ws.anchored.window.test";
+        assert!(!is_duplicate(route, "draw"), "first command passes");
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        assert!(
+            is_duplicate(route, "draw"),
+            "duplicate within the 1 s window dropped"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(900));
+        // ~1.4 s after the ANCHOR write: the anchored window has expired even
+        // though a duplicate arrived mid-window; the sliding window re-put at
+        // ~0.5 s and would still drop this one
+        assert!(
+            !is_duplicate(route, "draw"),
+            "anchored: one command passes per ~1 s"
+        );
+        assert!(!is_duplicate(route, "erase"), "a different command passes");
     }
 }

--- a/crates/platform-core/Cargo.toml
+++ b/crates/platform-core/Cargo.toml
@@ -35,6 +35,9 @@ rustls-native-certs = "0.8"
 # --- increment 10: annotation macros (Java @PreLoad/@BeforeApplication/@MainApplication) ---
 inventory = "0.3"
 platform-macros = { path = "../platform-macros" }
+# --- increment 71: ManagedCache (docs/design/managed-cache-port.md — the Caffeine-lineage
+# engine, wrapped; EvictionPolicy::lru per the maintainer's deterministic-eviction ruling) ---
+moka = { version = "0.12", features = ["sync"] }
 
 [dev-dependencies]
 # compile-fail guards for the macro surfaces (tests/ui)

--- a/crates/platform-core/src/actuator.rs
+++ b/crates/platform-core/src/actuator.rs
@@ -43,11 +43,13 @@
 //! Deferred (maintainer-approved): `/info/lib` — Java lists JAR dependencies
 //! from the archive manifest; a Rust binary has no runtime dependency
 //! manifest (a build-script–embedded cargo metadata could provide it later).
-//! Also deferred: XML responses and the Java per-route info cache.
+//! Also deferred: XML responses. The Java per-route info cache is ported
+//! (increment 71): the `type=info` lookup is cached 5 s per dependency via
+//! `ManagedCache("health.info")` — see `check_services`.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -58,6 +60,8 @@ use crate::platform::Platform;
 use crate::post_office::PostOffice;
 use crate::trace;
 use crate::util::app_config_reader::AppConfigReader;
+use crate::util::elapsed_time;
+use crate::util::managed_cache::ManagedCache;
 
 pub const INFO_ACTUATOR: &str = "info.actuator.service";
 pub const ROUTES_ACTUATOR: &str = "routes.actuator.service";
@@ -301,9 +305,22 @@ impl ComposableFunction for ActuatorServices {
     }
 }
 
-/// Query each health-check function: header `type=info` (3 s) merges its info
-/// map into the dependency entry, then `type=health` (10 s) decides the
-/// status (non-200 = down). Returns whether every service in the list is up.
+/// The per-dependency info-lookup cache (Java parity:
+/// `SimpleCache.createCache("health.info", 5000)` in `ActuatorServices` —
+/// this port maps every Java `SimpleCache` site onto `ManagedCache`, per the
+/// maintainer's one-cache-type ruling; `docs/design/managed-cache-port.md`).
+/// Only the `type=info` lookup is cached — never the `/health` result: the
+/// `type=health` probe re-runs on every call and `/livenessprobe` reads the
+/// atomic health flag.
+fn health_info_cache() -> &'static Arc<ManagedCache> {
+    static CACHE: OnceLock<Arc<ManagedCache>> = OnceLock::new();
+    CACHE.get_or_init(|| ManagedCache::create_cache("health.info", 5000))
+}
+
+/// Query each health-check function: header `type=info` (3 s, cached 5 s per
+/// route — Java `isServiceUnhealthy`) merges its info map into the dependency
+/// entry, then `type=health` (10 s) decides the status (non-200 = down).
+/// Returns whether every service in the list is up.
 async fn check_services(
     po: &PostOffice,
     services: &[String],
@@ -315,14 +332,26 @@ async fn check_services(
         let mut entry = serde_json::Map::new();
         entry.insert("route".into(), serde_json::Value::String(route.clone()));
         entry.insert("required".into(), serde_json::Value::Bool(required));
-        // info is advisory — merge whatever the service reports about itself
-        let info_request = EventEnvelope::new()
-            .set_to(route)
-            .set_header("type", "info");
-        if let Ok(info) = po.request(info_request, Duration::from_secs(3)).await {
-            if let Ok(serde_json::Value::Object(map)) = info.body_as::<serde_json::Value>() {
+        // info is advisory — merge whatever the service reports about itself.
+        // Java parity: the lookup is cached under "info/{route}" and only a
+        // map body is cached (a non-map response is re-requested every call)
+        let cache = health_info_cache();
+        let info_key = format!("info/{route}");
+        if !cache.exists(&info_key) {
+            let info_request = EventEnvelope::new()
+                .set_to(route)
+                .set_header("type", "info");
+            if let Ok(info) = po.request(info_request, Duration::from_secs(3)).await {
+                if let Ok(body @ serde_json::Value::Object(_)) = info.body_as::<serde_json::Value>()
+                {
+                    cache.put(&info_key, body);
+                }
+            }
+        }
+        if let Some(info) = cache.get_as::<serde_json::Value>(&info_key) {
+            if let serde_json::Value::Object(map) = info.as_ref() {
                 for (key, value) in map {
-                    entry.insert(key, value);
+                    entry.insert(key.clone(), value.clone());
                 }
             }
         }
@@ -359,47 +388,5 @@ async fn check_services(
     all_up
 }
 
-/// Human-readable elapsed time (the Java `util.elapsedTime` analog).
-fn elapsed_time(duration: Duration) -> String {
-    let total = duration.as_secs();
-    let (days, hours, minutes, seconds) = (
-        total / 86_400,
-        (total % 86_400) / 3600,
-        (total % 3600) / 60,
-        total % 60,
-    );
-    let mut parts = Vec::new();
-    if days > 0 {
-        parts.push(format!("{days} day{}", if days == 1 { "" } else { "s" }));
-    }
-    if hours > 0 {
-        parts.push(format!("{hours} hour{}", if hours == 1 { "" } else { "s" }));
-    }
-    if minutes > 0 {
-        parts.push(format!(
-            "{minutes} minute{}",
-            if minutes == 1 { "" } else { "s" }
-        ));
-    }
-    parts.push(format!(
-        "{seconds} second{}",
-        if seconds == 1 { "" } else { "s" }
-    ));
-    parts.join(" ")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn elapsed_time_formats() {
-        assert_eq!(elapsed_time(Duration::from_secs(0)), "0 seconds");
-        assert_eq!(elapsed_time(Duration::from_secs(1)), "1 second");
-        assert_eq!(elapsed_time(Duration::from_secs(61)), "1 minute 1 second");
-        assert_eq!(
-            elapsed_time(Duration::from_secs(90_061)),
-            "1 day 1 hour 1 minute 1 second"
-        );
-    }
-}
+// `elapsed_time` moved to `crate::util` (increment 71): it is now shared by
+// the `/info` uptime rendering here and the ManagedCache create log.

--- a/crates/platform-core/src/app_starter.rs
+++ b/crates/platform-core/src/app_starter.rs
@@ -50,7 +50,7 @@ use async_trait::async_trait;
 use crate::function::{AppError, ComposableFunction};
 use crate::platform::{FunctionOptions, Platform};
 use crate::util::app_config_reader::AppConfigReader;
-use crate::util::elastic_queue;
+use crate::util::{elastic_queue, managed_cache};
 
 /// Highest allowed hook sequence (Java `MAX_SEQ`); larger values clamp to it.
 const MAX_SEQ: u32 = 999;
@@ -146,6 +146,7 @@ impl AppStarter {
         //    preserve ordering; the event system buffers bursts), the event
         //    API, actuators, no.op and the HTTP client (all idempotent)
         elastic_queue::start_housekeeping();
+        managed_cache::start_housekeeping();
         let platform = Platform::get_instance();
         // the RPC reply listener is registered at Platform construction (so
         // every registry has it from birth); assert it here like the Java

--- a/crates/platform-core/src/lib.rs
+++ b/crates/platform-core/src/lib.rs
@@ -85,5 +85,6 @@ pub use platform::{FunctionOptions, Platform};
 pub use post_office::PostOffice;
 pub use util::app_config_reader::AppConfigReader;
 pub use util::config_reader::{ConfigError, ConfigReader};
+pub use util::managed_cache::{CacheValue, ManagedCache};
 pub use util::multi_level_map::{ConfigValue, MultiLevelMap};
 pub use util::{overrides, resources};

--- a/crates/platform-core/src/util/managed_cache.rs
+++ b/crates/platform-core/src/util/managed_cache.rs
@@ -1,0 +1,527 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Rust port of the Java `ManagedCache`
+//! (`org.platformlambda.core.util.ManagedCache`) — a **named, self-expiring
+//! (expire-after-write), size-bounded in-memory cache** with a process-wide
+//! registry. Design record: `docs/design/managed-cache-port.md`
+//! (maintainer-approved 2026-07-27).
+//!
+//! Engine: [moka](https://docs.rs/moka) (the Caffeine-lineage Rust cache),
+//! kept an internal detail behind this wrapper so it can be swapped without
+//! touching any consumer. Deliberate, documented divergences from the Java
+//! original (design §5):
+//!
+//! - **Deterministic eviction** (maintainer ruling, 2026-07-27): the store is
+//!   built with `EvictionPolicy::lru()` — newcomers are always admitted and
+//!   the least-recently-used entry is the victim — where Java's Caffeine uses
+//!   approximate W-TinyLFU with frequency-based admission plus deliberate
+//!   HashDoS jitter (no policy switch exists there; a refactoring note is
+//!   filed with the Java team).
+//! - The housekeeper is **lifecycle-wired** ([`start_housekeeping`], called by
+//!   `AppStarter`'s essential-services phase) instead of lazily started on
+//!   first create: `create_cache` legitimately runs where no Tokio runtime
+//!   exists (static init, plain tests). Correctness never depends on the
+//!   sweep in either engine — the store itself enforces expiry on access.
+//! - Expiry is clamped to a ~100-year ceiling as well as the Java 1 s floor
+//!   (moka's builder panics past 1000 years; Java accepts any `long`).
+//! - `entries()` / [`ManagedCache::get_cache_collection`] return snapshots
+//!   where Java hands out live `ConcurrentMap` views.
+//!
+//! Values are type-erased as [`CacheValue`] (`Arc<dyn Any + Send + Sync>`) —
+//! the faithful Rust carrier of Java's `Object` reference semantics: the
+//! `Arc` clone returned by [`ManagedCache::get`] is the analog of Java
+//! handing back the same object reference. Convention: one named cache
+//! stores one value shape; [`ManagedCache::get_as`] returns `None` on a type
+//! mismatch, exactly where Java's cast would sit.
+//!
+//! Java's `SimpleCache` is deliberately NOT ported (maintainer ruling): any
+//! Java `SimpleCache` call site ported later maps onto a `ManagedCache`
+//! instance — bounded + self-expiring is a strict superset of `SimpleCache`'s
+//! unbounded lazy expiry. State the parity note once at each adopted site.
+
+use std::any::Any;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use moka::policy::EvictionPolicy;
+use moka::sync::Cache;
+
+use crate::util::elapsed_time;
+
+/// Type-erased cache value — the Rust carrier of Java's `Object`.
+pub type CacheValue = Arc<dyn Any + Send + Sync>;
+
+/// Default capacity of [`ManagedCache::create_cache`] (Java `DEFAULT_MAX_ITEMS`).
+const DEFAULT_MAX_ITEMS: u64 = 2000;
+/// Expiry floor in ms (Java `MIN_EXPIRY`) — clamped up, never rejected.
+const MIN_EXPIRY_MS: u64 = 1000;
+/// Expiry ceiling (~100 years): moka's builder panics past 1000 years, so the
+/// clamp keeps `create_cache` total where Java accepts any `long` (design §5).
+const MAX_EXPIRY_MS: u64 = 100 * 365 * 24 * 60 * 60 * 1000;
+/// Housekeeper cadence (Java `HOUSEKEEPING_INTERVAL` — 10 minutes).
+const HOUSEKEEPING_INTERVAL: Duration = Duration::from_secs(600);
+
+/// A named, self-expiring, size-bounded cache (see the module doc).
+pub struct ManagedCache {
+    name: String,
+    expiry_ms: u64,
+    max_items: u64,
+    store: Cache<String, CacheValue>,
+    // telemetry stamps — Java uses plain (racy) longs; atomics with relaxed
+    // ordering carry the same values soundly
+    last_read: AtomicI64,
+    last_write: AtomicI64,
+    last_reset: AtomicI64,
+}
+
+/// The process-wide registry (Java `COLLECTION` + `SAFETY` lock, collapsed
+/// into one mutex-guarded map).
+fn registry() -> &'static Mutex<HashMap<String, Arc<ManagedCache>>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<String, Arc<ManagedCache>>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or_default()
+}
+
+impl ManagedCache {
+    /// Obtain (or create) the named cache with the default 2000-item bound
+    /// (Java `createCache(name, expiryMs)`). Idempotent by name: a later call
+    /// returns the existing instance unchanged — the first creation's
+    /// parameters win, later parameters are ignored (Java semantics).
+    pub fn create_cache(name: &str, expiry_ms: u64) -> Arc<ManagedCache> {
+        Self::create_cache_with_limit(name, expiry_ms, DEFAULT_MAX_ITEMS)
+    }
+
+    /// Obtain (or create) the named cache (Java `createCache(name, expiryMs,
+    /// maxItems)`). Expiry is clamped to \[1 s, ~100 years\].
+    pub fn create_cache_with_limit(
+        name: &str,
+        expiry_ms: u64,
+        max_items: u64,
+    ) -> Arc<ManagedCache> {
+        Self::create_clamped(
+            name,
+            expiry_ms.clamp(MIN_EXPIRY_MS, MAX_EXPIRY_MS),
+            max_items,
+        )
+    }
+
+    /// Test seam (design MC8, maintainer-approved): bypasses the 1 s floor so
+    /// TTL unit tests run in milliseconds. The public constructors above are
+    /// the only application path and always clamp.
+    #[cfg(test)]
+    fn create_cache_unclamped(name: &str, expiry_ms: u64, max_items: u64) -> Arc<ManagedCache> {
+        Self::create_clamped(name, expiry_ms.min(MAX_EXPIRY_MS), max_items)
+    }
+
+    fn create_clamped(name: &str, expiry_ms: u64, max_items: u64) -> Arc<ManagedCache> {
+        let mut collection = registry().lock().expect("managed cache registry");
+        if let Some(existing) = collection.get(name) {
+            return existing.clone();
+        }
+        let store = Cache::builder()
+            .max_capacity(max_items)
+            .time_to_live(Duration::from_millis(expiry_ms))
+            // deterministic eviction — maintainer ruling (module doc)
+            .eviction_policy(EvictionPolicy::lru())
+            .build();
+        let cache = Arc::new(ManagedCache {
+            name: name.to_string(),
+            expiry_ms,
+            max_items,
+            store,
+            last_read: AtomicI64::new(0),
+            last_write: AtomicI64::new(0),
+            last_reset: AtomicI64::new(now_ms()),
+        });
+        collection.insert(name.to_string(), cache.clone());
+        log::info!(
+            "Created cache ({}), expiry {}, maxItems={}",
+            name,
+            elapsed_time(Duration::from_millis(expiry_ms)),
+            max_items
+        );
+        cache
+    }
+
+    /// Resolve a cache by name from any module (Java `getInstance`).
+    pub fn get_instance(name: &str) -> Option<Arc<ManagedCache>> {
+        registry()
+            .lock()
+            .expect("managed cache registry")
+            .get(name)
+            .cloned()
+    }
+
+    /// Sorted snapshot of every registered cache for ops introspection
+    /// (Java `getCacheCollection` returns the live map — design §5).
+    pub fn get_cache_collection() -> BTreeMap<String, Arc<ManagedCache>> {
+        registry()
+            .lock()
+            .expect("managed cache registry")
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
+
+    /// Store a value (Java `put`) — stamps `last_write`; empty key = no-op.
+    /// NEVER pass a pre-wrapped `Arc`/[`CacheValue`] here — it would nest
+    /// (`Arc<Arc<T>>`) and `get_as::<T>` would miss; use [`Self::put_arc`]
+    /// for values that are already reference-counted.
+    pub fn put<V: Any + Send + Sync>(&self, key: &str, value: V) {
+        self.put_arc(key, Arc::new(value));
+    }
+
+    /// Store an already-wrapped value — stamps `last_write`; empty key = no-op.
+    pub fn put_arc(&self, key: &str, value: CacheValue) {
+        if !key.is_empty() {
+            self.last_write.store(now_ms(), Ordering::Relaxed);
+            self.store.insert(key.to_string(), value);
+        }
+    }
+
+    /// Fetch a value (Java `get`) — stamps `last_read` on any non-empty-key
+    /// call, hit or miss (Java stamps before the lookup).
+    pub fn get(&self, key: &str) -> Option<CacheValue> {
+        if key.is_empty() {
+            return None;
+        }
+        self.last_read.store(now_ms(), Ordering::Relaxed);
+        self.store.get(key)
+    }
+
+    /// Typed fetch: `None` on absence OR type mismatch — the Rust analog of
+    /// the cast at a Java call site.
+    pub fn get_as<T: Any + Send + Sync>(&self, key: &str) -> Option<Arc<T>> {
+        self.get(key).and_then(|value| value.downcast::<T>().ok())
+    }
+
+    /// Java `exists` — delegates to `get`, so it inherits the `last_read` stamp.
+    pub fn exists(&self, key: &str) -> bool {
+        self.get(key).is_some()
+    }
+
+    /// Java `remove` — stamps `last_write` even when the key is absent.
+    pub fn remove(&self, key: &str) {
+        if !key.is_empty() {
+            self.last_write.store(now_ms(), Ordering::Relaxed);
+            self.store.invalidate(key);
+        }
+    }
+
+    /// Java `clear` is three operations: stamp `lastReset`, `invalidateAll()`,
+    /// `cleanUp()` — the cleanup keeps `size()` honest immediately after a
+    /// clear. Emits no log (only `clean_up` logs).
+    pub fn clear(&self) {
+        self.last_reset.store(now_ms(), Ordering::Relaxed);
+        self.store.invalidate_all();
+        self.store.run_pending_tasks();
+    }
+
+    /// Java `cleanUp` — apply pending maintenance (expiry sweep, deferred
+    /// evictions) now.
+    pub fn clean_up(&self) {
+        log::debug!("Cleaning up {}", self.name);
+        self.store.run_pending_tasks();
+    }
+
+    /// Cache name (Java `getName`).
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The clamped expiry in ms (Java `getExpiry` returns the clamped value).
+    pub fn expiry_ms(&self) -> u64 {
+        self.expiry_ms
+    }
+
+    /// Capacity bound (Java `getMaxItems`).
+    pub fn max_items(&self) -> u64 {
+        self.max_items
+    }
+
+    /// Estimated entry count (Java `size()` = Caffeine `estimatedSize`;
+    /// moka `entry_count` — call [`Self::clean_up`] first for freshness).
+    pub fn size(&self) -> u64 {
+        self.store.entry_count()
+    }
+
+    /// Snapshot of the unexpired entries (Java `getMap` returns a live
+    /// `ConcurrentMap` view; Rust hands out no live guard — design §5).
+    pub fn entries(&self) -> Vec<(String, CacheValue)> {
+        self.store.iter().map(|(k, v)| ((*k).clone(), v)).collect()
+    }
+
+    /// Epoch ms of the last `get`/`exists` (Java `getLastRead`; 0 = never).
+    pub fn last_read(&self) -> i64 {
+        self.last_read.load(Ordering::Relaxed)
+    }
+
+    /// Epoch ms of the last `put`/`remove` (Java `getLastWrite`; 0 = never).
+    pub fn last_write(&self) -> i64 {
+        self.last_write.load(Ordering::Relaxed)
+    }
+
+    /// Epoch ms of construction or the last `clear` (Java `getLastReset`).
+    pub fn last_reset(&self) -> i64 {
+        self.last_reset.load(Ordering::Relaxed)
+    }
+}
+
+/// Start the 10-minute housekeeper the lifecycle owns (idempotent). Java
+/// starts its sweeper lazily inside the first constructor; here
+/// `create_cache` may run where no Tokio runtime exists, so the lifecycle
+/// wires this instead — a documented behavioral no-op (design §5): the sweep
+/// only reclaims memory in caches with no subsequent activity; the store
+/// itself enforces expiry on access. Must be called within a Tokio runtime
+/// (`AppStarter::run` does — its "essential services" phase).
+pub fn start_housekeeping() {
+    static STARTED: OnceLock<()> = OnceLock::new();
+    STARTED.get_or_init(|| {
+        log::info!("Housekeeper started");
+        tokio::spawn(async {
+            loop {
+                tokio::time::sleep(HOUSEKEEPING_INTERVAL).await;
+                housekeeping();
+            }
+        });
+    });
+}
+
+/// One housekeeping sweep over every registered cache (the Java
+/// `removeExpiredCache` body; a single sequential task, so sweeps never
+/// overlap — the intent of Java's `NOT_RUNNING` guard). The interval task
+/// calls this; tests call it directly — never test the timer.
+fn housekeeping() {
+    for cache in ManagedCache::get_cache_collection().into_values() {
+        cache.clean_up();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // NOTE: the registry is process-wide and unit tests run in parallel —
+    // every test uses its own unique cache name.
+
+    #[test]
+    fn round_trip_remove_clear_and_entries() {
+        let cache = ManagedCache::create_cache("unit.round.trip", 60_000);
+        cache.put("s", "text".to_string());
+        cache.put("n", 7_i64);
+        assert_eq!(cache.get_as::<String>("s").unwrap().as_str(), "text");
+        assert_eq!(*cache.get_as::<i64>("n").unwrap(), 7);
+        // wrong type -> None (the Java cast site)
+        assert!(cache.get_as::<i64>("s").is_none());
+        let mut keys: Vec<String> = cache.entries().into_iter().map(|(k, _)| k).collect();
+        keys.sort();
+        assert_eq!(keys, ["n", "s"]);
+        cache.remove("s");
+        assert!(!cache.exists("s"));
+        cache.clear();
+        // clear runs pending tasks (Java invalidateAll + cleanUp), so the
+        // estimate is honest immediately
+        assert_eq!(cache.size(), 0);
+        assert!(cache.get("n").is_none());
+    }
+
+    #[test]
+    fn pre_wrapped_arc_is_the_documented_trap() {
+        let cache = ManagedCache::create_cache("unit.wrong.wrap", 60_000);
+        let wrapped: Arc<String> = Arc::new("hello".to_string());
+        cache.put("k", wrapped); // stores TypeId Arc<String>, NOT String
+        assert!(cache.get_as::<String>("k").is_none());
+        assert!(cache.get_as::<Arc<String>>("k").is_some());
+        // the right way for a pre-wrapped value
+        cache.put_arc("k2", Arc::new("hello".to_string()));
+        assert_eq!(cache.get_as::<String>("k2").unwrap().as_str(), "hello");
+    }
+
+    #[test]
+    fn empty_key_is_a_guarded_no_op() {
+        let cache = ManagedCache::create_cache("unit.empty.key", 60_000);
+        cache.put("", "x".to_string());
+        cache.clean_up();
+        assert_eq!(cache.size(), 0);
+        assert!(cache.get("").is_none());
+        assert!(!cache.exists(""));
+        cache.remove("");
+        // Java guards BEFORE stamping: none of the above touched the markers
+        assert_eq!(cache.last_read(), 0);
+        assert_eq!(cache.last_write(), 0);
+    }
+
+    #[test]
+    fn expiry_clamps_at_both_ends() {
+        let low = ManagedCache::create_cache("unit.clamp.low", 500);
+        assert_eq!(low.expiry_ms(), 1000);
+        // must not panic (moka's builder rejects > 1000 years — design §5)
+        let high = ManagedCache::create_cache("unit.clamp.high", u64::MAX);
+        assert_eq!(high.expiry_ms(), MAX_EXPIRY_MS);
+    }
+
+    #[test]
+    fn create_is_idempotent_first_params_win() {
+        let first = ManagedCache::create_cache_with_limit("unit.create.idempotent", 5_000, 10);
+        let second = ManagedCache::create_cache_with_limit("unit.create.idempotent", 9_000, 99);
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(second.expiry_ms(), 5_000);
+        assert_eq!(second.max_items(), 10);
+    }
+
+    #[test]
+    fn registry_lookup_and_sorted_collection() {
+        ManagedCache::create_cache("unit.registry.zeta", 60_000);
+        ManagedCache::create_cache("unit.registry.alpha", 60_000);
+        assert!(ManagedCache::get_instance("unit.registry.alpha").is_some());
+        assert!(ManagedCache::get_instance("no.such.cache").is_none());
+        let all = ManagedCache::get_cache_collection();
+        let names: Vec<&str> = all
+            .keys()
+            .map(String::as_str)
+            .filter(|k| k.starts_with("unit.registry."))
+            .collect();
+        // BTreeMap keeps the snapshot deterministic (the /info/routes rule)
+        assert_eq!(names, ["unit.registry.alpha", "unit.registry.zeta"]);
+        assert_eq!(
+            all.get("unit.registry.alpha").unwrap().name(),
+            "unit.registry.alpha"
+        );
+    }
+
+    #[test]
+    fn ttl_expires_after_write_lazily() {
+        // 200 ms TTL: presence is asserted immediately after the put (only a
+        // >200 ms preemption between two adjacent statements could flake it);
+        // the absence side sleeps far past the boundary (sleeps never
+        // undershoot)
+        let cache = ManagedCache::create_cache_unclamped("unit.ttl.expiry", 200, 100);
+        cache.put("k", 42_i32);
+        assert!(cache.exists("k"));
+        std::thread::sleep(Duration::from_millis(600));
+        // no housekeeper involved — the store enforces expiry on access
+        assert!(cache.get_as::<i32>("k").is_none());
+        assert!(!cache.exists("k"));
+    }
+
+    #[test]
+    fn ttl_resets_on_update_expire_after_write() {
+        // a reset test inherently needs one mid-window presence assert; the
+        // 1200 ms TTL gives every boundary >= 400 ms of slow-CI headroom
+        let cache = ManagedCache::create_cache("unit.ttl.reset", 1200);
+        cache.put("k", "a".to_string());
+        std::thread::sleep(Duration::from_millis(800));
+        // a rewrite resets the clock (Caffeine expireAfterWrite parity) —
+        // the primitive behind the WS-dedup anchored window
+        cache.put("k", "b".to_string());
+        std::thread::sleep(Duration::from_millis(800));
+        // ~1.6 s after the first write (past its 1.2 s TTL — presence here
+        // PROVES the reset) but only ~0.8 s after the rewrite
+        assert_eq!(cache.get_as::<String>("k").unwrap().as_str(), "b");
+        std::thread::sleep(Duration::from_millis(700));
+        // ~1.5 s after the rewrite — expired
+        assert!(cache.get("k").is_none());
+    }
+
+    #[test]
+    fn lru_eviction_is_deterministic() {
+        // maintainer ruling: EvictionPolicy::lru — newcomers always admitted,
+        // the least-recently-used entry is the victim (design §5). Sequential
+        // access, so the recorded order is exact.
+        let cache = ManagedCache::create_cache_with_limit("unit.lru.eviction", 60_000, 3);
+        cache.put("a", 1_i32);
+        cache.put("b", 2_i32);
+        cache.put("c", 3_i32);
+        // flush the writes first: a maintenance pass applies the read log
+        // BEFORE the write log, so a read recorded ahead of its entry's
+        // write would be a recency no-op
+        cache.clean_up();
+        // touch a and b so c becomes the least recently used; flush the
+        // recorded reads before inserting the 4th entry
+        assert!(cache.exists("a"));
+        assert!(cache.exists("b"));
+        cache.clean_up();
+        cache.put("d", 4_i32);
+        cache.clean_up();
+        assert!(!cache.exists("c"), "the LRU entry is the victim");
+        assert!(cache.exists("a"));
+        assert!(cache.exists("b"));
+        assert!(cache.exists("d"), "the newcomer is always admitted");
+        assert_eq!(cache.size(), 3);
+    }
+
+    #[test]
+    fn telemetry_stamps_follow_the_java_map() {
+        let cache = ManagedCache::create_cache("unit.telemetry.stamps", 60_000);
+        assert_eq!(cache.last_read(), 0);
+        assert_eq!(cache.last_write(), 0);
+        assert!(cache.last_reset() > 0);
+        // get on a miss stamps last_read (Java stamps before the lookup)
+        assert!(cache.get("absent").is_none());
+        assert!(cache.last_read() > 0);
+        cache.put("k", "v".to_string());
+        let first_write = cache.last_write();
+        assert!(first_write > 0);
+        std::thread::sleep(Duration::from_millis(10));
+        // remove stamps last_write even when the key is absent (Java parity)
+        cache.remove("no-such-key");
+        assert!(cache.last_write() > first_write);
+        let first_reset = cache.last_reset();
+        std::thread::sleep(Duration::from_millis(10));
+        cache.clear();
+        assert!(cache.last_reset() > first_reset);
+    }
+
+    #[test]
+    fn housekeeping_sweeps_idle_caches() {
+        let cache = ManagedCache::create_cache_unclamped("unit.housekeeping", 50, 100);
+        cache.put("k", 1_i32);
+        std::thread::sleep(Duration::from_millis(250));
+        // the sweep body the interval task runs — never test the timer
+        housekeeping();
+        assert_eq!(cache.size(), 0);
+    }
+
+    #[test]
+    fn concurrent_put_get_smoke() {
+        let cache = ManagedCache::create_cache("unit.concurrent.smoke", 60_000);
+        let mut handles = Vec::new();
+        for t in 0..4 {
+            let cache = cache.clone();
+            handles.push(std::thread::spawn(move || {
+                for i in 0..250 {
+                    let key = format!("k{t}-{i}");
+                    cache.put(&key, i);
+                    assert_eq!(*cache.get_as::<i32>(&key).unwrap(), i);
+                }
+            }));
+        }
+        for handle in handles {
+            handle.join().unwrap();
+        }
+        cache.clean_up();
+        assert_eq!(cache.size(), 1000);
+    }
+}

--- a/crates/platform-core/src/util/mod.rs
+++ b/crates/platform-core/src/util/mod.rs
@@ -21,7 +21,80 @@ pub mod app_config_reader;
 pub mod config_reader;
 pub mod elastic_queue;
 pub mod feature;
+pub mod managed_cache;
 pub mod multi_level_map;
 pub mod overrides;
 pub mod resources;
 pub mod w3c_trace;
+
+/// Human-readable elapsed time — an EXACT port of the Java
+/// `Utility.elapsedTime(long)`, shared by the actuator (`/info` uptime) and
+/// the ManagedCache create log (both are Java-parity log/presentation
+/// surfaces). Java's quirks are kept verbatim: strict `>` at the day/hour/
+/// minute boundaries (exactly 1 minute renders "60 seconds", exactly 1 day
+/// renders "24 hours"), zero components are omitted, and a sub-second value
+/// renders as "N ms".
+pub(crate) fn elapsed_time(duration: std::time::Duration) -> String {
+    const ONE_SECOND_MS: u128 = 1000;
+    const ONE_MINUTE_MS: u128 = 60 * ONE_SECOND_MS;
+    const ONE_HOUR_MS: u128 = 60 * ONE_MINUTE_MS;
+    const ONE_DAY_MS: u128 = 24 * ONE_HOUR_MS;
+    let mut time = duration.as_millis();
+    let mut parts: Vec<String> = Vec::new();
+    if time > ONE_DAY_MS {
+        let days = time / ONE_DAY_MS;
+        parts.push(format!("{days} day{}", if days == 1 { "" } else { "s" }));
+        time -= days * ONE_DAY_MS;
+    }
+    if time > ONE_HOUR_MS {
+        let hours = time / ONE_HOUR_MS;
+        parts.push(format!("{hours} hour{}", if hours == 1 { "" } else { "s" }));
+        time -= hours * ONE_HOUR_MS;
+    }
+    if time > ONE_MINUTE_MS {
+        let minutes = time / ONE_MINUTE_MS;
+        parts.push(format!(
+            "{minutes} minute{}",
+            if minutes == 1 { "" } else { "s" }
+        ));
+        time -= minutes * ONE_MINUTE_MS;
+    }
+    if time >= ONE_SECOND_MS {
+        let seconds = time / ONE_SECOND_MS;
+        parts.push(format!(
+            "{seconds} second{}",
+            if seconds == 1 { "" } else { "s" }
+        ));
+    }
+    if parts.is_empty() {
+        format!("{time} ms")
+    } else {
+        parts.join(" ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn elapsed_time_matches_java_utility() {
+        // sub-second renders as ms (Java: sb.isEmpty() -> "N ms")
+        assert_eq!(elapsed_time(Duration::from_millis(0)), "0 ms");
+        assert_eq!(elapsed_time(Duration::from_millis(500)), "500 ms");
+        assert_eq!(elapsed_time(Duration::from_secs(1)), "1 second");
+        assert_eq!(elapsed_time(Duration::from_secs(61)), "1 minute 1 second");
+        // Java's strict `>` boundary quirks, kept verbatim
+        assert_eq!(elapsed_time(Duration::from_secs(60)), "60 seconds");
+        assert_eq!(elapsed_time(Duration::from_secs(3600)), "60 minutes");
+        assert_eq!(elapsed_time(Duration::from_secs(86_400)), "24 hours");
+        // zero components are omitted (Java: no seconds part when remainder 0)
+        assert_eq!(elapsed_time(Duration::from_secs(120)), "2 minutes");
+        assert_eq!(elapsed_time(Duration::from_secs(1800)), "30 minutes");
+        assert_eq!(
+            elapsed_time(Duration::from_secs(90_061)),
+            "1 day 1 hour 1 minute 1 second"
+        );
+    }
+}

--- a/crates/platform-core/tests/actuator.rs
+++ b/crates/platform-core/tests/actuator.rs
@@ -235,9 +235,11 @@ async fn info_reports_app_identity_and_uptime() {
     assert_eq!(json["app"]["description"], "actuator test app");
     assert_eq!(json["runtime"]["language"], "rust");
     assert!(json["origin"].as_str().is_some_and(|o| !o.is_empty()));
+    // Java Utility.elapsedTime rendering: a just-started server may report a
+    // sub-second uptime as "N ms" (Java parity), otherwise "N second(s)"
     assert!(json["up_time"]
         .as_str()
-        .is_some_and(|u| u.contains("second")));
+        .is_some_and(|u| u.contains("second") || u.ends_with(" ms")));
     assert!(json["time"]["start"]
         .as_str()
         .is_some_and(|t| t.ends_with('Z')));

--- a/crates/platform-core/tests/health_info_cache.rs
+++ b/crates/platform-core/tests/health_info_cache.rs
@@ -1,0 +1,186 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Increment 71: the `/health` per-dependency info-lookup cache (Java parity —
+//! `ActuatorServices`' `SimpleCache("health.info", 5000)`, mapped onto
+//! `ManagedCache` per the maintainer's one-cache-type ruling;
+//! `docs/design/managed-cache-port.md` §6.2).
+//!
+//! Isolated in its OWN test binary on purpose: the `health.info` cache is
+//! process-wide, and the other actuator tests all register their dependency
+//! at the shared `demo.health` route — sharing a binary would bleed cached
+//! info entries across tests in both directions. Here the config freeze and
+//! the dependency route belong to this binary alone.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Once};
+
+use async_trait::async_trait;
+use platform_core::actuator::{ActuatorContext, ActuatorKind, ActuatorServices};
+use platform_core::{
+    automation, overrides, resources, AppConfigReader, AppError, ComposableFunction, EventEnvelope,
+    Platform,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+static INFO_CALLS: AtomicUsize = AtomicUsize::new(0);
+static HEALTH_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+/// A health-check dependency that counts how often each protocol arm is hit.
+struct CountingHealth;
+
+#[async_trait]
+impl ComposableFunction for CountingHealth {
+    async fn handle_event(
+        &self,
+        headers: HashMap<String, String>,
+        _input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        match headers.get("type").map(String::as_str) {
+            Some("info") => {
+                INFO_CALLS.fetch_add(1, Ordering::SeqCst);
+                EventEnvelope::new().set_body(serde_json::json!({
+                    "service": "counting.store",
+                    "href": "memory://counting",
+                }))
+            }
+            Some("health") => {
+                HEALTH_CALLS.fetch_add(1, Ordering::SeqCst);
+                EventEnvelope::new().set_body("counting store is running")
+            }
+            _ => Err(AppError::new(400, "unknown type")),
+        }
+    }
+}
+
+fn setup_config() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        resources::prepend_resource_root("tests/resources");
+        let holding =
+            std::env::temp_dir().join(format!("mercury-health-cache-test-{}", std::process::id()));
+        overrides::set("transient.data.store", &holding.display().to_string());
+        let rest_file =
+            std::env::temp_dir().join(format!("rest-health-cache-{}.yaml", std::process::id()));
+        std::fs::write(
+            &rest_file,
+            "rest:\n  - service: \"noop.demo\"\n    methods: ['GET']\n    url: \"/api/noop\"\n",
+        )
+        .unwrap();
+        overrides::set(
+            "yaml.rest.automation",
+            &format!("file:{}", rest_file.display()),
+        );
+        overrides::set("rest.server.port", "0");
+        overrides::set("application.name", "health-info-cache-test");
+        // this binary's OWN dependency route (read at ActuatorContext
+        // construction) — never the shared demo.health
+        overrides::set("mandatory.health.dependencies", "counting.health.dep");
+        let _ = AppConfigReader::get_instance();
+    });
+}
+
+struct Noop;
+
+#[async_trait]
+impl ComposableFunction for Noop {
+    async fn handle_event(
+        &self,
+        _h: HashMap<String, String>,
+        _i: EventEnvelope,
+        _n: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        EventEnvelope::new().set_body("ok")
+    }
+}
+
+async fn server() -> (u16, Platform) {
+    setup_config();
+    let platform = Platform::new();
+    platform.register("noop.demo", Arc::new(Noop), 1).unwrap();
+    platform
+        .register("counting.health.dep", Arc::new(CountingHealth), 1)
+        .unwrap();
+    let context = ActuatorContext::new(&platform);
+    platform
+        .register(
+            platform_core::actuator::HEALTH_ACTUATOR,
+            Arc::new(ActuatorServices::new(ActuatorKind::Health, context)),
+            1,
+        )
+        .unwrap();
+    let addr = automation::start_http_server(&platform).await.unwrap();
+    (addr.port(), platform)
+}
+
+async fn http_get(port: u16, path: &str) -> (u16, String) {
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("connect");
+    let request = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    stream.write_all(request.as_bytes()).await.expect("write");
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).await.expect("read");
+    let text = String::from_utf8_lossy(&raw).to_string();
+    let (head, payload) = text.split_once("\r\n\r\n").unwrap_or((text.as_str(), ""));
+    let status: u16 = head
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse().ok())
+        .unwrap_or_else(|| panic!("no status in: {text:?}"));
+    (status, payload.to_string())
+}
+
+/// Java `isServiceUnhealthy` parity: the per-dependency `type=info` lookup is
+/// served from the 5 s `health.info` cache on the second `/health` call, while
+/// `type=health` re-runs on EVERY call — Java never caches the health probe
+/// (nor the /health result itself).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn info_lookup_is_cached_health_is_not() {
+    let (port, _platform) = server().await;
+    let (status_first, body_first) = http_get(port, "/health").await;
+    assert_eq!(status_first, 200);
+    let (status_second, body_second) = http_get(port, "/health").await;
+    assert_eq!(status_second, 200);
+    assert_eq!(
+        INFO_CALLS.load(Ordering::SeqCst),
+        1,
+        "the second /health must serve type=info from the 5 s cache"
+    );
+    assert_eq!(
+        HEALTH_CALLS.load(Ordering::SeqCst),
+        2,
+        "type=health runs on every call - the health outcome is never cached"
+    );
+    // the cached info map still merges into the dependency entry on BOTH calls
+    for body in [&body_first, &body_second] {
+        let json: serde_json::Value = serde_json::from_str(body).unwrap();
+        let dep = &json["dependency"][0];
+        assert_eq!(dep["route"], "counting.health.dep");
+        assert_eq!(dep["required"], true);
+        assert_eq!(dep["service"], "counting.store");
+        assert_eq!(dep["href"], "memory://counting");
+        assert_eq!(dep["status_code"], 200);
+        assert_eq!(dep["message"], "counting store is running");
+    }
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&body_second).unwrap()["status"],
+        "UP"
+    );
+}

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -84,6 +84,10 @@
 | 65 | Metadata injection hardening (Java parity): business cid rides the engine-managed `my_cid` envelope tag (wire-compatible `tags` field), worker injects the four `my_*` read-only keys into the input header copy at entry and sanitizes them (+ `x-event-api`) at exit — metadata is never transported; REST response echoes X-Correlation-Id; edge stamps the resolved cid onto the dataset headers | 2026-07-23 | — | 249 |
 | 66 | `temporary.inbox` alignment (Java parity): ONE reserved RPC reply-listener route keyed by correlation id — the `inbox.*` namespace freed for applications; RPC marker = the reserved `rpc` tag; `@origin` addressing never generated, parsed away inbound; reply dispatch direct on the sender's runtime | 2026-07-23 | — | 250 |
 | 67 | Collection plugins mirror (`isEmpty`/`getFirst`/`getLast` — contributed to the Java engine in mercury-composable PR #220): flows are engine-portable YAML, so plugins + error text behave identically on both engines | 2026-07-23 | — | 252 |
+| 68 | Configurable traceparent header name (field request, lock-step with Java): `http.traceparent.header` global + per-entry rest.yaml override; standard traceparent wins inbound (v4.10.4 ruling), dual-stamp outbound | 2026-07-24 | — | 257 |
+| 69 | Interop header hygiene (lock-step with Java): clean delivered-envelope view (5 engine keys scrubbed for non-interceptors; interceptors keep raw transport), /api/event wire alignment (insert-semantics stamps, Java header set, no x-correlation-id), endpoint timeout rides x-ttl | 2026-07-24 | — | 260 |
+| 70 | Annotation→macro consistency P1: all 46 built-in plugins + both fetch features dogfood `#[simple_plugin]`/`#[fetch_feature]`, one conflict policy (WARN + last-wins), positional grammar, order-free marker stacking, trybuild compile-fail suites | 2026-07-25 | — | 265 |
+| 71 | ManagedCache — the self-expiring in-memory cache (design `managed-cache-port.md`, maintainer-gated): moka engine with deterministic LRU eviction, `Arc<dyn Any>` value carrier, named registry + lifecycle housekeeper; adopters: WS dedup (anchored window fix), actuator `health.info` info-lookup cache, ext-state-machine fixture | 2026-07-27 | — | 287 |
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -2150,13 +2154,77 @@ same-named Java branch.
 
 ---
 
+## Increment 71 — ManagedCache: the self-expiring in-memory cache (2026-07-27)
+
+Port of `org.platformlambda.core.util.ManagedCache` per the maintainer-gated design
+`docs/design/managed-cache-port.md` (three rulings: ONE cache type — `SimpleCache` is NOT
+ported, any Java `SimpleCache` site maps onto a `ManagedCache` instance; adopt a proper
+self-expiring implementation — moka, the Caffeine-lineage engine, wrapped as an internal
+detail; **deterministic eviction** — `EvictionPolicy::lru()` instead of Java Caffeine's
+approximate W-TinyLFU + HashDoS jitter, a documented divergence in the Rust port's favor
+with a refactoring note filed for the Java team).
+
+- **Module:** `util::managed_cache` (re-exported as `platform_core::{ManagedCache,
+  CacheValue}`): named caches in a process-wide registry (`create_cache` /
+  `create_cache_with_limit` — idempotent by name, first creation's parameters win;
+  `get_instance`; sorted-snapshot `get_cache_collection`); expire-after-write TTL clamped
+  to [1 s, ~100 years] (Java floor; the ceiling keeps moka's builder total); default
+  2000-item bound; values type-erased as `CacheValue = Arc<dyn Any + Send + Sync>` (the
+  Rust carrier of Java `Object` reference semantics) with typed `get_as::<T>()`; the
+  Java telemetry-stamp map exactly (put/remove → last_write incl. remove-on-absent,
+  get/exists → last_read hit-or-miss, clear → last_reset; clear = stamp + invalidate_all
+  + run_pending_tasks); Java log wordings (`Created cache (..)`, `Housekeeper started`,
+  `Cleaning up ..`); 10-minute housekeeper lifecycle-wired in `AppStarter`'s
+  essential-services phase (never spawned from `create_cache` — it runs outside the
+  runtime; correctness never depends on the sweep). `elapsed_time` moved from the
+  actuator to `util` (shared by the create log and `/info` uptime).
+- **Adopter 1 — WS dedup (knowledge-graph):** `commands.rs::is_duplicate` migrated from
+  an unbounded `Mutex<HashMap>` stand-in to the Java `"last.ws.message"`/1 s cache. Two
+  fixes toward Java: bounded self-expiring memory (the session-close arm never removed
+  dedup entries), and the ANCHORED window (a duplicate no longer re-puts — the old
+  sliding window never let a continuous duplicate stream through); Java's
+  `Duplicated message - {} for {}` debug log added. The existing WS double-submit
+  regression passes unchanged; a time-spaced anchored-vs-sliding regression added.
+- **Adopter 2 — actuator info cache:** the per-dependency `type=info` lookup cached 5 s
+  under `info/{route}` (`"health.info"`, map bodies only) — Java `isServiceUnhealthy`
+  parity; `type=health` still runs on every call and the `/health` result is never
+  cached. Dedicated test binary (`tests/health_info_cache.rs` — the cache is
+  process-wide, so the counting test owns its binary and route): two back-to-back
+  `/health` ⇒ info counted once, health twice.
+- **Adopter 3 — event-script test fixture:** `ExternalStateMachine` in
+  `flow_runtime.rs` backed by the Java fixture's `"state.machine"`/10 s cache (values =
+  `Arc<Mutex<Map>>` handles — Java's in-place map mutation reproduced; PUT re-puts the
+  handle, refreshing the window like Java's `store.put`).
+- **Tests:** 12 in-module unit tests (round-trip/downcast/wrong-wrap trap, clamps both
+  ends, lazy TTL expiry via the `#[cfg(test)]` unclamped constructor [design MC8,
+  maintainer-approved] + reset-on-update, deterministic LRU victim, idempotency, registry,
+  telemetry stamps, housekeeping sweep body, concurrency smoke) + the two adopter
+  regressions. Docs: api-overview `ManagedCache` section, actuators guide health-cache
+  note, actuator module doc un-deferred, CHANGELOG Unreleased.
+- **Pre-commit adversarial review round (18-agent 3-lens pass; 12 confirmed findings
+  fixed):** the fixture migration initially kept `instances = 4` — a lost-update race the
+  old global `Mutex` had masked (two concurrent first puts for one trace each built their
+  own map; the flow_runtime suite went ~50% red) — fixed to `instances = 1`, restoring
+  the Java fixture's deliberate singleton semantics; the caller-side duplicate debug log
+  removed (Java logs ONCE, inside the comparison — the double line would have broken
+  log-presentation parity); `elapsed_time` rewritten as an EXACT `Utility.elapsedTime`
+  port (strict `>` boundaries, zero components omitted, sub-second "N ms") — the create
+  log now renders whole-minute TTLs exactly like Java ("2 minutes", not
+  "2 minutes 0 seconds") and `/info` uptime is corrected as a side effect; TTL test
+  margins widened to ≥ 400 ms slow-CI headroom; stale "deferred" claims swept
+  (platform-core-port §5f/§7) and the overview rows 68–71 backfilled.
+  Workspace 287 (273+14) / clippy 0 / fmt.
+
+---
+
 ## Deferred backlog (as of increment 10)
 
 See `docs/design/platform-core-port.md` §7 for the authoritative list: broadcast delivery,
 streams, kernel-thread analog, flow binding + HTTP relay + A/B +
 upload + streaming (REST), event-over-HTTP, OTLP forwarder extension, `/info/lib` +
 `/info/routes`, `yaml.preload.override`, etag/cache, the
-`Utility` grab-bag, crypto/caches, a dedicated lightweight RPC inbox.
+`Utility` grab-bag, crypto (the caches landed as increment 71's `ManagedCache`),
+a dedicated lightweight RPC inbox.
 
 **Next layer:** event-script (layer 2) — the YAML flow DSL, unlocking REST automation's
 `flow:` binding and the composable-application programming model.

--- a/docs/design/managed-cache-port.md
+++ b/docs/design/managed-cache-port.md
@@ -1,16 +1,21 @@
 # Design — `ManagedCache` → Rust (self-expiring in-memory cache)
 
-> **Status:** DRAFT v2 for maintainer review (v1 hardened by a 3-lens adversarial critique
-> against the Java source, the moka docs/changelog, and the Rust consumer sites) ·
+> **Status:** APPROVED 2026-07-27 (Eric: "design approved - moka confirmed, all three
+> adopters, test constructor ok"), amended at approval with ruling #3 below. v2 was
+> hardened by a 3-lens adversarial critique against the Java source, the moka
+> docs/changelog, and the Rust consumer sites ·
 > **Realizes:** `ot-managedcache-port` (backlog) · **Serves:** `vision-mercury` ·
 > **Author:** Claude Code · **Date:** 2026-07-27
 > **Canonical source:** `org.platformlambda.core.util.ManagedCache` (mercury-composable, Java).
-> This is a *Design-altitude* artifact in the VBDI loop. **Implementation waits on approval.**
 >
-> **Maintainer rulings already applied (2026-07-27):**
+> **Maintainer rulings applied (2026-07-27):**
 > 1. **Do NOT port `SimpleCache`.** One cache type only.
 > 2. **"Adopt a proper self-expiring in-memory cache"** — use a maintained implementation
 >    rather than hand-rolling expiry/eviction.
+> 3. **"Please ensure deterministic eviction"** (at approval) — the Rust port uses moka's
+>    `EvictionPolicy::lru` (≥0.12.5) instead of the default TinyLFU. This is a deliberate,
+>    documented divergence from Java's Caffeine (W-TinyLFU, which has no policy switch);
+>    a refactoring note for the mercury-composable team is filed alongside this increment.
 
 ## 1. Goal & scope
 
@@ -67,14 +72,14 @@ Java call sites are all connectors/mesh (`app.presence.list`, `sticky.destinatio
 
 | # | Decision | Rationale |
 |---|---|---|
-| MC1 | **Engine: `moka = { version = "0.12", features = ["sync"] }`** (`moka::sync::Cache`), wrapped — never exposed | Ruling #2 ("adopt a proper self-expiring cache") + the repo's canonical-analog precedent (chrono-tz = `ZoneId`): moka is the Caffeine-lineage Rust cache — `max_capacity` = `maximumSize`, `time_to_live` = `expireAfterWrite` (reset-on-update proven by moka's own TTL unit test), `entry_count()` = `estimatedSize`, `run_pending_tasks()` = `cleanUp()`. Since v0.12 it spawns **no threads of its own** (README/CHANGELOG v0.12.0: background threads removed; re-verify against the pinned version's changelog at implementation) — and unlike Caffeine, which offloads cleanup to the JVM common pool by default, maintenance runs strictly on calling threads, which *strengthens* the no-runtime-entanglement argument. Health check (2026-07): v0.12.15 released 2026-07-04, steady patch cadence, no RUSTSEC advisories, MSRV 1.71.1 vs our 1.95.0; the old `quanta` dependency concern is stale (optional/non-default since v0.12.10) — the sync tree is modest and mainstream (crossbeam-\*, parking_lot, smallvec, …; uuid already in our tree). Honest caveat: effectively one maintainer (bus factor 1) — the wrapper keeps the engine an internal detail, so it can be swapped (incl. hand-rolled) without touching any consumer. *(Alternative considered: ~150-line hand-rolled TTL+bound map — zero new deps; rejected under ruling #2 and for the future schema-registry hot path, where moka's concurrent design wins. Revisit only via the engine-swap hatch.)* |
+| MC1 | **Engine: `moka = { version = "0.12", features = ["sync"] }`** (`moka::sync::Cache`), built with **`eviction_policy(EvictionPolicy::lru())`** (ruling #3 — deterministic eviction: newcomers always admitted, least-recently-used entry evicted), wrapped — never exposed | Ruling #2 ("adopt a proper self-expiring cache") + the repo's canonical-analog precedent (chrono-tz = `ZoneId`): moka is the Caffeine-lineage Rust cache — `max_capacity` = `maximumSize`, `time_to_live` = `expireAfterWrite` (reset-on-update proven by moka's own TTL unit test), `entry_count()` = `estimatedSize`, `run_pending_tasks()` = `cleanUp()`. Since v0.12 it spawns **no threads of its own** (README/CHANGELOG v0.12.0: background threads removed; re-verify against the pinned version's changelog at implementation) — and unlike Caffeine, which offloads cleanup to the JVM common pool by default, maintenance runs strictly on calling threads, which *strengthens* the no-runtime-entanglement argument. Health check (2026-07): v0.12.15 released 2026-07-04, steady patch cadence, no RUSTSEC advisories, MSRV 1.71.1 vs our 1.95.0; the old `quanta` dependency concern is stale (optional/non-default since v0.12.10) — the sync tree is modest and mainstream (crossbeam-\*, parking_lot, smallvec, …; uuid already in our tree). Honest caveat: effectively one maintainer (bus factor 1) — the wrapper keeps the engine an internal detail, so it can be swapped (incl. hand-rolled) without touching any consumer. *(Alternative considered: ~150-line hand-rolled TTL+bound map — zero new deps; rejected under ruling #2 and for the future schema-registry hot path, where moka's concurrent design wins. Revisit only via the engine-swap hatch.)* |
 | MC2 | **Value carrier: `pub type CacheValue = Arc<dyn Any + Send + Sync>`** with a typed `get_as::<T>()` helper (`Arc::downcast`, stable std) | The faithful Rust carrier of Java `Object`: reference semantics (`Arc` clone = Java reference handout — moka's `get` returns a clone of V, i.e. a refcount bump), zero serialization tax, holds arbitrary structs; compile-verified against moka's `V: Clone + Send + Sync + 'static` bounds on rustc 1.95.0. This is load-bearing for the schema-registry consumer, which caches **parsed-schema handles** precisely to avoid re-parsing — `rmpv::Value`/`serde_json::Value` would force a serde round-trip per hit and exclude non-Serialize handles. Convention (documented): one named cache stores one value shape; `get_as` returns `None` on a type mismatch, exactly where Java's cast would sit. **Double-wrap trap (doc'd + tested):** `put(key, some_arc)` compiles — it stores TypeId `Arc<T>`, so `get_as::<T>()` misses; the `put` doc warns "never pass a pre-wrapped `Arc`/`CacheValue` to `put` — use `put_arc`", and §7 pins a wrong-wrap regression. Same move as the registration-metadata contract: canonical semantics fixed, carrier idiomatic per language. |
 | MC3 | **One type** (`ManagedCache`), no `SimpleCache` | Ruling #1. Bounded + self-expiring is a strict superset of SimpleCache's unbounded lazy expiry; any Java `SimpleCache` call site ported later becomes a `ManagedCache` instance (default bound), with a one-line parity note at that site. The mapping rule is stated once, here. |
 | MC4 | **Registry: monomorphic statics** — `get_instance(name) -> Option<Arc<ManagedCache>>`; `get_cache_collection() -> BTreeMap<String, Arc<ManagedCache>>` (sorted **snapshot**) | Because `ManagedCache` is one non-generic type (MC2 erases values, not caches), cross-module `getInstance` works with no type parameter — exactly Java. Snapshot instead of Java's live `ConcurrentMap` view (Rust hands out no live guard); BTreeMap-sorted per the repo's determinism convention (`/info/routes`, actuator.rs). Registry lock: `OnceLock<Mutex<HashMap<..>>>`; create-idempotency = `entry().or_insert_with()` under that one lock (Java's `ReentrantLock` + `ConcurrentMap` collapse into one; first creation's params win, §2). Schema-registry note: `create_cache` returns the `Arc` handle, so caches can also be **passed** into constructors (the Java client receives two handles) — the registry is a convenience, not the only access path. |
 | MC5 | **Housekeeper: lifecycle-wired, never spawned from `create_cache`** — `managed_cache::start_housekeeping()`, idempotent (`OnceLock`), 10-min `tokio` interval sweeping `run_pending_tasks()` over the registry; called from `app_starter`'s essential-services phase (the `elastic_queue::start_housekeeping()` precedent, app_starter.rs:148) | `create_cache` legitimately runs where no Tokio runtime exists (`OnceLock` static init, plain `#[test]`); `tokio::spawn` there panics. The repo's *other* housekeeping precedent — knowledge-graph `commands::start_housekeeping()`, started lazily from the request handler — is the closer analog to Java's lazy first-create trigger but is rejected here for exactly that reason: the KG handler always runs inside the runtime; `create_cache` does not. Java starts its sweeper lazily on first create — the trigger point differs (documented divergence), the observable behavior does not: correctness never depends on the sweep in either engine (moka expires on access like Caffeine; the sweep only freshens idle caches' memory/introspection). Bare tests call `clean_up()` explicitly. Logs `Housekeeper started` once (Java wording). |
 | MC6 | **API naming**: snake_case, bare-noun getters (repo style, e.g. `envelope.id()`) — see §4 | Matches `EventEnvelope` and the port's conventions; Java's overload becomes a second constructor fn (`create_cache` / `create_cache_with_limit`). |
 | MC7 | **Module**: `crates/platform-core/src/util/managed_cache.rs` (`pub mod managed_cache;` in util/mod.rs); `//!` doc names `org.platformlambda.core.util.ManagedCache`; **`ManagedCache` + `CacheValue` join the lib.rs `pub use` list** (the AppConfigReader/ConfigReader precedent — this is a public application-facing utility in Java, not an internal like `elastic_queue`) | Repo convention (Apache header; module doc names the Java class ported; parity notes inline). The knowledge-graph adopter consumes the lib.rs re-export. |
-| MC8 | **Testability**: public constructors keep the 1000 ms floor clamp (plus a documented ~100-year ceiling — moka's builder panics past 1000 years, a divergence Java's any-`long` API doesn't have; clamping keeps `create_cache` total); one **crate-private** unclamped-floor constructor (`pub(crate)`, doc'd test-only) enables fast TTL tests (~50 ms expiry + ~200 ms sleeps) | This is a **new pattern for the repo** — no `pub(crate)` test-only constructor exists today; the nearest precedent is the built-in test affordance "port 0 = ephemeral, for tests" (automation/server.rs). moka has an injectable `Clock`, but it is `pub(crate)` in moka itself — not available to us; and the repo's TTL-ish tests all sleep with tolerances (42 `sleep(from_millis)` calls across `crates/*/tests`). Without the seam, every TTL test sleeps >1 s. The clamp stays the only *public* path, so Java semantics hold for applications. Boundary rule for all TTL tests: assert presence only immediately after `put`, absence only well past TTL (≥ TTL + 300 ms) — never near the boundary. |
+| MC8 | **Testability**: public constructors keep the 1000 ms floor clamp (plus a documented ~100-year ceiling — moka's builder panics past 1000 years, a divergence Java's any-`long` API doesn't have; clamping keeps `create_cache` total); one unclamped-floor constructor, doc'd test-only, enables fast TTL tests. *(As implemented — strictly narrower than approved: `#[cfg(test)]` module-private, visible only to the in-module unit tests, which is where every fast-TTL test lives.)* | This is a **new pattern for the repo** — no `pub(crate)` test-only constructor exists today; the nearest precedent is the built-in test affordance "port 0 = ephemeral, for tests" (automation/server.rs). moka has an injectable `Clock`, but it is `pub(crate)` in moka itself — not available to us; and the repo's TTL-ish tests all sleep with tolerances (42 `sleep(from_millis)` calls across `crates/*/tests`). Without the seam, every TTL test sleeps >1 s. The clamp stays the only *public* path, so Java semantics hold for applications. Boundary rule for all TTL tests: assert presence only immediately after `put`, absence only well past TTL (≥ TTL + 300 ms) — never near the boundary. |
 
 ## 4. API surface (Java → Rust)
 
@@ -82,8 +87,9 @@ Java call sites are all connectors/mesh (`app.presence.list`, `sticky.destinatio
 // crates/platform-core/src/util/managed_cache.rs
 //! Rust port of org.platformlambda.core.util.ManagedCache — a named,
 //! self-expiring (expire-after-write), size-bounded in-memory cache with a
-//! process-wide registry. Engine: moka (Caffeine's Rust lineage), wrapped as
-//! an internal detail. [parity + divergence notes per §5]
+//! process-wide registry. Engine: moka (Caffeine's Rust lineage) built with
+//! EvictionPolicy::lru (deterministic eviction, maintainer ruling #3),
+//! wrapped as an internal detail. [parity + divergence notes per §5]
 
 pub type CacheValue = Arc<dyn Any + Send + Sync>;
 
@@ -123,7 +129,7 @@ pub fn start_housekeeping();             // idempotent; requires a Tokio runtime
 
 | Divergence | Direction | Note |
 |---|---|---|
-| Eviction policy under capacity pressure | moka TinyLFU vs Caffeine W-TinyLFU | Same lineage, both approximate; TinyLFU admission may reject a newcomer rather than evict. moka ≥0.12.5 also offers `EvictionPolicy::lru` if deterministic eviction is ever wanted. No in-scope consumer approaches `max_items`. |
+| Eviction policy under capacity pressure | **Rust = deterministic LRU (`EvictionPolicy::lru`, ruling #3) vs Java = Caffeine W-TinyLFU (frequency-based admission — a newcomer can lose to an older, hotter entry — plus deliberate HashDoS jitter: ~1/128 of losing candidates admitted via `ThreadLocalRandom`; no policy switch exists in Caffeine)** | Deliberate divergence in the Rust port's favor, ruled by the maintainer at the design gate. Source-verified: moka's LRU arm admits candidates unconditionally (no frequency sketch, no RNG anywhere in the path); sequential use + `run_pending_tasks()` is exactly reproducible. One honest caveat: under heavy concurrent load, read-recency events ride a bounded buffer and can be dropped — the LRU *ordering* may under-count reads, but eviction stays admission-free and RNG-free. The Java side's non-determinism is confirmed and a refactoring note was handed to the mercury-composable session (2026-07-27, via the cross-repo `/tmp` handoff channel — ephemeral by design; its substance is this row plus the Java options: accept + document, or leave Caffeine for Guava `concurrencyLevel(1)` / a synchronized access-order `LinkedHashMap`). No in-scope consumer approaches `max_items` either way. |
 | `getMap()` live view → `entries()` snapshot | safe | Rust hands out no live guard; introspection-only surface. |
 | Housekeeper start: first-create (Java) → lifecycle (`app_starter`) | behavioral no-op | Correctness never depends on the sweep in either engine; bare tests call `clean_up()`. |
 | `getCacheCollection()` live map → sorted snapshot | safe | Determinism convention. |
@@ -189,11 +195,13 @@ In-module unit tests: put/get/exists/remove/clear round-trip incl. `get_as` down
 wrong-type `None` + the **wrong-wrap regression** (`put(key, Arc<T>)` ⇒ `get_as::<T>()`
 is `None`, `get_as::<Arc<T>>()` hits — pins the MC2 doc warning); empty-key no-ops;
 floor clamp (`create_cache(n, 500)` ⇒ `expiry_ms() == 1000`) + ceiling clamp doesn't
-panic (`u64::MAX`); TTL expiry via the crate-private fast constructor (present
+panic (`u64::MAX`); TTL expiry via the `#[cfg(test)]` fast constructor (present
 immediately after put; `None` well past TTL — lazy, no housekeeper); TTL reset-on-update
 (re-`put` extends life — the anchored-window primitive); bound holds (`max_items = 3`,
-insert 4 ⇒ `size() <= 3` after `clean_up()`; **neither victim nor survivor set
-asserted** — TinyLFU admission may reject the newcomer); create-idempotency
+insert 4 sequentially ⇒ `size() <= 3` after `clean_up()`, **and — under ruling #3's LRU
+policy — the victim IS asserted: the least-recently-used entry is gone, the newest is
+present** (sequential single-threaded access, so the recorded access order is exact));
+create-idempotency
 (`Arc::ptr_eq`, second call's params ignored — Java semantics); registry (`get_instance`
 Some/None, sorted collection); telemetry stamps per the §2 map (incl. `remove` on an
 absent key stamps `last_write`; `get` miss stamps `last_read`; `clear` seeds/stamps
@@ -202,13 +210,17 @@ absent key stamps `last_write`; `get` miss stamps `last_read`; `clear` seeds/sta
 (the repo's housekeeping-fn-not-loop pattern, e.g. `scan_expired_stores()` in
 lifecycle tests).
 
-## 8. Open questions for the gate
+## 8. Gate outcome (2026-07-27)
 
-1. **MC1 (engine = moka)** — confirm, given ruling #2's "adopt a proper implementation"
-   reading and the bus-factor-1 caveat. The wrapper keeps it swappable either way.
-2. **Adopter scope** — actuator `health.info` cache (§6.2) in this increment
-   (recommended: yes, own commit + parity note)? The optional §6.3 test-fixture
-   adoption too, or keep the increment minimal?
-3. **MC8** — is the crate-private unclamped constructor acceptable for fast TTL tests?
-   It is a new pattern for this repo (nearest precedent: "port 0 = ephemeral, for
-   tests"). Rejecting it means >1 s sleeps in every TTL test.
+All three questions answered by the maintainer at the gate:
+
+1. **MC1 (engine = moka)** — **CONFIRMED**, with ruling #3 added: build with
+   `eviction_policy(EvictionPolicy::lru())` for deterministic eviction.
+2. **Adopter scope** — **all three adopters** (§6.1 WS dedup, §6.2 actuator info-lookup
+   cache, §6.3 event-script test fixture).
+3. **MC8 (crate-private fast-TTL test constructor)** — **APPROVED** (implemented
+   strictly narrower: `#[cfg(test)]` module-private — see the MC8 row).
+
+Follow-up filed with the gate: verify whether Java's Caffeine-backed `ManagedCache` has
+the same non-deterministic eviction (it does — W-TinyLFU admission, no policy switch)
+and leave a refactoring note for the mercury-composable team.

--- a/docs/design/platform-core-port.md
+++ b/docs/design/platform-core-port.md
@@ -504,8 +504,9 @@ default-endpoint merge + the static-content behavior:
   extension (minimal `MimeTypeResolver` analog). A `/` entry in rest.yaml always wins.
 - **Deferred:** `/info/lib` (maintainer-approved — Java reads the JAR manifest at runtime;
   a Rust binary has no runtime dependency manifest; a `build.rs`-embedded cargo metadata
-  could provide it later), `/info/routes`, XML responses, etag/cache headers,
-  `mime-types.yml` customization, the Java per-route info cache.
+  could provide it later), XML responses, `mime-types.yml` customization. *(Since shipped:
+  etag/cache headers — increment 8; `/info/routes` — the v4.10.6 typed-AsyncHttpRequest
+  arc; the Java per-route info cache — increment 71, `ManagedCache("health.info")`.)*
 
 **Tests:** 10 end-to-end (info identity/uptime, env opt-in-only exposure, liveness default,
 health no-deps hint, health UP with mandatory dep (info-merge asserted), health DOWN → 400 +
@@ -683,13 +684,14 @@ Broadcast delivery · streams (`Flux`/`Mono` → Rust `Stream`) · kernel-thread
 (`spawn_blocking` pool) · Event-over-HTTP · an OTLP forwarder extension (the
 `distributed.trace.forwarder` hook is ready) · trace annotations on the envelope wire ·
 full envelope fields · `yaml.preload.override` · `Utility` grab-bag (ported piecemeal as
-callers need it) · crypto/caches · a lightweight dedicated RPC inbox (Java `AsyncInbox`
+callers need it) · crypto · a lightweight dedicated RPC inbox (Java `AsyncInbox`
 parity). Each becomes
 its own Design increment tracing to `bp-platform-core`. *(Shipped: elastic overflow buffer — increment 3, §5b; lifecycle — §5c; telemetry — §5d;
 REST automation — §5e; actuators/static — §5f; static-content protocol — §5g; RPC inbox +
 benchmark — §5h; annotation macros + `AutoStart` one-liner + OS-signal shutdown — §5i;
 event-interceptor mode + scheduled events (`send_later`/cancel) + rest.yaml `flow:` binding —
-event-script design E-3, `event-script-port.md` §5c.)*
+event-script design E-3, `event-script-port.md` §5c; the cache utility — increment 71,
+`ManagedCache`, design `managed-cache-port.md`.)*
 
 ## 8. Open questions for the maintainer
 

--- a/docs/guides/actuators-and-http-client.md
+++ b/docs/guides/actuators-and-http-client.md
@@ -82,8 +82,11 @@ optional.health.dependencies: 'other.service.health'
 Each listed route is called twice: header `type=info` (3-second timeout, advisory — whatever
 map the service returns is merged into its dependency entry, typically `service` and `href`),
 then header `type=health` (10-second timeout, decisive — any status ≥ 400 marks the dependency
-down). The response lists every dependency with its `route`, `required` flag, `status_code`,
-and message. The overall verdict:
+down). The `type=info` lookup is cached for 5 seconds per dependency (Java parity: the
+`health.info` cache in `ActuatorServices`; only a map response is cached), so frequent health
+probes do not re-interrogate every dependency for its static identity — the `type=health`
+probe itself always runs and is never cached. The response lists every dependency with its
+`route`, `required` flag, `status_code`, and message. The overall verdict:
 
 - all mandatory dependencies up → `"status": "UP"` with HTTP **200**;
 - any mandatory dependency down → `"status": "DOWN"` with HTTP **400**.

--- a/docs/guides/api-overview.md
+++ b/docs/guides/api-overview.md
@@ -280,6 +280,37 @@ assert_eq!("profile not found", err.message());
 Returning `Err(AppError)` from a function becomes an error reply (`status >= 400`) to the
 caller; on a fire-and-forget delivery it is logged instead.
 
+## Utility: `ManagedCache`
+
+The Java `ManagedCache` ported (design record: `docs/design/managed-cache-port.md`) — a
+named, **self-expiring** (expire-after-write), **size-bounded** in-memory cache with a
+process-wide registry. The engine (moka, Caffeine's Rust lineage) is an internal detail;
+eviction under capacity pressure is **deterministic LRU** — a deliberate, documented
+improvement over the Java original's approximate W-TinyLFU.
+
+```rust
+use platform_core::ManagedCache;
+
+// idempotent by name — the first creation's parameters win
+let cache = ManagedCache::create_cache("my.cache", 5000);              // TTL ms (min 1000), max 2000 items
+let sized = ManagedCache::create_cache_with_limit("big.cache", 60_000, 10_000);
+
+cache.put("key", MyStruct { .. });                 // any Any + Send + Sync value
+let value = cache.get_as::<MyStruct>("key");       // Option<Arc<MyStruct>> — None if absent or wrong type
+let exists = cache.exists("key");
+cache.remove("key");
+cache.clear();
+
+let same = ManagedCache::get_instance("my.cache"); // resolve by name from any module
+let all = ManagedCache::get_cache_collection();    // sorted snapshot for introspection
+```
+
+Values are type-erased `Arc` handles (the Rust carrier of Java's `Object` reference
+semantics) — store one value shape per named cache. For a value that is *already* an
+`Arc`, use `put_arc` (passing an `Arc` to `put` would nest it and `get_as` would miss).
+Expired entries are reclaimed lazily on access plus a 10-minute housekeeper the
+application lifecycle starts automatically; correctness never depends on the sweep.
+
 ---
 
 *Adapted from the mercury-composable guide `docs/guides/api-overview.md`; keys/APIs enumerated from this repository's source.*


### PR DESCRIPTION
## What

Ports `org.platformlambda.core.util.ManagedCache` per the maintainer-gated design
([docs/design/managed-cache-port.md](https://github.com/Accenture/mercury/blob/feature/managed-cache/docs/design/managed-cache-port.md)):
a named, self-expiring (expire-after-write, 1 s floor), size-bounded (default 2000) cache
with a process-wide registry and a lifecycle-wired 10-minute housekeeper, exposed as
`platform_core::{ManagedCache, CacheValue}`. The engine is moka (Caffeine's Rust lineage),
wrapped as an internal detail and built with **deterministic LRU eviction**
(`EvictionPolicy::lru`) — newcomers always admitted, the least-recently-used entry always
the victim. Values are type-erased `Arc<dyn Any + Send + Sync>` handles (the Rust carrier
of Java's `Object` reference semantics) with a typed `get_as::<T>()`.

Three adopters land with the module:

- the Playground WS duplicate-command suppression (`last.ws.message`, 1 s — now bounded,
  self-expiring, and **anchored** like Java's window instead of sliding),
- the actuator's per-dependency `type=info` lookup cache (`health.info`, 5 s, map bodies
  only — the `type=health` probe and the `/health` result are never cached, Java parity),
- the event-script `ExternalStateMachine` test fixture (`state.machine`, 10 s, restored to
  the Java fixture's singleton semantics).

`elapsed_time` is now an exact `Utility.elapsedTime` port shared by `/info` uptime and the
create-cache log. Workspace 287 tests (273+14) / clippy 0 / fmt.

## Why

Four maintainer rulings shape the design: ONE cache type (`SimpleCache` is deliberately
not ported — any Java `SimpleCache` site maps onto a `ManagedCache` instance); adopt a
proper self-expiring implementation rather than hand-rolling; all three adopters in scope;
and **deterministic eviction** — Java Caffeine's W-TinyLFU is non-deterministic by design
(frequency-based admission plus deliberate HashDoS jitter, no policy switch), so the Rust
port opts into moka's plain LRU as a documented divergence in its favor, with a
refactoring note handed to the mercury-composable team.

The utility closes a Java-API-surface gap, fixes two real behaviors (the WS dedup sliding
window let a continuous duplicate stream suppress commands forever; the dedup map leaked
one entry per session route), and is the prerequisite for the future connectors port —
minimalist-kafka's schema-registry client is a heavy `ManagedCache` consumer whose
constructor-injected handles and parsed-schema values drove the `Arc` registry returns and
the `Any` carrier.

Co-Authored-By: Claude Code <noreply@anthropic.com>