### PR TITLE
Fold the Background tab into the Reference tab

### DIFF
--- a/memory/sessions/2026-07-30-043508.md
+++ b/memory/sessions/2026-07-30-043508.md
@@ -18,6 +18,11 @@ mandatory CompileGraph gate, minigraph-state-redis, tutorial-14, docs,
 interop evidence, cid-trim + 8085 port sync) is now on both mains awaiting
 that release.
 
+Also: pre-release docs touch-up (lightweight) — the top-level 'Background'
+nav tab folded into 'Reference' (Port Scope & Fidelity + Architecture
+Decisions as flat entries, Java-nav-consolidation parity with eb68872f;
+branch docs/nav-consolidation). Docs gates clean.
+
 ## Memory References
 
 - thread-graph-suspend-resume-p5 (closed thread extended: report/touch-up branch merged as PR #187)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,5 @@ nav:
       - "Interop Test Report (Java ⇄ Rust)": test-reports/event-over-http-interop.md
       - "Interop Test Report — Suspend/Resume": test-reports/suspend-resume-interop.md
       - "AI Companion Test Report": test-reports/AI-companion-test.md
-  - Background:
       - Port Scope & Fidelity: background/port-scope.md
       - Architecture Decisions: arch-decisions/ADR.md


### PR DESCRIPTION
## What

The top-level Background tab's two pages — Port Scope & Fidelity and Architecture
Decisions — move into the Reference section as regular entries at its tail. The tab row
shrinks by one; no page moves on disk, so existing links keep working. Docs gates clean
(nav-path resolution, both pages reachable).

## Why

Cross-repo consistency with the Java documentation site, which folded its Code and
Documentation Conventions tabs into Reference in the twin PR after the tab row exceeded
the screen's real estate. Pre-release docs polish for v4.11.0.

Co-Authored-By: Claude Code <noreply@anthropic.com>