### PR TITLE
Release v4.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
-## Unreleased
+## Version 4.11.4, 8/7/2026
+
+> Versions 4.11.2 and 4.11.3 were Java-only releases (the Kafka client/dependency
+> surface this port does not carry); this port's version tracks the Java line.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.11.1"
+version = "4.11.4"
 dependencies = [
  "async-trait",
  "log",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "event-script"
-version = "4.11.1"
+version = "4.11.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "event-script-macros"
-version = "4.11.1"
+version = "4.11.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -467,7 +467,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.11.1"
+version = "4.11.4"
 dependencies = [
  "async-trait",
  "event-script",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.11.1"
+version = "4.11.4"
 dependencies = [
  "async-trait",
  "log",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph"
-version = "4.11.1"
+version = "4.11.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph-macros"
-version = "4.11.1"
+version = "4.11.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -798,7 +798,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minigraph-playground"
-version = "4.11.1"
+version = "4.11.4"
 dependencies = [
  "async-trait",
  "event-script",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "minigraph-state-redis"
-version = "4.11.1"
+version = "4.11.4"
 dependencies = [
  "async-trait",
  "log",
@@ -985,7 +985,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "platform-core"
-version = "4.11.1"
+version = "4.11.4"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macros"
-version = "4.11.1"
+version = "4.11.4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.11.1"
+version = "4.11.4"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury-composable"


### PR DESCRIPTION
## What

Workspace version bump 4.11.1 → 4.11.4 with the Cargo.lock refresh and the CHANGELOG
cut for 8/7/2026 (4.11.2/4.11.3 were Java-only releases; this port's version tracks
the Java line). This release ships the suspend/resume rationalization in lock-step
with the Java reference engine (this port's ADR-0011): edge/jump suspension modes
replace the retired `suspend=true` property with a deprecation window, plus the
remodeled tutorial-14, the rewritten grammar surface, and the webapp replaced from
the Java repo's latest UI source.

## Why

The suspend/resume surface is field-core and regression-critical on both engines, so
the grammar change ships at the same version on both. Pre-release gate: workspace 58
test suites green, fmt clean, clippy 0.

Co-Authored-By: Claude Code <noreply@anthropic.com>