### PR TITLE
Release 4.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
-## Unreleased
+## Version 4.11.0, 7/30/2026
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.10.6"
+version = "4.11.0"
 dependencies = [
  "async-trait",
  "log",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "event-script"
-version = "4.10.6"
+version = "4.11.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "event-script-macros"
-version = "4.10.6"
+version = "4.11.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -467,7 +467,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.10.6"
+version = "4.11.0"
 dependencies = [
  "async-trait",
  "event-script",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.10.6"
+version = "4.11.0"
 dependencies = [
  "async-trait",
  "log",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph"
-version = "4.10.6"
+version = "4.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph-macros"
-version = "4.10.6"
+version = "4.11.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -798,7 +798,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minigraph-playground"
-version = "4.10.6"
+version = "4.11.0"
 dependencies = [
  "async-trait",
  "event-script",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "minigraph-state-redis"
-version = "4.10.6"
+version = "4.11.0"
 dependencies = [
  "async-trait",
  "log",
@@ -985,7 +985,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "platform-core"
-version = "4.10.6"
+version = "4.11.0"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macros"
-version = "4.10.6"
+version = "4.11.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.10.6"
+version = "4.11.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury-composable"

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -13,9 +13,9 @@
 ## Project State
 
 - **project:** mercury
-- **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), delivered bottom-up; all three in-scope layers (platform-core, event-script, active knowledge graph + Playground) ported and milestone-closed, **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs at accenture.github.io/mercury; regular PR process). Kafka service mesh + Spring out of scope. Current release **v4.10.6** (version tracks the Java line, contents by design). History/detail lives in `docs/INCREMENTS.md` (increment ledger), `docs/design/`, session logs, and CHANGELOG — not this line.
+- **status:** **Rust port of `mercury-composable`** (canonical Java v4.8.6), delivered bottom-up; all three in-scope layers (platform-core, event-script, active knowledge graph + Playground) ported and milestone-closed, **GRADUATED to github.com/Accenture/mercury 2026-07-20** (docs at accenture.github.io/mercury; regular PR process). Kafka service mesh + Spring out of scope. Current release **v4.11.0** (version tracks the Java line, contents by design). History/detail lives in `docs/INCREMENTS.md` (increment ledger), `docs/design/`, session logs, and CHANGELOG — not this line.
 - **last_enabled:** 2026-07-15
-- **last_session:** 2026-07-30 | agent: Claude Code (2026-07-30-043508)
+- **last_session:** 2026-07-30 | agent: Claude Code (2026-07-30-172823)
 - **last_review:** 2026-07-30 | through 2026-07-30-011111.md
 - **last_invariant_check:** 2026-07-26 | 2026-07-26-014908.md (all five confirmed against live code; two header drifts remedied; ui-fixture carve-out RATIFIED by Eric 2026-07-26)
 - **repo:** github.com/Accenture/mercury (official home; graduated 2026-07-20 from the private R&D repo acn-ericlaw/mercury)
@@ -156,6 +156,19 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
 
 > Mark completed items `- [x]` and leave them in place — the review sweeps them to
 > the archive once older than `archive_window` sessions. Don't archive them by hand.
+
+- [ ] (release in flight — 2026-07-30) **v4.11.0 release prep, lock-step with the Java
+  repo (Eric's plan; the suspend/resume feature release).** Contents this side: the
+  complete suspend/resume arc (PR #186), the interop report + cid trim + 8085 port sync
+  (PR #187), the nav consolidation (PR #188), plus the ManagedCache port + health-info
+  cache + WS-dedup/up_time fixes that rode Unreleased since 4.10.6. Sweep 4.10.6→4.11.0:
+  root Cargo.toml `[workspace.package]` (count-asserted single occurrence, no substring
+  hazards), lockfile regenerated (11 members at 4.11.0, zero at 4.10.6), continuity
+  status line; CHANGELOG Unreleased → `## Version 4.11.0, 7/30/2026`. Branch
+  `chore/release-4.11.0`, NOT pushed — Eric gates push/PR/tag (verify the tag lands on
+  the verified merge commit — the 4.10.2 tag-race lesson). Java side: 33 poms swept,
+  skipTests hardcode removed from 26 poms. Close when tagged + published both repos.
+  <!-- id: thread-release-4-11-0 | created: 2026-07-30 | last_used: 2026-07-30 | uses: 1 | tier: working | origin: 2026-07-30-172823.md -->
 
 - [x] (feature — 2026-07-29; **MERGED 2026-07-30 as
   [PR #186](https://github.com/Accenture/mercury/pull/186), merge commit `d2791b09`

--- a/memory/sessions/2026-07-30-172823.md
+++ b/memory/sessions/2026-07-30-172823.md
@@ -1,0 +1,35 @@
+# Session (2026-07-30T17:28:23.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**v4.11.0 release prep on branch `chore/release-4.11.0` (NOT pushed — Eric
+gates), lock-step with the Java repo's release today (7/30/2026 PT).**
+
+- **Sweep 4.10.6 → 4.11.0**: root `Cargo.toml` `[workspace.package]` is the
+  single live version carrier (count-asserted exactly one occurrence — no
+  substring hazards, the 4.8.2 lesson checked); lockfile regenerated (all 11
+  workspace members read 4.11.0, zero remain at 4.10.6); the continuity
+  status line updated per the sweep convention.
+- **CHANGELOG**: `## Unreleased` → `## Version 4.11.0, 7/30/2026` (the
+  repo's heading format). Contents: the suspend/resume feature arc (#186),
+  the interop report + cid trim + port sync (#187), the nav consolidation
+  (#188), plus the ManagedCache port, the /health info cache, and the
+  WS-dedup/up_time fixes riding Unreleased since 4.10.6.
+- **Gates at the release version**: full workspace tests + clippy + fmt
+  (result recorded at commit time), docs gates clean (mkdocs parse, nav
+  sweep, CHANGELOG headings).
+- Release-notes draft handed to the coordinator (feature-release framing:
+  workflow suspension in lock-step, the mandatory CompileGraph gate,
+  minigraph-state-redis, tutorial-14, the cross-engine interop evidence as
+  release proof).
+
+Java side at prep time: 33 poms swept, the hardcoded skipTests removed from
+26 poms, CHANGELOG dated, release-gate reactor running.
+
+## Memory References
+
+- thread-release-4-11-0 (created — the lock-step release thread)
+- thread-graph-suspend-resume-p5 (referenced: the release ships the arc)
+- conventions-rust-baseline (referenced: sweep/gate conventions)


### PR DESCRIPTION
## What

The v4.11.0 release preparation, in lock-step with the Rust engine's v4.11.0:

- Version sweep 4.10.6 → 4.11.0 across all 33 poms (including the new
  `extensions/minigraph-state-redis` module).
- **`mvn -DskipTests` works again**: every module's pom carried a hardcoded
  `<skipTests>false</skipTests>` in its surefire configuration, which silently
  overrides the command-line property — a developer's quick build still ran the full
  test suite. The element is removed from all 26 poms (the surefire 3.5.3 pin stays;
  the two poms with `environmentVariables` keep their remaining configuration). A full
  quick build of the 29-module reactor now takes ~34 seconds. CI is unaffected — it
  runs `mvn verify` without the flag.
- CHANGELOG: the Unreleased section is dated as **Version 4.11.0, 7/30/2026**, and
  completed with the business-cid trim and the cross-engine validation evidence.

## Why

4.11.0 is the workflow-suspension feature release: suspend/resume for the Active
Knowledge Graph (#238/#239), the production-polish round with CompileGraph as the
mandatory deployment gate (#240, ADR-0011), the docs and tutorial refresh (#241), the
reciprocal hardening pin (#242), the cross-engine interop report with the cid-trim
normalization (#243), and the consolidated docs navigation (#244) — released in
lock-step with the Rust engine so the identical feature surface ships on both. The
release gate passed before this PR: full reactor with tests at 4.11.0, the grammar
catalog check, and mkdocs --strict.

Co-Authored-By: Claude Code <noreply@anthropic.com>