### PR TITLE
Release v4.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
-## Unreleased
+## Version 4.11.1, 8/1/2026
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.11.0"
+version = "4.11.1"
 dependencies = [
  "async-trait",
  "log",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "event-script"
-version = "4.11.0"
+version = "4.11.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "event-script-macros"
-version = "4.11.0"
+version = "4.11.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -467,7 +467,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.11.0"
+version = "4.11.1"
 dependencies = [
  "async-trait",
  "event-script",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.11.0"
+version = "4.11.1"
 dependencies = [
  "async-trait",
  "log",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph"
-version = "4.11.0"
+version = "4.11.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph-macros"
-version = "4.11.0"
+version = "4.11.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -798,7 +798,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minigraph-playground"
-version = "4.11.0"
+version = "4.11.1"
 dependencies = [
  "async-trait",
  "event-script",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "minigraph-state-redis"
-version = "4.11.0"
+version = "4.11.1"
 dependencies = [
  "async-trait",
  "log",
@@ -985,7 +985,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "platform-core"
-version = "4.11.0"
+version = "4.11.1"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macros"
-version = "4.11.0"
+version = "4.11.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.11.0"
+version = "4.11.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury-composable"


### PR DESCRIPTION
## What

The v4.11.1 release: the workspace version bump (`4.11.0` → `4.11.1`, one
`workspace.package` line plus the lock file) and the CHANGELOG cut to
`Version 4.11.1, 8/1/2026`. No code changes — everything below merged and
CI-validated in #191:

- **Version-aware Redis consume** for the suspend/resume state store: native `GETDEL`
  on Redis 6.2+, an equally atomic `MULTI/EXEC` `GET`+`DEL` transaction on older
  servers (field report; at-most-once resume holds on both paths).
- **Task-level `ttl` override** for catchable sub-flow timeouts, the honored sub-flow
  `delay` with teardown cancellation, **graph node `ttl`** on the three calling skills,
  and **model-metadata immutability** at the gate, the pre-run check, and runtime.
- **Dry-run run-level watcher** with exactly-one-terminal arbitration, the honest
  companion drain (`ok:false` on truncation), the fetcher `x-ttl` wire alignment, and
  **end-to-end deadline propagation** with Java's exact ceil-to-seconds derivation.

## Why

This restores lock-step with the Java engine's v4.11.1 on the deadline/TTL surface —
regression-critical field-core for the suspend/resume installations — so a mixed
Java/Rust fleet carries identical semantics: the same catchable-timeout grammar, the
same immutability rules, and the same `Flow timeout for N ms` values for the same wire
request on either engine.

**Verification:** all 58 workspace suites green at the new version; clippy and fmt
clean on the merged content (Increments 76–80).

---

Co-Authored-By: Claude Code <noreply@anthropic.com>