### PR TITLE
Docs-site parity: Release Notes link and the Java-consistent home footer

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,19 +49,37 @@ Application Development**, on a lightweight, fast foundation
 (tokio instead of virtual threads, compile-time registration instead of classpath scanning,
 no Kafka service mesh, no Spring).
 
-## Where to go next
+## Explore the docs
 
-- **[Getting Started](guides/getting-started.md)** — build the workspace and run the examples.
-- **[Architecture](guides/architecture.md)** — how the pieces fit, from the actor model up.
-- **Pick your layer:** [event-driven functions](guides/event-driven/index.md) ·
-  [Event Script flows](guides/event-script/index.md) ·
-  [the knowledge graph](guides/knowledge-graph/index.md).
+- **Get started** — [Getting Started](guides/getting-started.md)
+- **Guides** — [Event-driven Functions](guides/event-driven/index.md) ·
+  [Event Script Flows](guides/event-script/index.md) ·
+  [REST Automation](guides/rest-automation.md) · [Event over HTTP](guides/event-over-http.md) ·
+  [Observability](guides/observability.md)
+- **Knowledge Graph** — [Knowledge Graph as Application](guides/knowledge-graph/index.md) ·
+  [Build Your First Graph](guides/knowledge-graph/build-your-first-graph.md) ·
+  [Workflow Suspension](guides/knowledge-graph/workflow-suspension.md) ·
+  [Playground & AI Companion](guides/knowledge-graph/playground-and-companion.md)
+- **Concepts** — [Methodology](guides/methodology.md) · [Architecture Overview](guides/architecture.md) ·
+  [Port Scope & Fidelity](background/port-scope.md) ·
+  [Architecture Decision Records](arch-decisions/ADR.md)
+- **Reference** — [Macros](guides/macros-reference.md) ·
+  [Configuration](guides/configuration-reference.md) · [Event Envelope](guides/event-envelope-reference.md) ·
+  [Flow Schema](guides/flow-schema-reference.md) · [API Overview](guides/api-overview.md)
 - **AI agents** start at [`docs/llms.txt`](llms.txt) — the machine-readable map of the
   agent-optimized documentation set (engine-verified; a fresh agent can build graphs from it
   with zero out-of-band context). Every layer section carries its own AI agent guide.
-- **[Port Scope & Fidelity](background/port-scope.md)** — what is ported, what deliberately
-  is not, and how fidelity is kept honest.
-- **[Architecture Decisions](arch-decisions/ADR.md)** — the durable design record.
+
+## Project
+
+- **Source:** [github.com/Accenture/mercury](https://github.com/Accenture/mercury)
+- **Release notes:** [CHANGELOG](https://github.com/Accenture/mercury/blob/main/CHANGELOG.md)
+- **Contributing:** [CONTRIBUTING](https://github.com/Accenture/mercury/blob/main/CONTRIBUTING.md)
+  · [Code of Conduct](https://github.com/Accenture/mercury/blob/main/CODE_OF_CONDUCT.md)
+- **Java version:** Mercury's canonical Java implementation — same three layers, same flow
+  YAML, behavior-synced with this engine:
+  [github.com/Accenture/mercury-composable](https://github.com/Accenture/mercury-composable)
+  · [documentation](https://accenture.github.io/mercury-composable/)
 
 !!! note "Rust port"
     Throughout this site, boxes like this mark the places where the Rust port deliberately

--- a/memory/sessions/2026-07-30-174606.md
+++ b/memory/sessions/2026-07-30-174606.md
@@ -21,6 +21,18 @@ is an ancestor of the merge — the 4.10.2 tag-race lesson applied.
   evidence as release proof, the trim/8085 lock-step notes, and the
   also-in-this-release items). Thread closes when published on both repos.
 
+Also: post-tag docs gap fix (lightweight, Eric's publication-time spots) —
+the Reference nav gained the external "Release Notes" CHANGELOG link; the
+home page gained the Java-parity "Project" block (Source / Release notes /
+Contributing / Code of Conduct, this repo's URLs; target files verified)
+plus the cross-engine "Java version:" line (the twin of Java's "Rust
+version" line, pointing at mercury-composable + its docs site); and the
+"Where to go next" section was restructured into the Java footer's
+"Explore the docs" cluster form (Get started / Guides / Knowledge Graph /
+Concepts / Reference / AI agents — the llms.txt line and Port Scope &
+Fidelity folded in, not dropped). Branch docs/release-notes-link; docs
+gates clean incl. every home-page relative link.
+
 ## Memory References
 
 - thread-release-4-11-0 (closed: tagged on the verified merge commit; publication pending Eric)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,3 +141,4 @@ nav:
       - "AI Companion Test Report": test-reports/AI-companion-test.md
       - Port Scope & Fidelity: background/port-scope.md
       - Architecture Decisions: arch-decisions/ADR.md
+      - Release Notes: https://github.com/Accenture/mercury/blob/main/CHANGELOG.md


### PR DESCRIPTION
## What

- The Reference nav gains the external **Release Notes** link to this repo's CHANGELOG
  on GitHub — the entry the Java docs site already had.
- The home page's tail is restructured to the Java site's two-section footer: **"Explore
  the docs"** (bold-labeled link clusters — Get started / Guides / Knowledge Graph with
  Workflow Suspension featured / Concepts with Port Scope & Fidelity / Reference / the
  AI-agents `llms.txt` entry), replacing the old "Where to go next" form, and a
  **"Project"** block (Source / Release notes / Contributing · Code of Conduct) closing
  with the cross-engine twin line — **"Java version:"** pointing at mercury-composable
  and its documentation site, the exact mirror of the Java home's "Rust version" line.

Every relative link on the page is verified to resolve; docs gates clean.

## Why

The two documentation sites are one product surface for a polyglot audience — the
release-notes entry and the footer structure should read identically on both, and each
site should point at the other the same way. Per the release rule, the v4.11.0 tag will
be moved onto this PR's merge commit before publication so the released docs are
complete on both engines.

Co-Authored-By: Claude Code <noreply@anthropic.com>