### PR TITLE
graph.task model.* staging, tutorial-13 as an HTTP client by configuration, default Accept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,50 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
+## Unreleased
+
+### Added
+
+1. **The async HTTP client sends a default `Accept: */*` when the caller gives none**
+   (maintainer ruling — best practice and Java parity: the Java engine's reactor-netty
+   client does this implicitly). The REST edge negotiates the response content-type from
+   the Accept header, so without the default the same request decoded JSON on the Java
+   engine and returned raw bytes here. An explicit accept is never overridden; pinned by
+   a wire-echo test for both cases.
+
+### Fixed
+
+1. **`graph.task` input mapping now supports `model.{key}` staging targets, restoring Event
+   Script parity for dynamic variables** (lock-step mirror of the Java reference engine's
+   PR #267). An `input[]` entry whose RHS starts with `model.` stages a variable in the
+   graph's state machine — instead of silently landing in the request body under a literal
+   `model` key — so a later entry can reference it as a dynamic variable, e.g.
+   `input.body.person_id -> model.person_id` followed by
+   `text(/api/mdm/profile/{model.person_id}) -> url`. This matches the `graph.api.fetcher`
+   and `graph.extension` input mappings, which already supported it. Engine-managed model
+   metadata remains immutable: the CompileGraph gate and the playground pre-run check reject
+   a reserved target at validation time, and the new runtime path calls the same shared
+   guard.
+
+### Changed
+
+1. **tutorial-13 now invokes the platform's AsyncHttpClient (`async.http.request`) instead of
+   a throwaway demo function.** The `graph.task` tutorial becomes a worked example of an HTTP
+   client by configuration: the input mapping stages `model.person_id` from the request body,
+   resolves it as a dynamic variable inside the `url`, uses `${rest.server.port:8080}`
+   environment/config substitution in the `host` — resolved when the model is loaded (at
+   deployment compile and at `instantiate graph` for a dry-run) while the authored and
+   exported model keeps the placeholder — and sets the HTTP timeout explicitly with
+   `text(5000) -> headers.x-ttl` (milliseconds): the graph's ttl bounds only the event call
+   to the function, so the `X-TTL` request header is the sanctioned way to give the HTTP
+   operation its own budget, and it propagates the deadline on the wire. The tutorial also
+   declares `headers.accept` explicitly as best practice — the probe that surfaced the
+   client-default divergence resolved by the new default Accept above. The `v1.hello.task`
+   demo mock is removed; the tutorial help, `graph.task` skill help, skills reference, the
+   AI grammar (`minigraph-commands.json`) and the HTTP-client guide are updated to teach the
+   staging, substitution and X-TTL idioms.
+
+---
 ## Version 4.11.4, 8/7/2026
 
 > Versions 4.11.2 and 4.11.3 were Java-only releases (the Kafka client/dependency

--- a/crates/knowledge-graph/resources/graph/tutorial-13.json
+++ b/crates/knowledge-graph/resources/graph/tutorial-13.json
@@ -13,15 +13,19 @@
       ],
       "alias": "hello-task",
       "properties": {
-        "task": "v1.hello.task",
+        "task": "async.http.request",
         "input": [
-          "input.body -> *",
-          "text(minigraph) -> header.x-app"
+          "input.body.person_id -> model.person_id",
+          "text(http://127.0.0.1:${rest.server.port:8080}) -> host",
+          "text(/api/mdm/profile/{model.person_id}) -> url",
+          "text(GET) -> method",
+          "text(application/json) -> headers.accept",
+          "text(5000) -> headers.x-ttl"
         ],
         "output": [
           "result -> output.body"
         ],
-        "purpose": "Invoke the composable function v1.hello.task with the request body and a custom header",
+        "purpose": "Invoke AsyncHttpClient with route 'async.http.request' to fetch a user profile",
         "skill": "graph.task"
       }
     },

--- a/crates/knowledge-graph/resources/help/help graph-task.md
+++ b/crates/knowledge-graph/resources/help/help graph-task.md
@@ -1,96 +1,115 @@
 Skill: Graph Task
 -----------------
-Invokes a composable function through its route name and collects the
-function's response into the node's "result" property. This is the
-lightweight way to plug a small piece of custom business logic into a graph:
-your own function becomes, in effect, a custom skill. For multi-step
-orchestration, prefer a sub-graph or an Event Script flow via graph.extension
-(see 'help graph-extension').
+When a node is configured with this skill of "graph task", it will invoke a composable function
+through its route name and collect the function's response into the "result" property of the node.
+In case of exception, the "status" and "error" fields will be set to the node's properties and the
+graph execution will stop unless an exception handler node is configured.
+
+A composable function is a TypedLambdaFunction registered using the PreLoad annotation. This provides
+a lightweight method to extend a knowledge graph's capability with a small piece of business logic,
+without writing a new skill - more complex business logic should be delegated to a flow extension
+or a subgraph using the "graph.extension" skill.
+
+Execution will start when the GraphExecutor reaches the node containing this skill.
 
 Route name
 ----------
 "graph.task"
 
+Setup
+-----
+To enable this skill for a node, set "skill=graph.task" as a property in a node.
+
+The following parameters are required in the properties of the node:
+
+1. task - the route name of the composable function to invoke
+2. input - one or more data mapping entries as input to the composable function
+
+The system uses the same syntax of Event Script for data mapping.
+
 Properties
 ----------
 ```
 skill=graph.task
-task={function-route}
-input[]={source} -> {target}
-output[]={source} -> {target}
+task=route.name.of.composable.function
+input[]={mapping of key-values from input, model or another node to the function's request}
+output[]={optional mapping of result set to one or more variables in the 'model.' or 'output.' namespace}
 ```
 
-- task (required) - the route name of a composable function registered in
-  this application.
-- input[] (optional) - maps values into the function's request; entries
-  apply IN ORDER (see below).
-- output[] (optional) - maps the function's result onward; the result always
-  lands at {node}.result regardless.
-
-Optional:
-
+Optional properties
+-------------------
 ```
-for_each[]={array-source} -> model.{var}   (iterate over a runtime list)
-concurrency={1-30}                         (parallel fan-out, default 3)
-exception={error-handler-node}             (jump on failure instead of abort)
+for_each[]={map an array parameter for iterative function execution}
+concurrency={controls parallel function calls for an "iterative task request". Default 3, max 30}
+exception={error-handler-node-name}
 ```
 
 Input data mapping
 ------------------
-input[] entries apply in order. The target addresses the function's request:
+source.composite.key -> target
 
-- "*" - the mapped value is MERGED into the whole request body. Because
-  entries apply in order, later entries can merge additional fields into a
-  body seeded with "*".
-- header.{name} - sets a request header of the function call.
-- any other key - sets that field in the request body (composite dot-bracket
-  keys supported).
+The source (LHS) can use a key-value from the `input.` namespace, the `model.` namespace, another
+node or a constant such as text(hello). The target (RHS) addresses the function's request:
 
-Sources are the usual mapping sources: input.*, model.*, another node,
-constants such as text(hello), or f:plugin(...) calls. If the function
-declares a typed (PoJo) input, the request body converts automatically at
-the function boundary.
+1. `*` - the LHS value becomes the whole request body (same as Event Script). Data mapping entries
+   are processed in order, so later entries can merge additional key-values into a request body
+   that was seeded with `*`.
+2. `header.{name}` - sets a request header of the function call
+3. `model.{key}` - stages a variable in the graph's state machine instead of the request body, so
+   that later entries can reference it as a **dynamic variable** (same as Event Script). e.g. after
+   `input.body.token -> model.token`, the entry `text(Bearer {model.token}) -> auth` resolves the
+   `{model.token}` reference. Engine-managed model metadata (model.cid, model.ttl, etc.) is
+   immutable - a mapping that targets it is rejected.
+4. any other composite key - a key-value in the request body
 
-Output data mapping
--------------------
-The function's response body is stored at {node}.result, the response status
-at {node}.status, and response headers at {node}.header. In output[]
-mappings, bare "result" is the WHOLE function result; result.{key} is a
-field of it (same rule as graph.extension):
-
+Example:
 ```
-output[]=result -> output.body
-output[]=result.total -> model.total
+input[]=input.body -> *
+input[]=input.header.hello -> header.hello
+input[]=input.body.amount -> amount
+input[]=input.body.person_id -> model.person_id
+input[]=text(/api/mdm/profile/{model.person_id}) -> url
 ```
+
+If the function is declared as a TypedLambdaFunction with a PoJo input class, the request body map
+is automatically converted to the PoJo at the function boundary.
+
+Result set
+----------
+Upon successful execution, the function's response body is stored in the "result" parameter, the
+response status in "status" and the response headers in "header" in the properties of the node.
+The optional output data mapping can copy them to the 'model.' or 'output.' namespace.
+
+Example:
+```
+output[]=result -> model.soap_request_payload
+```
+
+Timeout
+-------
+The function call uses the graph instance's time-to-live from "model.ttl" (default 30000 ms).
+
+This deadline bounds the event call to the composable function - it cannot reach inside a
+generic function. When the function has its own downstream timeout contract, express it in the
+input data mapping. For example, the AsyncHttpClient (async.http.request) takes its HTTP timeout
+from the "x-ttl" key-value under "headers" in milliseconds, e.g. `text(5000) -> headers.x-ttl`
+(see tutorial 13).
+
+Exception handling
+------------------
+If the function throws an exception (e.g. AppException with a status code) or the call times out,
+the "error" and "status" parameters of the node are set. When the node has an "exception" property,
+the graph jumps to that error handler node. Otherwise, the error is returned as the graph output.
 
 Example
 -------
 ```
-create node hello-task
+create node prepare-soap-request
 with type Task
 with properties
-skill=graph.task
-task=v1.hello.task
+task=v1.prepare.soap.request
 input[]=input.body -> *
-input[]=text(minigraph) -> header.x-app
-output[]=result -> output.body
+input[]=input.header.hello -> header.hello
+output[]=result -> model.soap_request_payload
+skill=graph.task
 ```
-
-Notes
------
-- The task route must exist at runtime, or the node fails fast.
-- A call is bounded by the graph instance's time-to-live (model.ttl,
-  default 30000 ms).
-- Failure routing: on a function error (or timeout), {node}.status and
-  {node}.error are set and the output[] mappings are skipped. With
-  exception={handler-node}, traversal jumps to the handler instead of
-  aborting; without it, the run aborts. The bounded-retry pattern is shown
-  under 'help graph-api-fetcher'.
-- for_each[]={array-source} -> model.{var} invokes the function once per
-  element of a runtime list (the source must resolve to a list; wire the
-  element in with an ordinary input[] mapping from model.{var}), with
-  bounded parallel fan-out (concurrency 1-30, default 3). The shared
-  iteration rules are under 'help graph-api-fetcher'.
-- Writing the composable function itself is a development task done in Rust
-  with the #[preload] attribute; from the Playground you only reference its
-  route name.

--- a/crates/knowledge-graph/resources/help/help tutorial 13.md
+++ b/crates/knowledge-graph/resources/help/help tutorial 13.md
@@ -1,22 +1,26 @@
 Tutorial 13
 -----------
-In this tutorial, you will create a graph model that invokes a composable function using the
-"graph.task" skill.
+In this session, you will create a graph model that invokes a composable function using the
+"graph.task" skill. The composable function is the AsyncHttpClient (route "async.http.request")
+provided by the platform-core module, turning the task node into an HTTP client by configuration.
 
 Pre-requisite
 -------------
-You would need some working knowledge of composable functions. A composable function is a struct
-implementing ComposableFunction, registered with the #[preload] attribute. For more details, see
-docs/guides/event-driven/ai-agent-guide.md in this repository (the composable-function authoring
-guide).
+You would need some working knowledge of composable functions. A composable function is a
+TypedLambdaFunction registered with the PreLoad annotation. For more details, please refer to the
+[Developer Guide](https://accenture.github.io/mercury-composable/).
 
 What is a task?
 ---------------
-A task is a node that invokes a composable function through its route name. MiniGraph is designed
-to be zero-code with built-in skills for data mapping, decision-making and API fetching. More
-complex business logic is delegated to a flow extension or a subgraph (tutorials 10 and 11). A
-task node sits in between: it provides a lightweight method to extend a knowledge graph's
-capability with a small piece of business logic, without writing a new skill.
+A task is a node that invokes a composable function through its route name. MiniGraph is designed to be
+zero-code with built-in skills for data mapping, decision-making and API fetching. More complex business
+logic is delegated to a flow extension or a subgraph (tutorials 10 and 11). A task node sits in between -
+it provides a lightweight method to extend a knowledge graph's capability with a small piece of business
+logic, without writing a new skill.
+
+In this tutorial, the "small piece of business logic" is not custom code at all - it is the framework's
+own AsyncHttpClient. Any function registered in the platform is callable by route name, so the task node
+can drive an HTTP call purely by configuration.
 
 Create the graph model
 ----------------------
@@ -36,11 +40,16 @@ Create the task node. The "task" property is the route name of the composable fu
 create node hello-task
 with type Task
 with properties
-task=v1.hello.task
-input[]=input.body -> *
-input[]=text(minigraph) -> header.x-app
+input[]=input.body.person_id -> model.person_id
+input[]=text(http://127.0.0.1:${rest.server.port:8080}) -> host
+input[]=text(/api/mdm/profile/{model.person_id}) -> url
+input[]=text(GET) -> method
+input[]=text(application/json) -> headers.accept
+input[]=text(5000) -> headers.x-ttl
 output[]=result -> output.body
+purpose=Invoke AsyncHttpClient with route 'async.http.request' to fetch a user profile
 skill=graph.task
+task=async.http.request
 ```
 
 Create the end node and connect the three nodes:
@@ -62,49 +71,50 @@ About the input data mapping
 ----------------------------
 The input data mapping follows the Event Script syntax and is applied in declaration order:
 
-1. `input.body -> *` maps the whole request body as the request body of the composable function.
-   Since data mapping entries are processed in order, later entries can merge additional
-   key-values into a request body that was seeded with `*`.
-2. `text(minigraph) -> header.x-app` sets a request header of the function call. You can also map
-   individual fields, e.g. `input.body.amount -> amount` would set one key-value in the request
-   body.
+1. `input.body.person_id -> model.person_id` stages a variable in the graph's state machine
+   (the `model.` namespace). It does not become part of the function's request - it is kept for
+   later entries to reference.
+2. `text(/api/mdm/profile/{model.person_id}) -> url` demonstrates a **dynamic variable**: the
+   `{model.person_id}` reference inside the text constant is substituted with the model value
+   staged by the earlier entry. This is the same idiom as Event Script's
+   `text(Bearer {model.token}) -> headers.Authorization`.
+3. `text(http://127.0.0.1:${rest.server.port:8080}) -> host` demonstrates **environment variable
+   substitution**. The `${name:default}` reference is resolved by the configuration system when the
+   model is loaded - at 'instantiate graph' for a dry-run and at deployment time for a deployed
+   model - so both lanes behave the same. The authored model (and any export) keeps the `${...}`
+   placeholder, making the model portable across environments.
+4. `text(application/json) -> headers.accept` declares the response type this client accepts.
+   Always declare it instead of relying on an HTTP library's implicit default - with an explicit
+   accept, the profile service replies with `content-type: application/json` and the
+   AsyncHttpClient decodes the response body into a map.
+5. `text(5000) -> headers.x-ttl` sets the **HTTP timeout** of the AsyncHttpClient. The graph's
+   regular ttl propagation (a node's optional `ttl` property, else `model.ttl`) bounds only the
+   event call to the composable function - it cannot reach inside a generic function, so the
+   HTTP client would otherwise run on its own 30-second default. The X-TTL value is expressed
+   in **milliseconds**. It also rides the wire as the `X-TTL` request header, so a downstream
+   Mercury service adopts it as its processing deadline (end-to-end deadline propagation).
+6. Any other RHS such as `url` and `method` is a composite key path in the function's request body.
+   RHS `*` would map the LHS value as the whole request body, and `header.{name}` would set a
+   request header of the function call.
 
-If the composable function declares a typed input, the request body is automatically converted at
-the function boundary.
+About async.http.request
+------------------------
+The input data mapping above builds a map of key-values. The AsyncHttpRequest class in platform-core
+renders that map into an HTTP request through its "fromMap" method at the function boundary. The
+commonly used keys are:
 
-About v1.hello.task
--------------------
-For your convenience, the composable function "v1.hello.task" is preloaded in dev mode. It
-composes a greeting from the "name" field, doubles the "amount" field and echoes the "x-app"
-request header. Below is an extract of the function:
-
-```rust
-/// The tutorial-13 demo task invoked through the graph.task skill.
-#[preload(route = "v1.hello.task", instances = 50)]
-#[optional_service("app.env=dev")]
-pub struct HelloTask;
-
-#[async_trait]
-impl ComposableFunction for HelloTask {
-    async fn handle_event(
-        &self,
-        headers: HashMap<String, String>,
-        input: EventEnvelope,
-        _instance: usize,
-    ) -> Result<EventEnvelope, AppError> {
-        let body: JsonValue = input.body_as().unwrap_or(JsonValue::Null);
-        let name = body.get("name").and_then(|v| v.as_str()).unwrap_or("stranger");
-        let mut result = serde_json::json!({"greeting": format!("Hello, {name}")});
-        if let Some(amount) = body.get("amount").and_then(|v| v.as_f64()) {
-            result["doubled"] = serde_json::json!(amount * 2.0);
-        }
-        if let Some(app) = headers.get("x-app") {
-            result["app"] = serde_json::json!(app);
-        }
-        EventEnvelope::new().set_body(result)
-    }
-}
 ```
+host              target host, e.g. http://127.0.0.1:8080
+url               URI path, e.g. /api/mdm/profile/100
+method            GET, POST, PUT, DELETE, etc.
+headers.{name}    an HTTP request header
+headers.x-ttl     HTTP timeout in milliseconds (default 30000); also propagates on the wire
+body              the HTTP request body (for POST/PUT)
+parameters.query.{name}   a query parameter
+```
+
+The mock MDM profile service (GET /api/mdm/profile/{id}) is preloaded in dev mode, serving
+person IDs 100 and 200.
 
 Perform a dry-run
 -----------------
@@ -112,61 +122,64 @@ To test the graph model, you can instantiate the graph with mock input as follow
 
 ```
 instantiate graph
-text(world) -> input.body.name
-int(21) -> input.body.amount
+int(100) -> input.body.person_id
 ```
 
 Then enter 'run' to execute the graph.
 
 ```
 > start graph...
-Graph instance created. Loaded 2 mock entries, model.ttl = 30000 ms
+Graph instance created. Loaded 1 mock entry, model.ttl = 30000 ms
 > run
 Walk to root
 Walk to hello-task
-Executed hello-task with skill graph.task in 4.12 ms
+Executed hello-task with skill graph.task in 18.5 ms
 Walk to end
 {
   "output": {
     "body": {
-      "greeting": "Hello, world",
-      "doubled": 42.0,
-      "app": "minigraph"
+      "profile": {
+        "id": "100",
+        "name": "Peter",
+        "address": "100 World Blvd"
+      },
+      "accounts": ["a101", "b202", "c303", "d400", "e500"],
+      "observed_ttl": "5000"
     }
   }
 }
-Graph traversal completed in 6 ms
+Graph traversal completed in 21 ms
 ```
 
-You can also check the application log. Telemetry and tracing information are shown, proving that
-the composable function was executed by the graph instance with full trace propagation.
+Note that 'instantiate graph' resolved `${rest.server.port:8080}` to the application's actual port,
+and the task node resolved `{model.person_id}` to 100 before calling the HTTP endpoint. The
+"observed_ttl" field is the mock service echoing the `X-TTL` request header it received - proof
+that the 5000 ms deadline arrived on the wire.
+
+You can also check the application log. Telemetry and tracing information are shown, proving that the
+composable function was executed by the graph instance with full trace propagation.
 
 ```
-Call task v1.hello.task, ttl=30000
-{trace={path=/graph/playground, service=graph.task...
-{trace={path=/graph/playground, service=v1.hello.task...
+GraphTask:144 - Call task async.http.request, ttl=30000
+Telemetry:81 - {trace={path=/graph/playground, service=graph.task...
+Telemetry:81 - {trace={path=/graph/playground, service=async.http.request...
+Telemetry:81 - {trace={path=/graph/playground, service=mock.mdm.profile...
 ```
 
 Error handling
 --------------
-If the composable function returns an error (e.g. an AppError with a status code) or the call
-times out, the "error" and "status" parameters of the node are set. You can add an "exception"
-property to the task node to route the error to a handler node, e.g. `exception=on-error`
-(tutorial 12 shows the full retry pattern).
+If the composable function throws an exception (e.g. AppException with a status code) or the call times
+out, the "error" and "status" parameters of the node are set. You can add an "exception" property to the
+task node to route the error to a handler node, e.g. `exception=on-error`.
+
+You can see this without any extra configuration - instantiate with an unknown person ID such as
+`int(999) -> input.body.person_id` and the HTTP error from the profile service becomes the graph
+output.
 
 Iterative execution
 -------------------
-Like the API fetcher and the flow extension, a task node supports iterative fork-join execution
-with the "for_each" and "concurrency" properties. Please enter 'describe skill graph.task' for
-details.
-
-Why invoke a composable function from a graph?
-----------------------------------------------
-The built-in skills cover data mapping, decision-making, computation and API fetching without
-writing any code, and flow extensions or subgraphs handle complex orchestration. A task node
-completes the picture: any custom business logic can be packaged as a composable function and
-plugged into a graph as if it were a custom skill. You can extend a knowledge graph's capability
-with the full power of the Mercury Composable programming model, one small function at a time.
+Like the API fetcher and the flow extension, a task node supports iterative fork-join execution with the
+"for_each" and "concurrency" properties. Please enter 'describe skill graph.task' for details.
 
 Export the graph model
 ----------------------
@@ -178,21 +191,33 @@ Graph exported to /tmp/graph/tutorial-13.json
 Described in /api/graph/model/tutorial-13/431-3
 ```
 
+The exported file keeps the `${rest.server.port:8080}` placeholder, so the same model resolves to
+the correct port in each environment it is deployed to.
+
 Deploy the graph model
 ----------------------
-To deploy the graph model, copy "/tmp/graph/tutorial-13.json" to your application's
-`resources/graph` folder. You can then test the deployed model with a curl command.
+To deploy the graph model, copy "/tmp/graph/tutorial-13.json" to your application's `main/resources/graph`
+folder. You can then test the deployed model with a curl command.
 
 ```
 curl -X POST http://127.0.0.1:8085/api/graph/tutorial-13 \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "world",
-    "amount": 21
+    "person_id": 100
 }'
 ```
 
 Summary
 -------
-In this tutorial, you have used the "graph.task" skill to invoke a composable function through its
-route name, with Event Script style input and output data mapping.
+In this session, we have discussed the use of the "graph.task" skill to invoke a composable function
+through its route name, with Event Script style input and output data mapping. Along the way you used
+a model variable as a dynamic variable in a later data mapping entry, and an environment variable
+reference that resolves when the model is loaded.
+
+Why invoke a composable function from a graph?
+----------------------------------------------
+The built-in skills cover data mapping, decision-making, computation and API fetching without writing
+any code, and flow extensions or subgraphs handle complex orchestration. A task node completes the
+picture - any custom business logic can now be packaged as a composable function and plugged into a
+graph as if it were a custom skill. As this tutorial shows, that includes functions the framework
+already provides: the AsyncHttpClient became an HTTP client by configuration, with no code at all.

--- a/crates/knowledge-graph/resources/public/assets/index-xIKOv-ds.js
+++ b/crates/knowledge-graph/resources/public/assets/index-xIKOv-ds.js
@@ -1258,100 +1258,119 @@ task=v1.redis.persist.model
 ttl=2d
 `,"../../../resources/help/help graph-task.md":`Skill: Graph Task
 -----------------
-Invokes a composable function through its route name and collects the
-function's response into the node's "result" property. This is the
-lightweight way to plug a small piece of custom business logic into a graph:
-your own function becomes, in effect, a custom skill. For multi-step
-orchestration, prefer a sub-graph or an Event Script flow via graph.extension
-(see 'help graph-extension').
+When a node is configured with this skill of "graph task", it will invoke a composable function
+through its route name and collect the function's response into the "result" property of the node.
+In case of exception, the "status" and "error" fields will be set to the node's properties and the
+graph execution will stop unless an exception handler node is configured.
+
+A composable function is a TypedLambdaFunction registered using the PreLoad annotation. This provides
+a lightweight method to extend a knowledge graph's capability with a small piece of business logic,
+without writing a new skill - more complex business logic should be delegated to a flow extension
+or a subgraph using the "graph.extension" skill.
+
+Execution will start when the GraphExecutor reaches the node containing this skill.
 
 Route name
 ----------
 "graph.task"
 
+Setup
+-----
+To enable this skill for a node, set "skill=graph.task" as a property in a node.
+
+The following parameters are required in the properties of the node:
+
+1. task - the route name of the composable function to invoke
+2. input - one or more data mapping entries as input to the composable function
+
+The system uses the same syntax of Event Script for data mapping.
+
 Properties
 ----------
 \`\`\`
 skill=graph.task
-task={function-route}
-input[]={source} -> {target}
-output[]={source} -> {target}
+task=route.name.of.composable.function
+input[]={mapping of key-values from input, model or another node to the function's request}
+output[]={optional mapping of result set to one or more variables in the 'model.' or 'output.' namespace}
 \`\`\`
 
-- task (required) - the route name of a composable function registered in
-  this application.
-- input[] (optional) - maps values into the function's request; entries
-  apply IN ORDER (see below).
-- output[] (optional) - maps the function's result onward; the result always
-  lands at {node}.result regardless.
-
-Optional:
-
+Optional properties
+-------------------
 \`\`\`
-for_each[]={array-source} -> model.{var}   (iterate over a runtime list)
-concurrency={1-30}                         (parallel fan-out, default 3)
-exception={error-handler-node}             (jump on failure instead of abort)
+for_each[]={map an array parameter for iterative function execution}
+concurrency={controls parallel function calls for an "iterative task request". Default 3, max 30}
+exception={error-handler-node-name}
 \`\`\`
 
 Input data mapping
 ------------------
-input[] entries apply in order. The target addresses the function's request:
+source.composite.key -> target
 
-- "*" - the mapped value is MERGED into the whole request body. Because
-  entries apply in order, later entries can merge additional fields into a
-  body seeded with "*".
-- header.{name} - sets a request header of the function call.
-- any other key - sets that field in the request body (composite dot-bracket
-  keys supported).
+The source (LHS) can use a key-value from the \`input.\` namespace, the \`model.\` namespace, another
+node or a constant such as text(hello). The target (RHS) addresses the function's request:
 
-Sources are the usual mapping sources: input.*, model.*, another node,
-constants such as text(hello), or f:plugin(...) calls. If the function
-declares a typed (PoJo) input, the request body converts automatically at
-the function boundary.
+1. \`*\` - the LHS value becomes the whole request body (same as Event Script). Data mapping entries
+   are processed in order, so later entries can merge additional key-values into a request body
+   that was seeded with \`*\`.
+2. \`header.{name}\` - sets a request header of the function call
+3. \`model.{key}\` - stages a variable in the graph's state machine instead of the request body, so
+   that later entries can reference it as a **dynamic variable** (same as Event Script). e.g. after
+   \`input.body.token -> model.token\`, the entry \`text(Bearer {model.token}) -> auth\` resolves the
+   \`{model.token}\` reference. Engine-managed model metadata (model.cid, model.ttl, etc.) is
+   immutable - a mapping that targets it is rejected.
+4. any other composite key - a key-value in the request body
 
-Output data mapping
--------------------
-The function's response body is stored at {node}.result, the response status
-at {node}.status, and response headers at {node}.header. In output[]
-mappings, bare "result" is the WHOLE function result; result.{key} is a
-field of it (same rule as graph.extension):
-
+Example:
 \`\`\`
-output[]=result -> output.body
-output[]=result.total -> model.total
+input[]=input.body -> *
+input[]=input.header.hello -> header.hello
+input[]=input.body.amount -> amount
+input[]=input.body.person_id -> model.person_id
+input[]=text(/api/mdm/profile/{model.person_id}) -> url
 \`\`\`
+
+If the function is declared as a TypedLambdaFunction with a PoJo input class, the request body map
+is automatically converted to the PoJo at the function boundary.
+
+Result set
+----------
+Upon successful execution, the function's response body is stored in the "result" parameter, the
+response status in "status" and the response headers in "header" in the properties of the node.
+The optional output data mapping can copy them to the 'model.' or 'output.' namespace.
+
+Example:
+\`\`\`
+output[]=result -> model.soap_request_payload
+\`\`\`
+
+Timeout
+-------
+The function call uses the graph instance's time-to-live from "model.ttl" (default 30000 ms).
+
+This deadline bounds the event call to the composable function - it cannot reach inside a
+generic function. When the function has its own downstream timeout contract, express it in the
+input data mapping. For example, the AsyncHttpClient (async.http.request) takes its HTTP timeout
+from the "x-ttl" key-value under "headers" in milliseconds, e.g. \`text(5000) -> headers.x-ttl\`
+(see tutorial 13).
+
+Exception handling
+------------------
+If the function throws an exception (e.g. AppException with a status code) or the call times out,
+the "error" and "status" parameters of the node are set. When the node has an "exception" property,
+the graph jumps to that error handler node. Otherwise, the error is returned as the graph output.
 
 Example
 -------
 \`\`\`
-create node hello-task
+create node prepare-soap-request
 with type Task
 with properties
-skill=graph.task
-task=v1.hello.task
+task=v1.prepare.soap.request
 input[]=input.body -> *
-input[]=text(minigraph) -> header.x-app
-output[]=result -> output.body
+input[]=input.header.hello -> header.hello
+output[]=result -> model.soap_request_payload
+skill=graph.task
 \`\`\`
-
-Notes
------
-- The task route must exist at runtime, or the node fails fast.
-- A call is bounded by the graph instance's time-to-live (model.ttl,
-  default 30000 ms).
-- Failure routing: on a function error (or timeout), {node}.status and
-  {node}.error are set and the output[] mappings are skipped. With
-  exception={handler-node}, traversal jumps to the handler instead of
-  aborting; without it, the run aborts. The bounded-retry pattern is shown
-  under 'help graph-api-fetcher'.
-- for_each[]={array-source} -> model.{var} invokes the function once per
-  element of a runtime list (the source must resolve to a list; wire the
-  element in with an ordinary input[] mapping from model.{var}), with
-  bounded parallel fan-out (concurrency 1-30, default 3). The shared
-  iteration rules are under 'help graph-api-fetcher'.
-- Writing the composable function itself is a development task done in Rust
-  with the #[preload] attribute; from the Playground you only reference its
-  route name.
 `,"../../../resources/help/help import.md":`Import a graph model or a node
 ------------------------------
 Load an exported graph model into your session as a draft for review and
@@ -2473,23 +2492,27 @@ graph.node.high.frequency=10
 \`\`\`
 `,"../../../resources/help/help tutorial 13.md":`Tutorial 13
 -----------
-In this tutorial, you will create a graph model that invokes a composable function using the
-"graph.task" skill.
+In this session, you will create a graph model that invokes a composable function using the
+"graph.task" skill. The composable function is the AsyncHttpClient (route "async.http.request")
+provided by the platform-core module, turning the task node into an HTTP client by configuration.
 
 Pre-requisite
 -------------
-You would need some working knowledge of composable functions. A composable function is a struct
-implementing ComposableFunction, registered with the #[preload] attribute. For more details, see
-docs/guides/event-driven/ai-agent-guide.md in this repository (the composable-function authoring
-guide).
+You would need some working knowledge of composable functions. A composable function is a
+TypedLambdaFunction registered with the PreLoad annotation. For more details, please refer to the
+[Developer Guide](https://accenture.github.io/mercury-composable/).
 
 What is a task?
 ---------------
-A task is a node that invokes a composable function through its route name. MiniGraph is designed
-to be zero-code with built-in skills for data mapping, decision-making and API fetching. More
-complex business logic is delegated to a flow extension or a subgraph (tutorials 10 and 11). A
-task node sits in between: it provides a lightweight method to extend a knowledge graph's
-capability with a small piece of business logic, without writing a new skill.
+A task is a node that invokes a composable function through its route name. MiniGraph is designed to be
+zero-code with built-in skills for data mapping, decision-making and API fetching. More complex business
+logic is delegated to a flow extension or a subgraph (tutorials 10 and 11). A task node sits in between -
+it provides a lightweight method to extend a knowledge graph's capability with a small piece of business
+logic, without writing a new skill.
+
+In this tutorial, the "small piece of business logic" is not custom code at all - it is the framework's
+own AsyncHttpClient. Any function registered in the platform is callable by route name, so the task node
+can drive an HTTP call purely by configuration.
 
 Create the graph model
 ----------------------
@@ -2509,11 +2532,16 @@ Create the task node. The "task" property is the route name of the composable fu
 create node hello-task
 with type Task
 with properties
-task=v1.hello.task
-input[]=input.body -> *
-input[]=text(minigraph) -> header.x-app
+input[]=input.body.person_id -> model.person_id
+input[]=text(http://127.0.0.1:\${rest.server.port:8080}) -> host
+input[]=text(/api/mdm/profile/{model.person_id}) -> url
+input[]=text(GET) -> method
+input[]=text(application/json) -> headers.accept
+input[]=text(5000) -> headers.x-ttl
 output[]=result -> output.body
+purpose=Invoke AsyncHttpClient with route 'async.http.request' to fetch a user profile
 skill=graph.task
+task=async.http.request
 \`\`\`
 
 Create the end node and connect the three nodes:
@@ -2535,49 +2563,50 @@ About the input data mapping
 ----------------------------
 The input data mapping follows the Event Script syntax and is applied in declaration order:
 
-1. \`input.body -> *\` maps the whole request body as the request body of the composable function.
-   Since data mapping entries are processed in order, later entries can merge additional
-   key-values into a request body that was seeded with \`*\`.
-2. \`text(minigraph) -> header.x-app\` sets a request header of the function call. You can also map
-   individual fields, e.g. \`input.body.amount -> amount\` would set one key-value in the request
-   body.
+1. \`input.body.person_id -> model.person_id\` stages a variable in the graph's state machine
+   (the \`model.\` namespace). It does not become part of the function's request - it is kept for
+   later entries to reference.
+2. \`text(/api/mdm/profile/{model.person_id}) -> url\` demonstrates a **dynamic variable**: the
+   \`{model.person_id}\` reference inside the text constant is substituted with the model value
+   staged by the earlier entry. This is the same idiom as Event Script's
+   \`text(Bearer {model.token}) -> headers.Authorization\`.
+3. \`text(http://127.0.0.1:\${rest.server.port:8080}) -> host\` demonstrates **environment variable
+   substitution**. The \`\${name:default}\` reference is resolved by the configuration system when the
+   model is loaded - at 'instantiate graph' for a dry-run and at deployment time for a deployed
+   model - so both lanes behave the same. The authored model (and any export) keeps the \`\${...}\`
+   placeholder, making the model portable across environments.
+4. \`text(application/json) -> headers.accept\` declares the response type this client accepts.
+   Always declare it instead of relying on an HTTP library's implicit default - with an explicit
+   accept, the profile service replies with \`content-type: application/json\` and the
+   AsyncHttpClient decodes the response body into a map.
+5. \`text(5000) -> headers.x-ttl\` sets the **HTTP timeout** of the AsyncHttpClient. The graph's
+   regular ttl propagation (a node's optional \`ttl\` property, else \`model.ttl\`) bounds only the
+   event call to the composable function - it cannot reach inside a generic function, so the
+   HTTP client would otherwise run on its own 30-second default. The X-TTL value is expressed
+   in **milliseconds**. It also rides the wire as the \`X-TTL\` request header, so a downstream
+   Mercury service adopts it as its processing deadline (end-to-end deadline propagation).
+6. Any other RHS such as \`url\` and \`method\` is a composite key path in the function's request body.
+   RHS \`*\` would map the LHS value as the whole request body, and \`header.{name}\` would set a
+   request header of the function call.
 
-If the composable function declares a typed input, the request body is automatically converted at
-the function boundary.
+About async.http.request
+------------------------
+The input data mapping above builds a map of key-values. The AsyncHttpRequest class in platform-core
+renders that map into an HTTP request through its "fromMap" method at the function boundary. The
+commonly used keys are:
 
-About v1.hello.task
--------------------
-For your convenience, the composable function "v1.hello.task" is preloaded in dev mode. It
-composes a greeting from the "name" field, doubles the "amount" field and echoes the "x-app"
-request header. Below is an extract of the function:
-
-\`\`\`rust
-/// The tutorial-13 demo task invoked through the graph.task skill.
-#[preload(route = "v1.hello.task", instances = 50)]
-#[optional_service("app.env=dev")]
-pub struct HelloTask;
-
-#[async_trait]
-impl ComposableFunction for HelloTask {
-    async fn handle_event(
-        &self,
-        headers: HashMap<String, String>,
-        input: EventEnvelope,
-        _instance: usize,
-    ) -> Result<EventEnvelope, AppError> {
-        let body: JsonValue = input.body_as().unwrap_or(JsonValue::Null);
-        let name = body.get("name").and_then(|v| v.as_str()).unwrap_or("stranger");
-        let mut result = serde_json::json!({"greeting": format!("Hello, {name}")});
-        if let Some(amount) = body.get("amount").and_then(|v| v.as_f64()) {
-            result["doubled"] = serde_json::json!(amount * 2.0);
-        }
-        if let Some(app) = headers.get("x-app") {
-            result["app"] = serde_json::json!(app);
-        }
-        EventEnvelope::new().set_body(result)
-    }
-}
 \`\`\`
+host              target host, e.g. http://127.0.0.1:8080
+url               URI path, e.g. /api/mdm/profile/100
+method            GET, POST, PUT, DELETE, etc.
+headers.{name}    an HTTP request header
+headers.x-ttl     HTTP timeout in milliseconds (default 30000); also propagates on the wire
+body              the HTTP request body (for POST/PUT)
+parameters.query.{name}   a query parameter
+\`\`\`
+
+The mock MDM profile service (GET /api/mdm/profile/{id}) is preloaded in dev mode, serving
+person IDs 100 and 200.
 
 Perform a dry-run
 -----------------
@@ -2585,61 +2614,64 @@ To test the graph model, you can instantiate the graph with mock input as follow
 
 \`\`\`
 instantiate graph
-text(world) -> input.body.name
-int(21) -> input.body.amount
+int(100) -> input.body.person_id
 \`\`\`
 
 Then enter 'run' to execute the graph.
 
 \`\`\`
 > start graph...
-Graph instance created. Loaded 2 mock entries, model.ttl = 30000 ms
+Graph instance created. Loaded 1 mock entry, model.ttl = 30000 ms
 > run
 Walk to root
 Walk to hello-task
-Executed hello-task with skill graph.task in 4.12 ms
+Executed hello-task with skill graph.task in 18.5 ms
 Walk to end
 {
   "output": {
     "body": {
-      "greeting": "Hello, world",
-      "doubled": 42.0,
-      "app": "minigraph"
+      "profile": {
+        "id": "100",
+        "name": "Peter",
+        "address": "100 World Blvd"
+      },
+      "accounts": ["a101", "b202", "c303", "d400", "e500"],
+      "observed_ttl": "5000"
     }
   }
 }
-Graph traversal completed in 6 ms
+Graph traversal completed in 21 ms
 \`\`\`
 
-You can also check the application log. Telemetry and tracing information are shown, proving that
-the composable function was executed by the graph instance with full trace propagation.
+Note that 'instantiate graph' resolved \`\${rest.server.port:8080}\` to the application's actual port,
+and the task node resolved \`{model.person_id}\` to 100 before calling the HTTP endpoint. The
+"observed_ttl" field is the mock service echoing the \`X-TTL\` request header it received - proof
+that the 5000 ms deadline arrived on the wire.
+
+You can also check the application log. Telemetry and tracing information are shown, proving that the
+composable function was executed by the graph instance with full trace propagation.
 
 \`\`\`
-Call task v1.hello.task, ttl=30000
-{trace={path=/graph/playground, service=graph.task...
-{trace={path=/graph/playground, service=v1.hello.task...
+GraphTask:144 - Call task async.http.request, ttl=30000
+Telemetry:81 - {trace={path=/graph/playground, service=graph.task...
+Telemetry:81 - {trace={path=/graph/playground, service=async.http.request...
+Telemetry:81 - {trace={path=/graph/playground, service=mock.mdm.profile...
 \`\`\`
 
 Error handling
 --------------
-If the composable function returns an error (e.g. an AppError with a status code) or the call
-times out, the "error" and "status" parameters of the node are set. You can add an "exception"
-property to the task node to route the error to a handler node, e.g. \`exception=on-error\`
-(tutorial 12 shows the full retry pattern).
+If the composable function throws an exception (e.g. AppException with a status code) or the call times
+out, the "error" and "status" parameters of the node are set. You can add an "exception" property to the
+task node to route the error to a handler node, e.g. \`exception=on-error\`.
+
+You can see this without any extra configuration - instantiate with an unknown person ID such as
+\`int(999) -> input.body.person_id\` and the HTTP error from the profile service becomes the graph
+output.
 
 Iterative execution
 -------------------
-Like the API fetcher and the flow extension, a task node supports iterative fork-join execution
-with the "for_each" and "concurrency" properties. Please enter 'describe skill graph.task' for
-details.
-
-Why invoke a composable function from a graph?
-----------------------------------------------
-The built-in skills cover data mapping, decision-making, computation and API fetching without
-writing any code, and flow extensions or subgraphs handle complex orchestration. A task node
-completes the picture: any custom business logic can be packaged as a composable function and
-plugged into a graph as if it were a custom skill. You can extend a knowledge graph's capability
-with the full power of the Mercury Composable programming model, one small function at a time.
+Like the API fetcher and the flow extension, a task node supports iterative fork-join execution with the
+"for_each" and "concurrency" properties. Please enter 'describe skill graph.task' for details.
 
 Export the graph model
 ----------------------
@@ -2651,24 +2683,36 @@ Graph exported to /tmp/graph/tutorial-13.json
 Described in /api/graph/model/tutorial-13/431-3
 \`\`\`
 
+The exported file keeps the \`\${rest.server.port:8080}\` placeholder, so the same model resolves to
+the correct port in each environment it is deployed to.
+
 Deploy the graph model
 ----------------------
-To deploy the graph model, copy "/tmp/graph/tutorial-13.json" to your application's
-\`resources/graph\` folder. You can then test the deployed model with a curl command.
+To deploy the graph model, copy "/tmp/graph/tutorial-13.json" to your application's \`main/resources/graph\`
+folder. You can then test the deployed model with a curl command.
 
 \`\`\`
 curl -X POST http://127.0.0.1:8085/api/graph/tutorial-13 \\
   -H "Content-Type: application/json" \\
   -d '{
-    "name": "world",
-    "amount": 21
+    "person_id": 100
 }'
 \`\`\`
 
 Summary
 -------
-In this tutorial, you have used the "graph.task" skill to invoke a composable function through its
-route name, with Event Script style input and output data mapping.
+In this session, we have discussed the use of the "graph.task" skill to invoke a composable function
+through its route name, with Event Script style input and output data mapping. Along the way you used
+a model variable as a dynamic variable in a later data mapping entry, and an environment variable
+reference that resolves when the model is loaded.
+
+Why invoke a composable function from a graph?
+----------------------------------------------
+The built-in skills cover data mapping, decision-making, computation and API fetching without writing
+any code, and flow extensions or subgraphs handle complex orchestration. A task node completes the
+picture - any custom business logic can now be packaged as a composable function and plugged into a
+graph as if it were a custom skill. As this tutorial shows, that includes functions the framework
+already provides: the AsyncHttpClient became an HTTP client by configuration, with no code at all.
 `,"../../../resources/help/help tutorial 14.md":`Tutorial 14
 -----------
 In this session, you will build a purchase workflow with THREE human checkpoints - a customer
@@ -5731,4 +5775,4 @@ with properties
 `);return Gs(o),o}function Js(e,t){let n=t.trim(),r=Cs(e,{mode:`edit`,originalAlias:n});if(!r.valid)throw Error(Object.values(r.errors)[0]??`Invalid node form state.`);let i=e.nodeType.trim(),a=Ws(e,!0),o=[`update node ${n}`];if(i&&o.push(`with type ${i}`),a.length>0){o.push(`with properties`);for(let e of a)Ks(o,e.key,e.value)}let s=o.join(`
 `);return Gs(s),s}function Ys(e,t={}){let n=e.trim(),r=ws(n,t);if(!r.valid)throw Error(Object.values(r.errors)[0]??`Invalid node alias.`);let i=`delete node ${n}`;return Gs(i),i}function Xs(e){let t=Es(e);if(!t.valid)throw Error(Object.values(t.errors)[0]??`Invalid connection form state.`);let n=`connect ${e.sourceAlias.trim()} to ${e.targetAlias.trim()} with ${e.relation.trim()}`;return Gs(n),n}var Zs=1e4,Qs=`A graph authoring action is already pending. Wait for it to finish before starting another.`,$s=`Could not send the create-node command because the WebSocket is not open. The form values remain in this dialog.`,ec=`Could not send the edit-node command because the WebSocket is not open. Your changes remain in this dialog.`,tc=`Could not send the delete-node command because the WebSocket is not open.`,nc=`Could not send the create-connection command because the WebSocket is not open. The form values remain in this dialog.`,rc=`Could not send delete-node commands because the WebSocket is not open.`,ic=`No selected nodes are available to delete.`,ac=`Select 100 or fewer nodes to delete at once.`,oc=`Some delete-node commands were sent, but not all backend results were observed yet. Refresh the graph before trying again.`,sc=`This node is no longer available in the current graph.`,cc=`Connection disconnected. Refresh the page and create the node again after the app reconnects.`,lc=`Connection disconnected. Refresh the page and edit the node again after the app reconnects.`,uc=`Connection disconnected. Refresh the page and create the connection again after the app reconnects.`,dc=`Connection disconnected while the graph authoring action was pending. The outcome is unknown. Refresh the page and check the graph before trying again.`,fc={status:`closed`,pendingSubmit:null,serverMessage:null};function pc(e){return e.pendingSubmit}function mc(e){return e.action===`delete-nodes`}function hc(e){return e===`create-connection`?nc:e===`edit-node`?ec:e===`delete-node`?tc:$s}function gc(e){return mc(e)?oc:`The ${e.action} command was sent, but no backend result was observed yet. The outcome is unknown.`}function _c(e){return e===`create-connection`?uc:e===`edit-node`?lc:cc}function vc(e,t){return!e||!t?!1:e.trim().toLowerCase()===t.trim().toLowerCase()}function yc(e,t){return e?.nodes.find(e=>e.alias.toLowerCase()===t.toLowerCase())??null}function bc(e,t){return e.status===`error`?!0:t.action===`create-connection`?e.action===`create-connection`?e.alias===null?!0:vc(e.alias,t.alias)?e.status===`accepted`?vc(e.targetAlias,t.targetAlias):e.targetAlias===null||vc(e.targetAlias,t.targetAlias):!1:e.action===null?vc(e.alias,t.alias)||vc(e.alias,t.targetAlias):!1:vc(e.alias,t.alias)?e.action===null||e.action===t.action:!1}function xc(e,t){let n=pc(e);return!n||mc(n)||!bc(t,n)?null:t.status===`accepted`?{state:fc,acceptedResult:{status:t.status,action:t.action,alias:t.alias,targetAlias:t.targetAlias,message:t.message}}:e.status===`open`?{state:{...e,phase:`editing`,pendingSubmit:null,serverMessage:t.status===`error`?`Backend returned an error while this submit was pending: ${t.message}`:t.message}}:{state:fc,notification:{message:t.message,type:`error`}}}function Sc(e){return{...e,phase:`editing`,pendingSubmit:null,serverMessage:hc(e.action)}}function Cc(e){let t=pc(e);if(!t)return null;let n=gc(t);return e.status===`open`?{state:{...e,phase:`editing`,pendingSubmit:null,serverMessage:n}}:{state:fc,notification:{message:n,type:`error`}}}function wc(e){let t=pc(e);if(e.status===`open`){let n=t?dc:_c(e.action);return{state:{...e,phase:`editing`,pendingSubmit:null,serverMessage:n,connectionLost:!0}}}return t?{state:fc,notification:{message:dc,type:`error`}}:null}function Tc(e){return`sourceAlias`in e}function Ec({bus:e,connected:t,graphData:n,executor:r,timeoutMs:i=Zs,onAccepted:a,onUserMessage:o}){let[s,c]=(0,M.useState)(fc),[l,u]=(0,M.useState)({}),d=(0,M.useRef)(s),f=(0,M.useRef)(null),p=(0,M.useRef)(t),m=(0,M.useRef)(n),h=(0,M.useRef)(a),g=(0,M.useRef)(o);(0,M.useEffect)(()=>{d.current=s},[s]),(0,M.useEffect)(()=>{m.current=n},[n]),(0,M.useEffect)(()=>{h.current=a},[a]),(0,M.useEffect)(()=>{g.current=o},[o]);let _=(0,M.useCallback)((e,t=`error`)=>{g.current?.(e,t)},[]),v=(0,M.useCallback)(e=>{d.current=e,c(e)},[]),y=(0,M.useCallback)(()=>{f.current!==null&&(clearTimeout(f.current),f.current=null)},[]),b=(0,M.useCallback)(()=>{y(),f.current=setTimeout(()=>{let e=Cc(d.current);e&&(v(e.state),e.notification&&_(e.notification.message,e.notification.type)),f.current=null},i)},[y,_,v,i]),x=(0,M.useCallback)(e=>{if(!t)return;if(pc(d.current)){_(Qs,`error`);return}let n=As(e);u({}),v({status:`open`,action:`create-node`,phase:`editing`,formState:n,originalAlias:null,pendingSubmit:null,serverMessage:null,connectionLost:!1})},[t,_,v]),S=(0,M.useCallback)((e,n)=>{if(!t)return;if(pc(d.current)){_(Qs,`error`);return}let r={sourceAlias:e,targetAlias:n,relation:``},{relation:i,...a}=Es(r,{graphData:m.current,connected:t}).errors;Object.keys(a).length>0||(u({}),v({status:`open`,action:`create-connection`,phase:`editing`,formState:r,pendingSubmit:null,serverMessage:null,connectionLost:!1}))},[t,_,v]),C=(0,M.useCallback)(e=>{if(!t){_(lc,`error`);return}if(pc(d.current)){_(Qs,`error`);return}let n=yc(m.current,e.alias);if(!n){_(sc,`error`);return}let r=Fs(n);if(!r.valid||!r.formState){_(r.message??`This node cannot be edited in the UI.`,`error`);return}u({}),v({status:`open`,action:`edit-node`,phase:`editing`,formState:r.formState,originalAlias:n.alias,pendingSubmit:null,serverMessage:null,connectionLost:!1})},[t,_,v]),w=(0,M.useCallback)(e=>{if(!t){_(tc,`error`);return}if(pc(d.current)){_(Qs,`error`);return}let n=ws(e.alias,{graphData:m.current});if(!n.valid){_(Object.values(n.errors)[0]??`Invalid node alias.`,`error`);return}let i;try{i=Ys(e.alias,{graphData:m.current})}catch(e){_(e instanceof Error?e.message:String(e),`error`);return}if(!r.execute(i)){_(tc,`error`);return}let a={action:`delete-node`,alias:e.alias.trim(),command:i,sentAt:new Date().toISOString()};u({}),v({status:`closed`,pendingSubmit:a,serverMessage:null}),b()},[t,r,_,v,b]),ee=(0,M.useCallback)(e=>{if(!t){_(rc,`error`);return}if(pc(d.current)){_(Qs,`error`);return}if(e.length===0){_(ic,`info`);return}if(e.length>100){_(ac,`error`);return}let n=new Set,i=e.filter(e=>{let t=e.alias.trim().toLowerCase();return n.has(t)?!1:(n.add(t),!0)}),a=[],o=[];for(let e of i){let t=ws(e.alias,{graphData:m.current});if(!t.valid){_(Object.values(t.errors)[0]??ic,`error`);return}try{o.push(e.alias.trim()),a.push(Ys(e.alias,{graphData:m.current}))}catch(e){_(e instanceof Error?e.message:String(e),`error`);return}}for(let[e,t]of a.entries())if(!r.execute(t)){_(e===0?rc:dc,`error`);return}let s={action:`delete-nodes`,aliases:o,commands:a,sentAt:new Date().toISOString(),results:{}};u({}),v({status:`closed`,pendingSubmit:s,serverMessage:null}),_(`${o.length} delete-node commands sent. Waiting for backend response.`,`info`),b()},[t,r,_,v,b]),T=(0,M.useCallback)(e=>{let t=d.current;if(t.status===`open`&&!(t.phase===`sending`||t.connectionLost)){if(u({}),t.action===`create-connection`){if(!Tc(e))return;v({...t,formState:e,pendingSubmit:null,serverMessage:null,connectionLost:!1});return}Tc(e)||v({...t,formState:e,pendingSubmit:null,serverMessage:null,connectionLost:!1})}},[v]),te=(0,M.useCallback)(()=>{let e=d.current;if(e.status!==`open`||e.phase===`sending`||e.connectionLost)return;let n=e.action;if(!t){v({...e,serverMessage:hc(n)});return}let i=e.action===`create-connection`?Es(e.formState,{graphData:m.current,connected:t}):Cs(e.formState,e.action===`edit-node`?{mode:`edit`,originalAlias:e.originalAlias}:{graphData:m.current});if(!i.valid){u(i.errors);return}let a,o,s=null;try{if(e.action===`edit-node`)o=e.originalAlias?.trim()??``,a=Js(e.formState,o);else if(e.action===`create-node`)o=e.formState.alias.trim(),a=qs(e.formState);else if(Tc(e.formState))o=e.formState.sourceAlias.trim(),s=e.formState.targetAlias.trim(),a=Xs(e.formState);else{u({command:`Invalid connection form state.`});return}}catch(e){u({command:e instanceof Error?e.message:String(e)});return}if(!r.execute(a)){v(Sc(e));return}let c={action:n,alias:o,targetAlias:s,command:a,sentAt:new Date().toISOString()};u({}),v({...e,phase:`sending`,pendingSubmit:c,serverMessage:null,connectionLost:!1}),b()},[t,r,v,b]),E=(0,M.useCallback)(()=>{let e=d.current;e.status===`open`&&e.phase!==`sending`&&(y(),u({}),v(fc))},[y,v]);return(0,M.useEffect)(()=>e.on(`minigraph.nodeAction.textResult`,e=>{let t=d.current,n=pc(t);if(!n)return;if(mc(n)){let r=F(n,e);if(!r)return;if(e.status===`accepted`&&h.current?.({status:e.status,action:e.action,alias:e.alias,targetAlias:e.targetAlias,message:e.message}),!I(r)){v({...t,pendingSubmit:r});return}y(),v(fc);let i=Ri(r);_(i.message,i.type);return}let r=xc(t,e);r&&(y(),r.acceptedResult&&u({}),v(r.state),r.acceptedResult&&h.current?.(r.acceptedResult),r.notification&&_(r.notification.message,r.notification.type))}),[e,y,_,v]),(0,M.useEffect)(()=>{if(p.current&&!t){let e=wc(d.current);e&&(y(),v(e.state),e.notification&&_(e.notification.message,e.notification.type))}p.current=t},[y,t,_,v]),(0,M.useEffect)(()=>()=>{y()},[y]),{state:s,validationErrors:l,openCreateNode:x,openCreateConnection:S,openEditNode:C,deleteNode:w,deleteNodes:ee,updateFormState:T,submit:te,close:E}}var Dc=/^ws-\d+-\d+$/;function Oc(e){return Dc.test(e.trim())}var kc={sessionId:null,startedSince:null,subscribedTo:null,subscribers:[],loading:!1,pendingCommand:null,error:null,lastInfo:null};function Ac(e){return Array.from(new Set(e)).sort()}function jc({enabled:e,connected:t,bus:n,classificationMap:r,sendRawText:i,addToast:a}){let[o,s]=(0,M.useState)(kc),c=(0,M.useRef)(new Set),l=(0,M.useRef)(0),u=(0,M.useRef)(i),d=(0,M.useRef)(a);(0,M.useEffect)(()=>{u.current=i},[i]),(0,M.useEffect)(()=>{d.current=a},[a]);let f=(0,M.useCallback)(()=>{if(!e||!t)return!1;s(e=>({...e,loading:!0,pendingCommand:`refresh`,error:null,lastInfo:null}));let n=u.current(`session`);if(!n){let e=`Could not load session details because the WebSocket is not open.`;s(t=>({...t,loading:!1,pendingCommand:null,error:e})),d.current(e,`error`)}return n},[t,e]),p=(0,M.useCallback)(e=>{let t=`${e.kind}:${e.msgId}`;if(!c.current.has(t)){if(c.current.add(t),e.kind===`minigraph.session.started`){s({...kc,sessionId:e.sessionId});return}if(e.kind===`minigraph.session.status`){s(t=>({...t,sessionId:e.sessionId,startedSince:e.startedSince,subscribedTo:e.subscribedTo,subscribers:Ac(e.subscribers),loading:!1,pendingCommand:null,error:null,lastInfo:null}));return}if(e.kind===`minigraph.session.commandResult`){if(e.status===`accepted`){s(t=>({...t,subscribedTo:e.command===`subscribe`?e.sessionId:e.command===`unsubscribe`?null:t.subscribedTo,pendingCommand:null,error:null,lastInfo:null}));return}s(t=>({...t,pendingCommand:null,error:e.message,lastInfo:null}));return}if(e.kind===`minigraph.session.notification`){e.type===`host-closed`?s(t=>({...t,subscribedTo:t.subscribedTo===e.sessionId?null:t.subscribedTo,subscribers:t.subscribers.filter(t=>t!==e.sessionId),error:null,lastInfo:null})):e.type===`subscriber-joined`?s(t=>({...t,subscribers:Ac([...t.subscribers,e.sessionId]),error:null,lastInfo:null})):s(t=>({...t,subscribers:t.subscribers.filter(t=>t!==e.sessionId),error:null,lastInfo:null}));return}e.kind===`session.reset`&&(s(e=>({...e,startedSince:null,subscribedTo:null,subscribers:[],loading:!1,pendingCommand:null,error:null,lastInfo:null})),f())}},[f]),m=(0,M.useCallback)(()=>{s(e=>({...e,error:null,lastInfo:null}))},[]),h=(0,M.useCallback)(n=>{let r=n.trim();if(!e||!t||o.pendingCommand!==null||o.subscribedTo!==null)return!1;if(!Oc(r))return s(e=>({...e,error:`Enter a valid session ID like ws-123456-1.`,lastInfo:null})),!1;s(e=>({...e,pendingCommand:`subscribe`,error:null,lastInfo:null}));let c=i(`session subscribe ${r}`);if(!c){let e=`Could not subscribe because the WebSocket is not open.`;s(t=>({...t,pendingCommand:null,error:e})),a(e,`error`)}return c},[a,t,e,i,o.pendingCommand,o.subscribedTo]),g=(0,M.useCallback)(()=>{if(!e||!t||o.pendingCommand!==null||o.subscribedTo===null)return!1;s(e=>({...e,pendingCommand:`unsubscribe`,error:null,lastInfo:null}));let n=i(`session unsubscribe`);if(!n){let e=`Could not unsubscribe because the WebSocket is not open.`;s(t=>({...t,pendingCommand:null,error:e})),a(e,`error`)}return n},[a,t,e,i,o.pendingCommand,o.subscribedTo]),_=(0,M.useCallback)(()=>{if(!e||!t||o.pendingCommand!==null||o.subscribedTo!==null||o.subscribers.length===0)return!1;s(e=>({...e,pendingCommand:`reset`,error:null,lastInfo:null}));let n=i(`session reset`);if(!n){let e=`Could not reset because the WebSocket is not open.`;s(t=>({...t,pendingCommand:null,error:e})),a(e,`error`)}return n},[a,t,e,i,o.pendingCommand,o.subscribedTo,o.subscribers.length]);(0,M.useEffect)(()=>{e&&t||(c.current.clear(),l.current=0,s(kc))},[t,e]),(0,M.useEffect)(()=>{if(!e)return;let t=n.on(`minigraph.session.started`,e=>{p(e)}),r=n.on(`minigraph.session.status`,e=>{p(e)}),i=n.on(`minigraph.session.commandResult`,e=>{p(e)}),a=n.on(`minigraph.session.notification`,e=>{p(e)}),o=n.on(`session.reset`,e=>{p(e)});return()=>{t(),r(),i(),a(),o()}},[n,e,p]),(0,M.useEffect)(()=>{!e||!t||f()},[t,e,f]),(0,M.useEffect)(()=>{if(!e||!r)return;let t=l.current;for(let[e,n]of r)if(!(e<=l.current)){for(let e of n)(e.kind===`minigraph.session.started`||e.kind===`minigraph.session.status`||e.kind===`minigraph.session.commandResult`||e.kind===`minigraph.session.notification`||e.kind===`session.reset`)&&p(e);t=Math.max(t,e)}l.current=t,c.current.clear()},[r,e,p]);let v=o.subscribedTo===null,y=o.subscribers.length>0;return(0,M.useMemo)(()=>({state:o,connected:t,isPrimary:v,hasSubscribers:y,canSubscribe:e&&t&&o.pendingCommand===null&&o.subscribedTo===null,canUnsubscribe:e&&t&&o.subscribedTo!==null&&o.pendingCommand===null,canReset:e&&t&&o.pendingCommand===null&&o.subscribedTo===null&&o.subscribers.length>0,subscribeToSession:h,unsubscribe:g,resetSession:_,clearMessage:m}),[m,t,e,y,v,_,o,h,g])}var Mc=(e,t)=>t.some(t=>e instanceof t),Nc,Pc;function Fc(){return Nc||=[IDBDatabase,IDBObjectStore,IDBIndex,IDBCursor,IDBTransaction]}function Ic(){return Pc||=[IDBCursor.prototype.advance,IDBCursor.prototype.continue,IDBCursor.prototype.continuePrimaryKey]}var Lc=new WeakMap,Rc=new WeakMap,zc=new WeakMap;function Bc(e){let t=new Promise((t,n)=>{let r=()=>{e.removeEventListener(`success`,i),e.removeEventListener(`error`,a)},i=()=>{t(Kc(e.result)),r()},a=()=>{n(e.error),r()};e.addEventListener(`success`,i),e.addEventListener(`error`,a)});return zc.set(t,e),t}function Vc(e){if(Lc.has(e))return;let t=new Promise((t,n)=>{let r=()=>{e.removeEventListener(`complete`,i),e.removeEventListener(`error`,a),e.removeEventListener(`abort`,a)},i=()=>{t(),r()},a=()=>{n(e.error||new DOMException(`AbortError`,`AbortError`)),r()};e.addEventListener(`complete`,i),e.addEventListener(`error`,a),e.addEventListener(`abort`,a)});Lc.set(e,t)}var Hc={get(e,t,n){if(e instanceof IDBTransaction){if(t===`done`)return Lc.get(e);if(t===`store`)return n.objectStoreNames[1]?void 0:n.objectStore(n.objectStoreNames[0])}return Kc(e[t])},set(e,t,n){return e[t]=n,!0},has(e,t){return e instanceof IDBTransaction&&(t===`done`||t===`store`)||t in e}};function Uc(e){Hc=e(Hc)}function Wc(e){return Ic().includes(e)?function(...t){return e.apply(qc(this),t),Kc(this.request)}:function(...t){return Kc(e.apply(qc(this),t))}}function Gc(e){return typeof e==`function`?Wc(e):(e instanceof IDBTransaction&&Vc(e),Mc(e,Fc())?new Proxy(e,Hc):e)}function Kc(e){if(e instanceof IDBRequest)return Bc(e);if(Rc.has(e))return Rc.get(e);let t=Gc(e);return t!==e&&(Rc.set(e,t),zc.set(t,e)),t}var qc=e=>zc.get(e);function Jc(e,t,{blocked:n,upgrade:r,blocking:i,terminated:a}={}){let o=indexedDB.open(e,t),s=Kc(o);return r&&o.addEventListener(`upgradeneeded`,e=>{r(Kc(o.result),e.oldVersion,e.newVersion,Kc(o.transaction),e)}),n&&o.addEventListener(`blocked`,e=>n(e.oldVersion,e.newVersion,e)),s.then(e=>{a&&e.addEventListener(`close`,()=>a()),i&&e.addEventListener(`versionchange`,e=>i(e.oldVersion,e.newVersion,e))}).catch(()=>{}),s}function Yc(e,{blocked:t}={}){let n=indexedDB.deleteDatabase(e);return t&&n.addEventListener(`blocked`,e=>t(e.oldVersion,e)),Kc(n).then(()=>void 0)}var Xc=[`get`,`getKey`,`getAll`,`getAllKeys`,`count`],Zc=[`put`,`add`,`delete`,`clear`],Qc=new Map;function $c(e,t){if(!(e instanceof IDBDatabase&&!(t in e)&&typeof t==`string`))return;if(Qc.get(t))return Qc.get(t);let n=t.replace(/FromIndex$/,``),r=t!==n,i=Zc.includes(n);if(!(n in(r?IDBIndex:IDBObjectStore).prototype)||!(i||Xc.includes(n)))return;let a=async function(e,...t){let a=this.transaction(e,i?`readwrite`:`readonly`),o=a.store;return r&&(o=o.index(t.shift())),(await Promise.all([o[n](...t),i&&a.done]))[0]};return Qc.set(t,a),a}Uc(e=>({...e,get:(t,n,r)=>$c(t,n)||e.get(t,n,r),has:(t,n)=>!!$c(t,n)||e.has(t,n)}));var el=[`continue`,`continuePrimaryKey`,`advance`],tl={},nl=new WeakMap,rl=new WeakMap,il={get(e,t){if(!el.includes(t))return e[t];let n=tl[t];return n||=tl[t]=function(...e){nl.set(this,rl.get(this)[t](...e))},n}};async function*al(...e){let t=this;if(t instanceof IDBCursor||(t=await t.openCursor(...e)),!t)return;t=t;let n=new Proxy(t,il);for(rl.set(n,t),zc.set(n,qc(t));t;)yield n,t=await(nl.get(n)||t.continue()),nl.delete(n)}function ol(e,t){return t===Symbol.asyncIterator&&Mc(e,[IDBIndex,IDBObjectStore,IDBCursor])||t===`iterate`&&Mc(e,[IDBIndex,IDBObjectStore])}Uc(e=>({...e,get(t,n,r){return ol(t,n)?al:e.get(t,n,r)},has(t,n){return ol(t,n)||e.has(t,n)}}));var sl=`minigraph-clipboard`,cl=1,ll=`items`,ul=null;function dl(){return Jc(sl,cl,{upgrade(e){e.objectStoreNames.contains(ll)&&e.deleteObjectStore(ll);let t=e.createObjectStore(ll,{keyPath:`id`});t.createIndex(`by-alias`,`node.alias`,{unique:!0}),t.createIndex(`by-clippedAt`,`clippedAt`)}})}function fl(){return ul||=dl().catch(async e=>(console.warn(`[clipboard/db] openDB failed, deleting and recreating:`,e),ul=null,await Yc(sl),dl())),ul}async function pl(){return(await(await fl()).getAllFromIndex(ll,`by-clippedAt`)).reverse()}async function ml(e){return(await fl()).getFromIndex(ll,`by-alias`,e)}async function hl(e){await(await fl()).add(ll,e)}async function gl(e,t){let n=(await fl()).transaction(ll,`readwrite`);await n.store.delete(e),await n.store.add(t),await n.done}async function _l(e){await(await fl()).delete(ll,e)}async function vl(){await(await fl()).clear(ll)}var yl=`minigraph-clipboard-sync`;function bl(){return new BroadcastChannel(yl)}function xl(e,t){switch(t.type){case`HYDRATE`:return{items:t.items,isLoading:!1};case`ITEM_ADDED`:return{...e,items:[t.item,...e.items]};case`ITEM_REPLACED`:{let n=e.items.filter(e=>e.id!==t.previousId);return{...e,items:[t.item,...n]}}case`ITEM_REMOVED`:return{...e,items:e.items.filter(e=>e.id!==t.id)};case`ITEMS_CLEARED`:return{...e,items:[]};default:return e}}var Sl=(0,M.createContext)(null);function Cl({children:e}){let[t,n]=(0,M.useReducer)(xl,{items:[],isLoading:!0}),r=(0,M.useRef)(null);(0,M.useEffect)(()=>{pl().then(e=>n({type:`HYDRATE`,items:e}))},[]),(0,M.useEffect)(()=>{let e;try{e=bl()}catch{return}return r.current=e,e.onmessage=e=>{let t=e.data;switch(t.type){case`item-added`:n({type:`ITEM_ADDED`,item:t.item});break;case`item-replaced`:n({type:`ITEM_REPLACED`,item:t.item,previousId:t.previousId});break;case`item-removed`:n({type:`ITEM_REMOVED`,id:t.id});break;case`items-cleared`:n({type:`ITEMS_CLEARED`});break}},()=>{e.close(),r.current=null}},[]);let i=(0,M.useCallback)(e=>{r.current?.postMessage(e)},[]),a=(0,M.useCallback)(async(e,t,r)=>{try{let a={id:crypto.randomUUID(),clippedAt:new Date().toISOString(),sourceWsPath:r.sourceWsPath,sourceLabel:r.sourceLabel,node:e,connections:t},o=await ml(e.alias);if(o)return{status:`duplicate`,existingItem:o,pendingItem:a};try{await hl(a)}catch(t){if(t instanceof DOMException&&t.name===`ConstraintError`){let t=await ml(e.alias);if(t)return{status:`duplicate`,existingItem:t,pendingItem:a}}throw t}return n({type:`ITEM_ADDED`,item:a}),i({type:`item-added`,item:a}),{status:`added`}}catch(e){return{status:`error`,message:e instanceof Error?e.message:String(e)}}},[i]),o=(0,M.useCallback)(async(e,t)=>{await gl(t,e),n({type:`ITEM_REPLACED`,item:e,previousId:t}),i({type:`item-replaced`,item:e,previousId:t})},[i]),s=(0,M.useCallback)(async e=>{await _l(e),n({type:`ITEM_REMOVED`,id:e}),i({type:`item-removed`,id:e})},[i]),c=(0,M.useCallback)(async()=>{await vl(),n({type:`ITEMS_CLEARED`}),i({type:`items-cleared`})},[i]);return(0,P.jsx)(Sl.Provider,{value:{items:t.items,isLoading:t.isLoading,clipNode:a,confirmReplace:o,removeItem:s,clearAll:c},children:e})}function wl(){let e=(0,M.useContext)(Sl);if(!e)throw Error(`useClipboardContext must be used inside <ClipboardProvider>`);return e}var Tl=new Intl.Collator(void 0,{sensitivity:`base`,numeric:!0});function El(e){return e.node.types[0]?.trim()||`unknown`}function Dl(e,t){return Tl.compare(e,t)}function Ol(e,t){return e-t}function kl(e){return e===`recent`||e===`connections`?`descending`:`ascending`}function Al(e,t){return t===`descending`?-e:e}function jl(e,t){let n=t.trim();if(!n)return{missing:!0,value:``};let r=e.node.properties[n];return r==null?{missing:!0,value:``}:typeof r==`string`?{missing:!1,value:r}:typeof r==`number`||typeof r==`boolean`?{missing:!1,value:String(r)}:{missing:!1,value:JSON.stringify(r)}}function Ml(e,t,n,r){let i=jl(e,n),a=jl(t,n);return i.missing&&!a.missing?1:!i.missing&&a.missing?-1:Al(Dl(i.value,a.value),r)}function Nl(e,t){let n=t.direction??kl(t.field);return e.map((e,t)=>({item:e,originalIndex:t})).sort((e,r)=>{let i=0;switch(t.field){case`type`:i=Dl(El(e.item),El(r.item));break;case`alias`:i=Dl(e.item.node.alias,r.item.node.alias);break;case`source`:i=Dl(e.item.sourceLabel,r.item.sourceLabel);break;case`connections`:i=e.item.connections.length-r.item.connections.length;break;case`property`:i=Ml(e.item,r.item,t.propertyKey??``,n);break;default:i=Date.parse(e.item.clippedAt)-Date.parse(r.item.clippedAt);break}return t.field!==`property`&&(i=Al(i,n)),i===0?Ol(e.originalIndex,r.originalIndex):i}).map(({item:e})=>e)}function Pl(e){let t=Date.now()-new Date(e).getTime();if(t<0)return`just now`;let n=Math.floor(t/1e3);if(n<60)return`just now`;let r=Math.floor(n/60);if(r<60)return`${r} min ago`;let i=Math.floor(r/60);if(i<24)return`${i} hour${i>1?`s`:``} ago`;let a=Math.floor(i/24);return a===1?`yesterday`:a<30?`${a} days ago`:new Date(e).toLocaleDateString()}var Fl={item:`_item_1ne62_1`,previewFrame:`_previewFrame_1ne62_13`,preview:`_preview_1ne62_13`,previewShell:`_previewShell_1ne62_25`,metaBlock:`_metaBlock_1ne62_29`,timestamp:`_timestamp_1ne62_35`,removeChrome:`_removeChrome_1ne62_40`,removeIcon:`_removeIcon_1ne62_71`};function Il({item:e,onRemove:t,onOpenMenu:n,onCloseMenu:r}){let{node:i,clippedAt:a,sourceLabel:o}=e;return(0,P.jsxs)(`div`,{className:Fl.item,children:[(0,P.jsxs)(`div`,{className:Fl.previewFrame,children:[(0,P.jsx)(`button`,{type:`button`,className:Fl.removeChrome,draggable:!1,"aria-label":`Remove node ${i.alias} from clipboard`,onClick:n=>{n.stopPropagation(),r(),t(e.id)},children:(0,P.jsx)(Is,{className:Fl.removeIcon,"aria-hidden":`true`,focusable:`false`})}),(0,P.jsx)(`div`,{className:Fl.preview,role:`group`,draggable:!0,onDragStart:t=>{r(),Co(t.dataTransfer,e.id)},onContextMenu:t=>{t.preventDefault(),n(e.id,t.clientX,t.clientY)},onKeyDown:t=>{if(t.key===`ContextMenu`||t.key===`F10`&&t.shiftKey){t.preventDefault();let r=t.currentTarget.getBoundingClientRect();n(e.id,Math.round(r.left+8),Math.round(r.top+8))}},tabIndex:0,"aria-label":`Drag node ${i.alias} into the graph to paste`,children:(0,P.jsx)(`div`,{className:Fl.previewShell,style:ua(i.types[0]??`unknown`),children:(0,P.jsx)(ma,{alias:i.alias,nodeType:i.types[0]??`unknown`,properties:i.properties})})})]}),(0,P.jsx)(`div`,{className:Fl.metaBlock,children:(0,P.jsxs)(`div`,{className:Fl.timestamp,children:[`Clipped `,Pl(a),` from `,o]})})]})}var Ll={menu:`_menu_164vh_1`,menuItem:`_menuItem_164vh_12`},Rl=16;function K(e,t,n){let r=Rl,i=Math.max(Rl,n-t-Rl);return Math.min(Math.max(e,r),i)}function q({open:e,x:t,y:n,canPasteToInput:r,onPasteToInput:i,onInspect:a,onClose:o}){let s=(0,M.useRef)(null),c=(0,M.useRef)(null),l=(0,M.useRef)(null),[u,d]=(0,M.useState)({left:t,top:n});return(0,M.useLayoutEffect)(()=>{if(!e||!s.current)return;let r=s.current.getBoundingClientRect();d({left:K(t,r.width,window.innerWidth),top:K(n,r.height,window.innerHeight)})},[e,t,n]),(0,M.useEffect)(()=>{if(!e)return;r?c.current?.focus():l.current?.focus();let t=e=>{s.current&&!s.current.contains(e.target)&&o()},n=e=>{e.key===`Escape`&&(e.preventDefault(),o())},i=()=>o();return document.addEventListener(`pointerdown`,t),document.addEventListener(`keydown`,n),window.addEventListener(`scroll`,i,!0),window.addEventListener(`resize`,i),()=>{document.removeEventListener(`pointerdown`,t),document.removeEventListener(`keydown`,n),window.removeEventListener(`scroll`,i,!0),window.removeEventListener(`resize`,i)}},[e,r,o]),e?(0,P.jsxs)(`div`,{ref:s,className:Ll.menu,style:{left:u.left,top:u.top},role:`menu`,"aria-label":`Clipboard item actions`,children:[(0,P.jsx)(`button`,{ref:c,role:`menuitem`,type:`button`,className:Ll.menuItem,disabled:!r,onClick:()=>{r&&i()},children:`Paste to Input`}),(0,P.jsx)(`button`,{ref:l,role:`menuitem`,type:`button`,className:Ll.menuItem,onClick:a,children:`Inspect`})]}):null}var J={sidebar:`_sidebar_1jo34_2`,header:`_header_1jo34_12`,headerTitle:`_headerTitle_1jo34_25`,clearBtn:`_clearBtn_1jo34_32`,sortBar:`_sortBar_1jo34_48`,sortMenuWrapper:`_sortMenuWrapper_1jo34_63`,sortMenuButton:`_sortMenuButton_1jo34_68`,sortButtonLabel:`_sortButtonLabel_1jo34_93`,sortButtonValue:`_sortButtonValue_1jo34_98`,sortButtonDirection:`_sortButtonDirection_1jo34_106`,sortButtonCaret:`_sortButtonCaret_1jo34_114`,sortButtonCaretOpen:`_sortButtonCaretOpen_1jo34_121`,sortPopover:`_sortPopover_1jo34_125`,sortGroup:`_sortGroup_1jo34_139`,propertySortRow:`_propertySortRow_1jo34_150`,sortGroupTitle:`_sortGroupTitle_1jo34_154`,sortOption:`_sortOption_1jo34_164`,propertyLabel:`_propertyLabel_1jo34_197`,propertyInput:`_propertyInput_1jo34_205`,itemList:`_itemList_1jo34_223`,loading:`_loading_1jo34_233`,emptyState:`_emptyState_1jo34_243`,emptyIcon:`_emptyIcon_1jo34_256`,emptyTitle:`_emptyTitle_1jo34_261`,emptyHint:`_emptyHint_1jo34_265`,inspectPanel:`_inspectPanel_1jo34_271`,inspectHeader:`_inspectHeader_1jo34_279`,inspectClose:`_inspectClose_1jo34_293`,inspectBody:`_inspectBody_1jo34_307`,dialog:`_dialog_1jo34_313`,dialogTitle:`_dialogTitle_1jo34_328`,dialogBody:`_dialogBody_1jo34_335`,dialogActions:`_dialogActions_1jo34_342`,cancelBtn:`_cancelBtn_1jo34_349`,replaceBtn:`_replaceBtn_1jo34_363`};function Y(){return(0,P.jsxs)(`div`,{className:J.emptyState,children:[(0,P.jsx)(`span`,{className:J.emptyIcon,children:`📋`}),(0,P.jsx)(`span`,{className:J.emptyTitle,children:`No items clipped yet.`}),(0,P.jsx)(`span`,{className:J.emptyHint,children:`Right-click a node in the Graph view to get started.`})]})}var X=[{value:`recent`,label:`Recent`},{value:`type`,label:`Type`},{value:`alias`,label:`Alias`},{value:`source`,label:`Source`},{value:`connections`,label:`Connections`},{value:`property`,label:`Property`}],zl=[{value:`ascending`,label:`Ascending`},{value:`descending`,label:`Descending`}],Bl=X.reduce((e,t)=>({...e,[t.value]:t.label}),{});function Vl({connected:e,onPasteToInput:t}){let n=(0,M.useId)(),i=(0,M.useId)(),a=(0,M.useRef)(null),s=wl(),[c,l]=(0,M.useState)(null),[u,d]=(0,M.useState)(null),[f,p]=(0,M.useState)(`recent`),[m,h]=(0,M.useState)(kl(`recent`)),[g,_]=(0,M.useState)(``),[v,y]=(0,M.useState)(!1),b=(e,t,n)=>{d({itemId:e,x:t,y:n})},x=()=>{d(null)},S=e=>{x(),t(e)},C=e=>{x(),l(t=>t?.id===e.id?null:e)},w=e=>{x(),l(t=>t?.id===e?null:t),s.removeItem(e)},ee=()=>{x(),l(null),s.clearAll()},T=e=>{p(e),h(kl(e))};(0,M.useEffect)(()=>{let e=new Set(s.items.map(e=>e.id));u&&!e.has(u.itemId)&&d(null),c&&!e.has(c.id)&&l(null)},[s.items,u,c]),(0,M.useEffect)(()=>{if(!v)return;let e=e=>{a.current?.contains(e.target)||y(!1)},t=e=>{e.key===`Escape`&&y(!1)};return document.addEventListener(`pointerdown`,e),document.addEventListener(`keydown`,t),()=>{document.removeEventListener(`pointerdown`,e),document.removeEventListener(`keydown`,t)}},[v]);let te=(0,M.useMemo)(()=>u?s.items.find(e=>e.id===u.itemId)??null:null,[u,s.items]),E=(0,M.useMemo)(()=>Nl(s.items,{field:f,direction:m,propertyKey:g}),[s.items,m,f,g]);return(0,P.jsxs)(`div`,{className:J.sidebar,children:[(0,P.jsxs)(`div`,{className:J.header,children:[(0,P.jsx)(`span`,{className:J.headerTitle,children:`Workspace`}),s.items.length>0&&(0,P.jsx)(`button`,{className:J.clearBtn,onClick:ee,"aria-label":`Clear all workspace items`,children:`Clear`})]}),s.items.length>0&&(0,P.jsx)(`div`,{className:J.sortBar,children:(0,P.jsxs)(`div`,{className:J.sortMenuWrapper,ref:a,children:[(0,P.jsxs)(`button`,{type:`button`,className:J.sortMenuButton,onClick:()=>y(e=>!e),"aria-expanded":v,"aria-controls":n,children:[(0,P.jsx)(`span`,{className:J.sortButtonLabel,children:`Sort`}),(0,P.jsx)(`span`,{className:J.sortButtonValue,children:Bl[f]}),(0,P.jsx)(`span`,{className:J.sortButtonDirection,children:m===`ascending`?`Asc`:`Desc`}),(0,P.jsx)(`span`,{className:`${J.sortButtonCaret}${v?` ${J.sortButtonCaretOpen}`:``}`,"aria-hidden":`true`,children:`▾`})]}),v&&(0,P.jsxs)(`div`,{id:n,className:J.sortPopover,children:[(0,P.jsxs)(`div`,{className:J.sortGroup,role:`group`,"aria-labelledby":`${n}-field-title`,children:[(0,P.jsx)(`div`,{id:`${n}-field-title`,className:J.sortGroupTitle,children:`Sort By`}),X.map(e=>(0,P.jsxs)(`label`,{className:J.sortOption,children:[(0,P.jsx)(`input`,{type:`radio`,name:`${n}-field`,value:e.value,checked:f===e.value,onChange:()=>T(e.value)}),(0,P.jsx)(`span`,{children:e.label})]},e.value))]}),f===`property`&&(0,P.jsxs)(`div`,{className:J.propertySortRow,children:[(0,P.jsx)(`label`,{className:J.propertyLabel,htmlFor:i,children:`Property Key`}),(0,P.jsx)(`input`,{id:i,className:J.propertyInput,value:g,onChange:e=>_(e.target.value),placeholder:`skill`,"aria-label":`Property key to sort by`})]}),(0,P.jsxs)(`div`,{className:J.sortGroup,role:`group`,"aria-labelledby":`${n}-direction-title`,children:[(0,P.jsx)(`div`,{id:`${n}-direction-title`,className:J.sortGroupTitle,children:`Sort Direction`}),zl.map(e=>(0,P.jsxs)(`label`,{className:J.sortOption,children:[(0,P.jsx)(`input`,{type:`radio`,name:`${n}-direction`,value:e.value,checked:m===e.value,onChange:()=>h(e.value)}),(0,P.jsx)(`span`,{children:e.label})]},e.value))]})]})]})}),(0,P.jsx)(`div`,{className:J.itemList,children:s.isLoading?(0,P.jsx)(`div`,{className:J.loading,children:`Loading…`}):s.items.length===0?(0,P.jsx)(Y,{}):E.map(e=>(0,P.jsx)(Il,{item:e,onRemove:w,onOpenMenu:b,onCloseMenu:x},e.id))}),c&&(0,P.jsxs)(`div`,{className:J.inspectPanel,children:[(0,P.jsxs)(`div`,{className:J.inspectHeader,children:[(0,P.jsxs)(`span`,{children:[`Inspect node `,c.node.alias]}),(0,P.jsx)(`button`,{className:J.inspectClose,onClick:()=>l(null),"aria-label":`Close inspect panel`,children:`✕`})]}),(0,P.jsx)(`div`,{className:J.inspectBody,children:(0,P.jsx)(o,{data:{node:c.node,connections:c.connections},style:r})})]}),u&&te&&(0,P.jsx)(q,{open:!0,x:u.x,y:u.y,canPasteToInput:e,onPasteToInput:()=>S(te),onInspect:()=>C(te),onClose:x})]})}function Hl(e){let{wheelTargetRef:t,scrollRef:n,contentWrapperRef:r,currentIndex:i,totalPages:a,onNavigatePrev:o,onNavigateNext:s}=e,c=(0,M.useRef)(0),l=(0,M.useRef)(null),u=(0,M.useRef)(!1),d=(0,M.useRef)(null),f=(0,M.useRef)(o),p=(0,M.useRef)(s),m=(0,M.useRef)(i),h=(0,M.useRef)(a);(0,M.useEffect)(()=>{f.current=o}),(0,M.useEffect)(()=>{p.current=s}),(0,M.useEffect)(()=>{m.current=i}),(0,M.useEffect)(()=>{h.current=a}),(0,M.useEffect)(()=>{d.current!==null&&(clearTimeout(d.current),d.current=null),r.current&&(r.current.style.transition=`none`,r.current.style.transform=`translateY(0)`),c.current=0,l.current=null},[i]),(0,M.useEffect)(()=>{let e=t.current;if(!e)return;function i(){c.current=0,l.current=null,r.current&&(r.current.style.transition=`transform 0.28s cubic-bezier(0.25, 0.46, 0.45, 0.94)`,r.current.style.transform=`translateY(0)`)}function a(e){if(e.deltaY===0)return;let t=n.current;if(!t)return;let a=t.scrollTop<=0,o=t.scrollTop+t.clientHeight>=t.scrollHeight-1,s=e.deltaY<0,g=e.deltaY>0,_=a&&s,v=o&&g;if(!_&&!v){i();return}if(u.current)return;let y=m.current,b=h.current;if(_&&y===0||v&&y===b-1)return;let x=_?`prev`:`next`;if(l.current!==null&&l.current!==x&&i(),l.current=x,c.current+=Math.abs(e.deltaY),r.current){let e=x===`prev`?-1:1,t=c.current*(18/120),n=Math.min(t,18)*e;r.current.style.transition=`none`,r.current.style.transform=`translateY(${n}px)`}if(d.current!==null&&clearTimeout(d.current),d.current=setTimeout(i,180),c.current>=120){d.current!==null&&clearTimeout(d.current);let e=l.current;i(),u.current=!0,e===`prev`?f.current():p.current(),setTimeout(()=>{u.current=!1},650)}}return e.addEventListener(`wheel`,a,{passive:!0}),()=>{d.current!==null&&clearTimeout(d.current),e.removeEventListener(`wheel`,a)}},[])}var Ul={helpRoot:`_helpRoot_18tja_2`,categoryNav:`_categoryNav_18tja_11`,categoryTabScroller:`_categoryTabScroller_18tja_21`,categoryTab:`_categoryTab_18tja_21`,categoryTabActive:`_categoryTabActive_18tja_71`,maximizeButton:`_maximizeButton_18tja_78`,closeButton:`_closeButton_18tja_100`,helpBody:`_helpBody_18tja_122`,emptyFallback:`_emptyFallback_18tja_130`,helpContent:`_helpContent_18tja_147`,topicLink:`_topicLink_18tja_226`,helpBodyContent:`_helpBodyContent_18tja_271`,chipStrip:`_chipStrip_18tja_276`,chipStripLabel:`_chipStripLabel_18tja_294`,topicChip:`_topicChip_18tja_310`,topicChipActive:`_topicChipActive_18tja_338`};function Wl(e){return typeof e==`string`?e:typeof e==`number`?String(e):Array.isArray(e)?e.map(Wl).join(``):M.isValidElement(e)?Wl(e.props.children):``}function Gl(e){if(!e.trim().toLowerCase().startsWith(`help `))return null;let t=e.trim().slice(5).replace(/\s*\(.*\)\s*$/,``).trim().toLowerCase();return t.length>0?t:null}function Kl({activeTopic:e,onNavigate:t,onClose:n,onToggleMaximize:r,isMaximized:i}){let a=(0,M.useRef)(null),o=(0,M.useRef)(null),s=(0,M.useRef)(null),c=(0,M.useRef)(null);(0,M.useEffect)(()=>{a.current&&(a.current.scrollTop=0)},[e]),(0,M.useEffect)(()=>{let e=c.current;if(!e)return;let t=e.querySelector(`[aria-current="step"]`);t&&t.scrollIntoView({block:`nearest`,inline:`nearest`,behavior:`smooth`})},[e]);let l=ui(e),u=(0,M.useMemo)(()=>di(l),[l]),d=u.length,f=(0,M.useMemo)(()=>ci.find(e=>e.id===l)?.chipStripLabel??null,[l]),p=pi.indexOf(e),m=p<0?0:p,h=pi.length;Hl({wheelTargetRef:o,scrollRef:a,contentWrapperRef:s,currentIndex:m,totalPages:h,onNavigatePrev:()=>t(pi[m-1]??``),onNavigateNext:()=>t(pi[m+1]??pi[pi.length-1])});let g=oi(e);return(0,P.jsxs)(`div`,{className:Ul.helpRoot,role:`region`,"aria-label":`Help browser`,ref:o,children:[(0,P.jsxs)(`nav`,{className:Ul.categoryNav,"aria-label":`Help categories`,children:[(0,P.jsx)(`div`,{className:Ul.categoryTabScroller,children:ci.map(e=>(0,P.jsx)(`button`,{className:[Ul.categoryTab,e.id===l?Ul.categoryTabActive:``].join(` `).trim(),"aria-current":e.id===l?`true`:void 0,onClick:()=>{t(di(e.id)[0]??``)},children:e.label},e.id))}),r&&(0,P.jsx)(`button`,{className:Ul.maximizeButton,onClick:r,"aria-label":i?`Restore help panel`:`Maximize help panel`,children:i?`⊞`:`⛶`}),n&&(0,P.jsx)(`button`,{className:Ul.closeButton,onClick:n,"aria-label":`Close help panel`,children:`×`})]}),d>1&&(0,P.jsxs)(`div`,{className:Ul.chipStrip,ref:c,children:[f!==null&&(0,P.jsx)(`span`,{className:Ul.chipStripLabel,children:f}),u.map(n=>{let r=n===e,i=fi(n,l);return(0,P.jsx)(`button`,{className:[Ul.topicChip,r?Ul.topicChipActive:``].join(` `).trim(),"aria-current":r?`step`:void 0,onClick:()=>t(n),children:i},n)})]}),(0,P.jsx)(`div`,{className:Ul.helpBody,ref:a,children:(0,P.jsx)(`div`,{className:Ul.helpBodyContent,ref:s,children:g===null?(0,P.jsxs)(`div`,{className:Ul.emptyFallback,children:[(0,P.jsxs)(`code`,{children:[`help `,e||``]}),`\xA0 not found in the local bundle.`]}):(0,P.jsx)(`div`,{className:Ul.helpContent,children:(0,P.jsx)(y,{remarkPlugins:[x],components:e===``?{li:({children:e,...n})=>{let r=Gl(Wl(e).trim());return r!==null&&oi(r)!==null?(0,P.jsx)(`li`,{...n,children:(0,P.jsx)(`button`,{className:Ul.topicLink,"aria-label":`Open help topic: ${r}`,onClick:()=>t(r),children:e})}):(0,P.jsx)(`li`,{...n,children:e})}}:void 0,children:g})})})})]})}function ql({existingItem:e,pendingItem:t,onReplace:n,onCancel:r}){let i=(0,M.useRef)(null);return(0,M.useEffect)(()=>{let e=i.current;e&&!e.open&&e.showModal()},[]),(0,P.jsxs)(`dialog`,{ref:i,className:J.dialog,onClose:r,"aria-labelledby":`duplicate-dialog-title`,children:[(0,P.jsx)(`h2`,{id:`duplicate-dialog-title`,className:J.dialogTitle,children:`Duplicate Node`}),(0,P.jsxs)(`p`,{className:J.dialogBody,children:[`A clipboard item with alias `,(0,P.jsxs)(`strong`,{children:[`"`,t.node.alias,`"`]}),` already exists (clipped `,Pl(e.clippedAt),`).`]}),(0,P.jsx)(`p`,{className:J.dialogBody,children:`Replace it with the new snapshot?`}),(0,P.jsxs)(`div`,{className:J.dialogActions,children:[(0,P.jsx)(`button`,{className:J.cancelBtn,onClick:r,children:`Cancel`}),(0,P.jsx)(`button`,{className:J.replaceBtn,onClick:n,children:`Replace`})]})]})}function Jl(e,t){if(!t)return null;let n=e.trim().toLowerCase();if(n!==`help`&&!n.startsWith(`help `))return null;let r=mi(e);return oi(r)===null?null:r}var Yl=class{constructor(){this.listeners=new Map}on(e,t){let n=e;return this.listeners.has(n)||this.listeners.set(n,new Set),this.listeners.get(n).add(t),()=>{this.listeners.get(n)?.delete(t)}}emit(e){let t=this.listeners.get(e.kind);t&&t.forEach(t=>{try{t(e)}catch(t){console.error(`[ProtocolBus] listener for '${e.kind}' threw:`,t)}})}clear(){this.listeners.clear()}},Xl=`(ws-\\d+-\\d+)`,Zl=RegExp(`^session ${Xl} started(?:\\nCompanion endpoint: (\\/api\\/companion\\/${Xl}))?$`,`i`),Ql=RegExp(`^Session ${Xl} started since (.+)$`),$l=RegExp(`^subscribed to ${Xl}$`),eu=/^subscribed by \[(.*)]$/,tu=RegExp(`^Subscribed to ${Xl}$`),nu=RegExp(`^Session unsubscribed from ${Xl}$`),ru=RegExp(`^Session ${Xl} not found$`),iu=RegExp(`^${Xl} is not a primary session$`),au=RegExp(`^You have already subscribed to ${Xl}(?:\\nPlease do 'session reset' before subscribing to another session)?$`),ou=RegExp(`^${Xl} subscribed to your session$`),su=RegExp(`^${Xl} unsubscribed from your session$`),cu=RegExp(`^Session ${Xl} has closed$`);function lu(e){let t=e.trim();return t.length===0||t.startsWith(`> `)?null:t}function uu(e){return e.split(`,`).map(e=>e.trim()).filter(e=>e.length>0&&Oc(e))}function du(e){let t=lu(e);if(!t)return null;let n=t.match(Zl);return n?{sessionId:n[1],companionEndpoint:n[2]??null}:null}function fu(e){let t=lu(e);if(!t)return null;let n=t.split(`
 `).map(e=>e.trim()).filter(Boolean),r=n[0];if(!r)return null;let i=r.match(Ql);if(!i)return null;let a=null,o=[];for(let e of n.slice(1)){let t=e.match($l);if(t){a=t[1];continue}let n=e.match(eu);n&&(o=uu(n[1]))}return{sessionId:i[1],startedSince:i[2],subscribedTo:a,subscribers:o}}function pu(e){let t=lu(e);if(!t)return null;let n=t.match(tu);if(n)return{command:`subscribe`,status:`accepted`,sessionId:n[1],message:t};let r=t.match(nu);if(r)return{command:`unsubscribe`,status:`accepted`,sessionId:r[1],message:t};let i=t.match(ru);if(i)return{command:`subscribe`,status:`rejected`,sessionId:i[1],message:t};let a=t.match(iu);if(a)return{command:`subscribe`,status:`rejected`,sessionId:a[1],message:t};let o=t.match(au);return o?{command:`subscribe`,status:`rejected`,sessionId:o[1],message:t}:t===`You cannot subscribe to yourself`?{command:`subscribe`,status:`rejected`,sessionId:null,message:t}:t===`Nothing to unsubscribe`?{command:`unsubscribe`,status:`rejected`,sessionId:null,message:t}:t===`Invalid session command`?{command:`unknown`,status:`rejected`,sessionId:null,message:t}:null}function mu(e){let t=lu(e);if(!t)return null;let n=t.match(ou);if(n)return{type:`subscriber-joined`,sessionId:n[1],message:t};let r=t.match(su);if(r)return{type:`subscriber-left`,sessionId:r[1],message:t};let i=t.match(cu);return i?{type:`host-closed`,sessionId:i[1],message:t}:null}var hu=new Set([`info`,`error`,`ping`,`welcome`]);function gu(e,t){let n=[],r={msgId:e,raw:t},i=!1,a=!1,o=!1,s=!1,c=!1,l=!1,u=Dr(t);if(u.isJSON){let e=u.data;if(typeof e.type==`string`){let i=e.type;return n.push({...r,kind:`lifecycle`,type:i,knownType:hu.has(i),message:typeof e.message==`string`?e.message:t,time:e.time??null}),n.length>0?n:[{...r,kind:`unclassified`}]}return n.push({...r,kind:`json.response`,data:u.data}),n.length>0?n:[{...r,kind:`unclassified`}]}let d=Pr(t);d&&(c=!0,n.push({...r,kind:`payload.large`,apiPath:d.apiPath,byteSize:d.byteSize,filename:d.filename}));let f=Fr(t);f&&(o=!0,n.push({...r,kind:`upload.invitation`,uploadPath:f}));let p=Nr(t);if(p&&(s=!0,n.push({...r,kind:`upload.contentPath`,uploadPath:p})),Mr(t)){a=!0;let e=jr(t);e&&n.push({...r,kind:`graph.link`,apiPath:e})}if(a){let e=Or(t);e&&n.push({...r,kind:`graph.exported`,graphName:e.graphName,apiPath:e.apiPath})}let m=Jr(t);m&&n.push({...r,kind:`graph.mutation`,mutationType:m});let h=qr(t);h&&n.push({...r,kind:`minigraph.nodeAction.textResult`,status:h.status,action:h.action,alias:h.alias,targetAlias:h.targetAlias,message:h.message}),h&&(h.action===`create-node`||h.status===`error`)&&n.push({...r,kind:`minigraph.createNode.textResult`,status:h.status,alias:h.alias,message:h.message}),t===`Session restarted`&&(l=!0,n.push({...r,kind:`session.reset`}));let g=du(t);g&&(l=!0,n.push({...r,kind:`minigraph.session.started`,sessionId:g.sessionId,companionEndpoint:g.companionEndpoint}));let _=fu(t);_&&(l=!0,n.push({...r,kind:`minigraph.session.status`,sessionId:_.sessionId,startedSince:_.startedSince,subscribedTo:_.subscribedTo,subscribers:_.subscribers}));let v=pu(t);v&&(l=!0,n.push({...r,kind:`minigraph.session.commandResult`,command:v.command,status:v.status,sessionId:v.sessionId,message:v.message}));let y=mu(t);y&&(l=!0,n.push({...r,kind:`minigraph.session.notification`,type:y.type,sessionId:y.sessionId,message:y.message})),t.startsWith(`> `)&&(i=!0,n.push({...r,kind:`command.echo`,commandText:t.slice(2)})),Ir(t)&&n.push({...r,kind:`command.helpOrDescribe`,commandText:t.slice(2)});let b=Lr(t);b&&n.push({...r,kind:`command.importGraph`,graphName:b});let x=kr(t);return x&&n.push({...r,kind:`graph.export.failed`,reason:x.reason}),!i&&!a&&!o&&!s&&!c&&!l&&Ar(t)&&n.push({...r,kind:`docs.response`,isMarkdown:!0}),n.length===0&&n.push({...r,kind:`unclassified`}),n}function _u({messages:e,bus:t}){let n=(0,M.useRef)(-1);(0,M.useEffect)(()=>{e.length>0&&(n.current=e[e.length-1].id)},[]);let r=(0,M.useMemo)(()=>{let t=new Map;for(let n of e)t.set(n.id,gu(n.id,n.raw));return t},[e]);return(0,M.useEffect)(()=>{if(e.length===0)return;let i=e.filter(e=>e.id>n.current);if(i.length!==0){n.current=e[e.length-1].id;for(let e of i){let n=r.get(e.id);if(n)for(let e of n)t.emit(e)}}},[e,t,r]),{classificationMap:r}}function vu({config:e}){let{title:t,wsPath:n,storageKeyPayload:r,storageKeyHistory:i,storageKeyTab:a,storageKeySavedGraphs:o,supportsUpload:s,supportsClipboard:c,supportsHelp:l,supportsAuthoring:u,supportsSessionCollaboration:d,tabs:f}=e,p=Ct(),[m,h]=hr(r,``),g=wr(),[_,v]=(0,M.useState)(()=>g.peekPendingPayload(n)),{takePendingPayload:y}=g;(0,M.useEffect)(()=>{let e=y(n);e!==null&&v(e)},[y,n]);let b=_??m,x=(0,M.useCallback)(e=>{v(null),h(e)},[h]),T=(0,M.useMemo)(()=>b?fr(b):{valid:!0,error:null,type:null},[b]),{toasts:te,addToast:E,removeToast:ne}=mr(),re=(0,M.useRef)(new Yl).current,D=Zr({wsPath:n,storageKeyHistory:i,payload:b,addToast:E,bus:re,handleLocalCommand:(0,M.useCallback)(e=>Jl(e,l===!0)!==null,[l])}),{classificationMap:ie}=_u({messages:D.messages,bus:re}),[ae,oe]=Ai(n),{graphData:se,setGraphData:O,rightTab:k,setRightTab:ce,isRefreshing:le}=ti(ae,E,f[0],f,a),{modalUploadPath:ue,successfulUploadPaths:de,handleOpenUploadModal:A,handleCloseUploadModal:j,handleUploadSuccess:fe,handleUploadError:pe,resetSuccessfulPaths:me}=vi({bus:re,addToast:E});ni({bus:re,pinnedGraphPath:ae,setPinnedGraphPath:oe,connected:D.connected,sendRawText:D.sendRawText,addToast:E});let he=(0,M.useRef)(!1);(0,M.useEffect)(()=>{he.current&&!D.connected&&(oe(null),O(null)),he.current=D.connected},[D.connected,oe,O]);let[ge,_e]=hr(e.storageKeyHelpTopic??`help-topic-fallback`,``),[ve,ye]=hr(`help-panel-open`,!1),[be,xe]=(0,M.useState)(()=>!!l&&!ve),[Se,Ce]=(0,M.useState)(!1),we=(0,M.useRef)(null),Te=(0,M.useCallback)(()=>{be&&(Ce(!0),we.current=setTimeout(()=>xe(!1),400))},[be]);(0,M.useEffect)(()=>{if(!be||Se)return;let e=setTimeout(Te,3e3);return()=>clearTimeout(e)},[be,Se,Te]),(0,M.useEffect)(()=>{ve&&be&&Te()},[ve,be,Te]),(0,M.useEffect)(()=>()=>{we.current&&clearTimeout(we.current)},[]),(0,M.useEffect)(()=>{if(!l)return;let e=e=>{e.ctrlKey&&e.key==="`"&&(e.preventDefault(),ye(e=>!e))};return window.addEventListener(`keydown`,e),()=>window.removeEventListener(`keydown`,e)},[l,ye]),hi({bus:re,setHelpTopic:_e,onTabSwitch:l?()=>ye(!0):()=>{}}),yi({bus:re,connected:D.connected,appendMessage:D.appendMessage,addToast:E});let Ee=wl(),[De,Oe]=hr(`clipboard-sidebar-open`,!1),[ke,Ae]=(0,M.useState)(null),je=(0,M.useCallback)(e=>{let t=Ni(e,se);D.setCommand(t.command),E(`${t.verb===`create`?`Create`:`Update`} command for "${e.node.alias}" pasted to input`,`info`)},[se,D.setCommand,E]),Me=(0,M.useCallback)(e=>{let t=Ee.items.find(t=>t.id===e);if(!t){E(`Clipboard item is no longer available. It may have been removed in another tab.`,`error`);return}let n=Ni(t,se);if(!D.sendRawText(n.command)){E(`Could not send clipboard paste command because the WebSocket is not open.`,`error`);return}E(`Clipboard node "${t.node.alias}" sent as ${n.verb}. Waiting for backend response.`,`info`)},[Ee.items,se,D.sendRawText,E]),Ne=(0,M.useCallback)(async(t,r)=>{try{let i=await Ee.clipNode(t,r,{sourceWsPath:n,sourceLabel:e.label});switch(i.status){case`added`:E(`Node "${t.alias}" clipped to workspace`,`success`);break;case`duplicate`:Ae({pendingItem:i.pendingItem,existingItem:i.existingItem});break;case`error`:E(`Clip failed: ${i.message}`,`error`);break}}catch(e){E(`Clip failed: ${e instanceof Error?e.message:String(e)}`,`error`)}},[Ee,n,e.label,E]),Pe=(0,M.useCallback)(async t=>{if(t.length===0){E(`No selected nodes are available to clip.`,`info`);return}if(t.length>100){E(`Select 100 or fewer nodes to clip at once.`,`error`);return}let r={added:0,duplicates:0,failed:0};for(let i of t){if(!i.node?.alias?.trim()){r.failed+=1;continue}try{let t=await Ee.clipNode(i.node,i.connections,{sourceWsPath:n,sourceLabel:e.label});t.status===`added`&&(r.added+=1),t.status===`duplicate`&&(r.duplicates+=1),t.status===`error`&&(r.failed+=1)}catch{r.failed+=1}}let i=Fi(r);E(i.message,i.type)},[E,Ee,e.label,n]),Fe=bi(o??``),{defaultName:Ie,savedName:Le,resetName:Re}=Ei(o?`${o}-untitled-counter`:`untitled-counter`,re,D.connected,D.connectionEpoch),ze=(0,M.useMemo)(()=>{let e=se?.nodes.find(e=>e.types.includes(`Root`)),t=typeof e?.properties?.name==`string`?e.properties.name:void 0;return t?.trim()?t:null},[se])??Ie,Be=(0,M.useMemo)(()=>Ii(D.sendRawText),[D.sendRawText]),N=Ec({bus:re,connected:D.connected,graphData:se,executor:Be,onUserMessage:E}),Ve=jc({enabled:d===!0,bus:re,classificationMap:ie,connected:D.connected,sendRawText:D.sendRawText,addToast:E}),{handleSaveGraph:He,handleLoadGraph:Ue}=Oi({bus:re,connected:D.connected,sendRawText:D.sendRawText,saveGraph:o?Fe.saveGraph:null,addToast:E}),We=(0,M.useCallback)(e=>{let t=ie.get(e.id)?.find(e=>e.kind===`graph.link`);t&&oe(t.apiPath)},[ie]),{handleSendToJsonPath:Ge}=gi({ctx:g,navigate:p,addToast:E,wsPath:n}),Ke=Qr(`(max-width: 768px)`),{defaultLayout:qe,onLayoutChanged:Je}=w({id:e.path+`-panel-split`,storage:localStorage}),Ye=(0,M.useCallback)(()=>x(pr(b)),[b]),Xe=(0,M.useCallback)(()=>{D.clearMessages(),oe(null),O(null),me(),Re()},[D.clearMessages,O,me,Re]);return(0,P.jsxs)(`div`,{className:lr.wrapper,children:[(0,P.jsx)(Bi,{toasts:te,onRemove:ne}),ue&&(0,P.jsx)(gs,{uploadPath:ue,onSuccess:fe,onClose:j,onError:pe}),u&&(0,P.jsx)(Us,{state:N.state,validationErrors:N.validationErrors,onFormStateChange:N.updateFormState,onSubmit:N.submit,onClose:N.close}),(0,P.jsxs)(`header`,{className:lr.header,children:[(0,P.jsx)(`h1`,{className:lr.title,children:t}),(0,P.jsxs)(`div`,{className:lr.headerActions,children:[o&&(0,P.jsx)(ea,{disabled:!se,defaultName:Ie,savedName:Le,onSave:He,nameExists:Fe.hasGraph,connected:D.connected}),o&&Fe.savedGraphs.length>0&&(0,P.jsx)(na,{savedGraphs:Fe.savedGraphs,onLoad:Ue,onDelete:Fe.deleteGraph,connected:D.connected}),c&&(0,P.jsxs)(`button`,{className:lr.clipboardToggle,onClick:()=>Oe(e=>!e),"aria-label":De?`Close workspace sidebar`:`Open workspace sidebar`,"aria-pressed":De,children:[`Workspace`,Ee.items.length>0?` (${Ee.items.length})`:``]}),(0,P.jsx)(Zi,{addToast:E,sessionCollaboration:d?Ve:null}),l&&(0,P.jsxs)(`div`,{className:lr.helpButtonWrapper,children:[(0,P.jsx)(`button`,{className:`${lr.helpToggle}${be&&!Se?` ${lr.helpTogglePulsing}`:``}`,onClick:()=>ye(e=>!e),"aria-label":ve?`Close help panel`:`Open help panel`,"aria-pressed":ve,children:`?`}),be&&(0,P.jsxs)(`div`,{className:`${lr.helpHint}${Se?` ${lr.helpHintFading}`:``}`,onClick:Te,role:`status`,children:[(0,P.jsx)(`kbd`,{className:lr.helpHintKbd,children:"Ctrl + `"}),` to toggle help`]})]})]})]}),ke&&(0,P.jsx)(ql,{existingItem:ke.existingItem,pendingItem:ke.pendingItem,onReplace:async()=>{try{await Ee.confirmReplace(ke.pendingItem,ke.existingItem.id),Ae(null),E(`Clipboard item "${ke.pendingItem.node.alias}" replaced`,`success`)}catch(e){E(`Replace failed: ${e instanceof Error?e.message:String(e)}`,`error`)}},onCancel:()=>{Ae(null),E(`Clip cancelled`,`info`)}}),(0,P.jsxs)(ee,{className:lr.panelGroup,orientation:Ke?`vertical`:`horizontal`,defaultLayout:qe,onLayoutChanged:Je,children:[(0,P.jsx)(C,{defaultSize:ve||De?`50%`:`60%`,minSize:`25%`,children:(0,P.jsx)(ds,{messages:D.messages,classificationMap:ie,onCopy:D.copyMessages,onClear:Xe,consoleRef:D.consoleRef,command:D.command,onCommandChange:D.setCommand,onCommandKeyDown:D.handleKeyDown,onSend:D.sendCommand,sendDisabled:!D.connected||!D.command.trim(),inputDisabled:!D.connected,commandHistory:D.history,onGraphLinkMessage:We,onCopyMessage:()=>E(`Copied to clipboard`,`success`),onSendToJsonPath:Ge,onUploadMockData:A,successfulUploadPaths:de})}),(0,P.jsx)(S,{className:lr.resizeHandle,"aria-label":`Resize panels`}),(0,P.jsx)(C,{defaultSize:ve?`50%`:De?`30%`:`40%`,minSize:`20%`,children:(0,P.jsx)($o,{tabs:f,payload:b,onChange:x,validation:T,onFormat:Ye,onUpload:s?D.uploadPayload:void 0,graphData:se,graphName:ze,activeTab:k,onTabChange:ce,onGraphRenderError:e=>E(e,`error`),onGraphDataCopySuccess:()=>E(`Graph JSON copied to clipboard!`,`success`),onGraphDataCopyError:()=>E(`Copy failed`,`error`),isGraphRefreshing:le,onClipNode:c?Ne:void 0,onClipNodes:c?Pe:void 0,onClipboardDrop:c?Me:void 0,isConnected:D.connected,supportsAuthoring:u,onCreateNode:u?N.openCreateNode:void 0,onCreateConnection:u?N.openCreateConnection:void 0,onEditNode:u?N.openEditNode:void 0,onDeleteNode:u?N.deleteNode:void 0,onDeleteNodes:u?N.deleteNodes:void 0,helpPanel:l&&ve?((e,t)=>(0,P.jsx)(Kl,{activeTopic:ge,onNavigate:_e,onClose:()=>ye(!1),onToggleMaximize:e,isMaximized:t})):void 0})}),c&&De&&(0,P.jsxs)(P.Fragment,{children:[(0,P.jsx)(S,{className:lr.resizeHandle,"aria-label":`Resize clipboard`}),(0,P.jsx)(C,{defaultSize:`20%`,minSize:`10%`,maxSize:`40%`,children:(0,P.jsx)(Vl,{connected:D.connected,onPasteToInput:je})})]})]})]})}function yu(){let e=_r[0].path;return(0,P.jsx)(Cr,{children:(0,P.jsx)(Cl,{children:(0,P.jsx)(Hn,{children:(0,P.jsxs)(Zt,{children:[_r.map(e=>(0,P.jsx)(Yt,{path:e.path,element:(0,P.jsx)(vu,{config:e},e.path)},e.path)),(0,P.jsx)(Yt,{path:`*`,element:(0,P.jsx)(Jt,{to:e,replace:!0})})]})})})})}(0,cr.createRoot)(document.getElementById(`root`)).render((0,P.jsx)(M.StrictMode,{children:(0,P.jsx)(yu,{})}));
-//# sourceMappingURL=index-DqzF65vX.js.map
+//# sourceMappingURL=index-xIKOv-ds.js.map

--- a/crates/knowledge-graph/resources/public/index.html
+++ b/crates/knowledge-graph/resources/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Minigraph Playground</title>
-  <script type="module" crossorigin src="/assets/index-DqzF65vX.js"></script>
+  <script type="module" crossorigin src="/assets/index-xIKOv-ds.js"></script>
   <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-QTnfLwEv.js">
   <link rel="modulepreload" crossorigin href="/assets/vendor-json-view-XsbV5yWD.js">
   <link rel="modulepreload" crossorigin href="/assets/vendor-markdown-Di8s8vbi.js">

--- a/crates/knowledge-graph/src/common.rs
+++ b/crates/knowledge-graph/src/common.rs
@@ -52,7 +52,7 @@ pub const OUTPUT_HEADER_NAMESPACE: &str = "output.header";
 pub const NODE_NAME: &str = "node ";
 pub const NOT_FOUND: &str = " not found";
 
-const MODEL_NAMESPACE: &str = "model.";
+pub const MODEL_NAMESPACE: &str = "model.";
 const OUTPUT_NAMESPACE: &str = "output.";
 const OUTPUT_ARRAY: &str = "output[";
 const PLUGIN_PREFIX: &str = "f:";

--- a/crates/knowledge-graph/src/mock.rs
+++ b/crates/knowledge-graph/src/mock.rs
@@ -15,12 +15,12 @@
 //
 
 //! Dev-only mock services — the Rust port of the Java
-//! `com.accenture.minigraph.mock` package (`MdmProfile`, `AccountDetails`,
-//! `HelloTask`). Each is gated by `#[optional_service("app.env=dev")]` (the
+//! `com.accenture.minigraph.mock` package (`MdmProfile`, `AccountDetails`).
+//! Each is gated by `#[optional_service("app.env=dev")]` (the
 //! Java `@OptionalService` annotation), so it registers **only** when
-//! `app.env=dev` — the data-dictionary / API-fetcher tutorials call these over
-//! HTTP as stand-in enterprise services. Profile/account fixtures ship in the
-//! engine crate's `resources/mock/`.
+//! `app.env=dev` — the data-dictionary / API-fetcher / graph-task tutorials
+//! call these over HTTP as stand-in enterprise services. Profile/account
+//! fixtures ship in the engine crate's `resources/mock/`.
 
 use std::collections::HashMap;
 
@@ -107,36 +107,6 @@ impl ComposableFunction for AccountDetails {
             &format!("account-{account_id}"),
             &format!("Account {account_id} not found"),
         )
-    }
-}
-
-/// Java `HelloTask` (`v1.hello.task`): the tutorial-13 demo task invoked through
-/// the `graph.task` skill.
-#[preload(route = "v1.hello.task", instances = 50)]
-#[optional_service("app.env=dev")]
-pub struct HelloTask;
-
-#[async_trait]
-impl ComposableFunction for HelloTask {
-    async fn handle_event(
-        &self,
-        headers: HashMap<String, String>,
-        input: EventEnvelope,
-        _instance: usize,
-    ) -> Result<EventEnvelope, AppError> {
-        let body: JsonValue = input.body_as().unwrap_or(JsonValue::Null);
-        let name = body
-            .get("name")
-            .and_then(|v| v.as_str())
-            .unwrap_or("stranger");
-        let mut result = serde_json::json!({"greeting": format!("Hello, {name}")});
-        if let Some(amount) = body.get("amount").and_then(|v| v.as_f64()) {
-            result["doubled"] = serde_json::json!(amount * 2.0);
-        }
-        if let Some(app) = headers.get("x-app") {
-            result["app"] = serde_json::json!(app);
-        }
-        EventEnvelope::new().set_body(result)
     }
 }
 

--- a/crates/knowledge-graph/src/skills.rs
+++ b/crates/knowledge-graph/src/skills.rs
@@ -33,13 +33,13 @@ use platform_core::{AppError, EventEnvelope, Platform, PostOffice};
 use rmpv::Value;
 
 use crate::common::{
-    combine, count_execute_statements, get_effective_ttl, get_else_statement, get_entries,
-    get_first_word, get_for_each_mapping, get_graph_instance, get_if_statement,
-    get_model_array_size, get_next_model_param_set, get_next_node, get_next_tag, get_node,
-    get_then_statement, handle_data_mapping_entry, invalid, perform_fetcher_output_mapping,
-    reset_nodes, split_blocks, substitute_var_if_any, COMPUTE_TAG, DELAY_TAG, ERROR, EXCEPTION,
-    EXECUTE, HEADER, IF_TAG, IN, MAPPING_TAG, MAP_TO, NEXT, NODE, NODE_NAME, RESET_TAG, RESULT,
-    SINK, SKILL, STATUS, TARGET, TYPE,
+    assert_mutable_model_target, combine, count_execute_statements, get_effective_ttl,
+    get_else_statement, get_entries, get_first_word, get_for_each_mapping, get_graph_instance,
+    get_if_statement, get_model_array_size, get_next_model_param_set, get_next_node, get_next_tag,
+    get_node, get_then_statement, handle_data_mapping_entry, invalid,
+    perform_fetcher_output_mapping, reset_nodes, split_blocks, substitute_var_if_any, COMPUTE_TAG,
+    DELAY_TAG, ERROR, EXCEPTION, EXECUTE, HEADER, IF_TAG, IN, MAPPING_TAG, MAP_TO, MODEL_NAMESPACE,
+    NEXT, NODE, NODE_NAME, RESET_TAG, RESULT, SINK, SKILL, STATUS, TARGET, TYPE,
 };
 use crate::math::ExpressionEngine;
 use crate::model::GraphInstance;
@@ -512,12 +512,38 @@ fn build_task_request(
         let lhs = substitute_var_if_any(entry[..sep].trim(), state)?;
         let rhs = entry[sep + MAP_TO.len()..].trim();
         let value = get_lhs_or_constant(&lhs, state).map_err(invalid)?;
-        body = stage_task_parameter(node_name, &mut request_headers, rhs, value, body)?;
+        if rhs.starts_with(MODEL_NAMESPACE) {
+            // Event Script parity: an input entry may stage a model variable that later
+            // entries reference as a dynamic variable, e.g. text(Bearer {model.token})
+            stage_model_variable(node_name, rhs, value, state)?;
+        } else {
+            body = stage_task_parameter(node_name, &mut request_headers, rhs, value, body)?;
+        }
     }
     for (key, value) in request_headers {
         request = request.set_header(&key, &value);
     }
     Ok(request.set_raw_body(body))
+}
+
+fn stage_model_variable(
+    node_name: &str,
+    rhs: &str,
+    value: Option<Value>,
+    state: &mut MultiLevelMap,
+) -> Result<(), AppError> {
+    assert_mutable_model_target(node_name, rhs)?;
+    match value {
+        Some(v) => state.set_element(rhs, v).map_err(invalid)?,
+        None => {
+            if rhs.ends_with(']') && rhs.contains('[') {
+                state.set_element(rhs, Value::Nil).map_err(invalid)?;
+            } else {
+                state.remove_element(rhs);
+            }
+        }
+    }
+    Ok(())
 }
 
 fn stage_task_parameter(

--- a/crates/knowledge-graph/tests/compiler.rs
+++ b/crates/knowledge-graph/tests/compiler.rs
@@ -51,11 +51,11 @@ fn manifest_listed_graphs_are_compiled() {
     assert!(!graphs::graph_exists("rust-no-purpose"));
     // 13 tutorials + 21 original fixtures + the 7 valid suspend fixtures
     // (incl. the jump-mode and retired-property compat shapes) + the 3 valid
-    // ttl fixtures (node-ttl ok + the 2 x-ttl wire echoes); the 12
+    // ttl fixtures (node-ttl ok + the 2 x-ttl wire echoes); the 13
     // deliberately-invalid fixtures
-    // (suspend err1-7, no-end, ttl err1-4) are rejected by the mandatory
-    // quality gate. Every graph a runtime test executes MUST be listed
-    // here - deployed execution is compiled-or-404 (no lazy load)
+    // (suspend err1-7, no-end, ttl err1-4, task-6) are rejected by the
+    // mandatory quality gate. Every graph a runtime test executes MUST be
+    // listed here - deployed execution is compiled-or-404 (no lazy load)
     let mut all = graphs::get_all_graphs();
     all.sort();
     assert_eq!(
@@ -104,6 +104,10 @@ fn invalid_manifest_graphs_are_not_compiled() {
         "unit-test-ttl-err2",
         "unit-test-ttl-err3",
         "unit-test-ttl-err4",
+        // a graph.task input[] entry writing to reserved model metadata
+        // (model.ttl) - the model-staging RHS is gate-checked like every
+        // other model-writing path
+        "unit-test-task-6",
     ] {
         assert!(
             !graphs::graph_exists(id),
@@ -133,6 +137,8 @@ fn node_ttl_placement_and_metadata_immutability_are_validated() {
         "unit-test-ttl-err2",
         "unit-test-ttl-err3",
         "unit-test-ttl-err4",
+        // graph.task input[] staging into reserved model metadata (model.ttl)
+        "unit-test-task-6",
     ] {
         assert!(
             model_validator::validate(&import(id)).is_err(),

--- a/crates/knowledge-graph/tests/graph_runtime.rs
+++ b/crates/knowledge-graph/tests/graph_runtime.rs
@@ -15,7 +15,7 @@
 //
 
 //! End-to-end graph execution — parity ports of the Java `GraphTests`
-//! (tutorials 1/2/4/7/8/9/13) and `GraphTaskTest` (unit-test-task-1..5),
+//! (tutorials 1/2/4/7/8/9/13) and `GraphTaskTest` (unit-test-task-1..6),
 //! running the real `graph-executor` flow through the flow engine. Tutorials
 //! needing `graph.api.fetcher` / `graph.extension` join at K-5/K-6.
 //! Rust-supplement graphs (listed in `graphs.yaml` like everything else —
@@ -263,8 +263,8 @@ impl ComposableFunction for DemoPoJoTask {
     }
 }
 
-// `v1.hello.task`, `mock.mdm.profile`, and `mock.account.details` are now
-// provided by the engine's dev-gated mocks (`knowledge_graph::mock`, each
+// `mock.mdm.profile` and `mock.account.details` are provided by the engine's
+// dev-gated mocks (`knowledge_graph::mock`, each
 // `#[optional_service("app.env=dev")]`); with `app.env: dev` in this crate's
 // test `application.yml` they register automatically — no local copies needed.
 
@@ -1295,21 +1295,27 @@ async fn graphs_run_end_to_end_like_java(platform: &Platform) {
     let mm = body_map(&reply);
     assert_eq!(Some(Value::from(30.0)), mm.get_element("sum"));
 
-    // --- tutorial 13: graph.task invoking a composable function
+    // --- tutorial 13: graph.task invoking the AsyncHttpClient - the input
+    // mapping stages 'model.person_id' and resolves it as a dynamic variable
+    // in the url; success proves CompileGraph resolved ${rest.server.port:8080}
+    // when the deployed model was loaded
     let reply = run_graph(
         &platform,
         "tutorial-13",
-        serde_json::json!({"name": "world", "amount": 21}),
+        serde_json::json!({"person_id": 100}),
         serde_json::json!({}),
     )
     .await;
     let mm = body_map(&reply);
+    assert_eq!(Some(Value::from("100")), mm.get_element("profile.id"));
+    assert_eq!(Some(Value::from("Peter")), mm.get_element("profile.name"));
     assert_eq!(
-        Some(Value::from("Hello, world")),
-        mm.get_element("greeting")
+        Some(Value::from("100 World Blvd")),
+        mm.get_element("profile.address")
     );
-    assert_eq!(Some(Value::from(42.0)), mm.get_element("doubled"));
-    assert_eq!(Some(Value::from("minigraph")), mm.get_element("app"));
+    // 'text(5000) -> headers.x-ttl' sets the HTTP timeout and rides the wire
+    // as the X-TTL request header - the mock echoes what it observed
+    assert_eq!(Some(Value::from("5000")), mm.get_element("observed_ttl"));
 }
 
 async fn graph_task_matches_java_semantics(platform: &Platform) {
@@ -1334,6 +1340,13 @@ async fn graph_task_matches_java_semantics(platform: &Platform) {
         mm.get_element("hello_header")
     );
     assert_eq!(Some(Value::from(200.0)), mm.get_element("doubled"));
+    // 'text(alpha) -> model.token' stages a model variable (Event Script
+    // parity) and the next entry references it as a dynamic variable into a
+    // composite body path
+    assert_eq!(
+        Some(Value::from("Bearer alpha")),
+        mm.get_element("received.nested.auth")
+    );
     // the function's response header maps to the graph output header
     assert_eq!(
         Some("demo"),
@@ -1403,6 +1416,39 @@ async fn graph_task_matches_java_semantics(platform: &Platform) {
     let text = event_script::conversions::to_json_string(reply.body());
     assert!(
         text.contains("does not exist"),
+        "unexpected error response: {text}"
+    );
+
+    // --- tutorial-13 negative: the mock mdm service throws for an unknown
+    // person id and the graph returns the HTTP error as its output
+    let reply = run_graph(
+        &platform,
+        "tutorial-13",
+        serde_json::json!({"person_id": 999}),
+        serde_json::json!({}),
+    )
+    .await;
+    assert_ne!(200, reply.status());
+    let text = event_script::conversions::to_json_string(reply.body());
+    assert!(
+        text.contains("Profile 999 not found"),
+        "unexpected error response: {text}"
+    );
+
+    // --- unit-test-task-6: an input mapping must not overwrite engine-managed
+    // model metadata - the deployment gate rejects the graph so it answers 404
+    // as if nonexistent (compiled-or-404)
+    let reply = run_graph(
+        &platform,
+        "unit-test-task-6",
+        serde_json::json!({"hello": "world"}),
+        serde_json::json!({}),
+    )
+    .await;
+    assert_eq!(404, reply.status());
+    let text = event_script::conversions::to_json_string(reply.body());
+    assert!(
+        text.contains("not found"),
         "unexpected error response: {text}"
     );
 }

--- a/crates/knowledge-graph/tests/playground.rs
+++ b/crates/knowledge-graph/tests/playground.rs
@@ -686,6 +686,99 @@ async fn playground_command_grammar_and_companion() {
         );
     }
 
+    // --- tutorial-13 dry-run (Java CompanionSyncTest twin): 'instantiate graph'
+    // loads the model through the config reader, so ${rest.server.port:8080} in
+    // the task node's 'host' resolves to the application's actual port (success
+    // proves the 8080 default was NOT used), and the graph.task input mapping
+    // stages model.person_id for the {model.person_id} dynamic variable in the
+    // 'url'. Deployed execution of the same model is covered in graph_runtime.rs
+    // - the two lanes must behave the same.
+    let t13_in = "ws.100004.1.in";
+    let t13_out = "ws.100004.1.out";
+    let t13_id = "ws-100004-1";
+    let t13_lines: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    platform
+        .register(
+            t13_out,
+            Arc::new(Console {
+                lines: t13_lines.clone(),
+            }),
+            1,
+        )
+        .expect("tutorial-13 console route");
+    let _ = po
+        .send(
+            EventEnvelope::new()
+                .set_to(knowledge_graph::commands::ROUTE)
+                .set_raw_body(Value::Map(vec![
+                    (Value::from("type"), Value::from("open")),
+                    (Value::from("in"), Value::from(t13_in)),
+                ])),
+        )
+        .await;
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    // this harness boots on an ephemeral port (rest.server.port=0 override), so
+    // point the SAME config key at the actual bound port: 'instantiate graph'
+    // resolves ${rest.server.port:8080} against the app config chain, exactly
+    // as a deployment environment injects the real value
+    let bound = platform_core::automation::server_address()
+        .expect("server bound")
+        .port();
+    overrides::set("rest.server.port", &bound.to_string());
+    // the tutorial model must come from the deployed classpath copy, not a
+    // stale export from an earlier manual run
+    let _ = std::fs::remove_file("/tmp/graph/tutorial-13.json");
+    command(&po, t13_in, t13_out, "import graph from tutorial-13").await;
+    assert!(
+        console_has(&t13_lines, "Graph model imported"),
+        "tutorial-13 import expected"
+    );
+    command(
+        &po,
+        t13_in,
+        t13_out,
+        "instantiate graph\nint(100) -> input.body.person_id",
+    )
+    .await;
+    assert!(
+        console_has(&t13_lines, "Graph instance created"),
+        "tutorial-13 instantiate expected"
+    );
+    let sync_t13 = platform_core::automation::AsyncHttpRequest::new()
+        .set_method("POST")
+        .set_target_host(&base_url())
+        .set_url(&format!("/api/companion/{t13_id}/sync"))
+        .set_header("content-type", "text/plain")
+        .set_body(Value::from("run"));
+    let reply = po
+        .request(
+            EventEnvelope::new()
+                .set_to("async.http.request")
+                .set_raw_body(sync_t13.to_value()),
+            Duration::from_secs(35),
+        )
+        .await
+        .expect("sync tutorial-13 run request");
+    let t13_outcome = MultiLevelMap::from_value(reply.body().clone());
+    assert_eq!(
+        Some(Value::Boolean(true)),
+        t13_outcome.get_element("ok"),
+        "tutorial-13 dry-run must succeed: {:?}",
+        reply.body()
+    );
+    // the traversal's JSON payload arrives in 'result' (narration is 'output')
+    let t13_result = event_script::conversions::to_json_string(
+        &t13_outcome.get_element("result").unwrap_or(Value::Nil),
+    );
+    assert!(
+        t13_result.contains("Peter") && t13_result.contains("100 World Blvd"),
+        "tutorial-13 dry-run returns the fetched profile: {t13_result}"
+    );
+    assert!(
+        t13_result.contains("5000"),
+        "the mock echoes the X-TTL request header (observed_ttl): {t13_result}"
+    );
+
     // --- close the session
     let _ = po
         .send(

--- a/crates/knowledge-graph/tests/resources/graph/unit-test-task-6.json
+++ b/crates/knowledge-graph/tests/resources/graph/unit-test-task-6.json
@@ -11,20 +11,17 @@
       "types": [
         "Task"
       ],
-      "alias": "demo-task",
+      "alias": "forbidden-task",
       "properties": {
         "task": "v1.demo.task",
         "input": [
           "input.body -> *",
-          "int(100) -> amount",
-          "input.header.x-demo -> header.hello",
-          "text(alpha) -> model.token",
-          "text(Bearer {model.token}) -> nested.auth"
+          "text(9999) -> model.ttl"
         ],
         "output": [
-          "result -> output.body",
-          "demo-task.header.x-task -> output.header.x-task"
+          "result -> output.body"
         ],
+        "purpose": "input mapping must not overwrite engine-managed model metadata",
         "skill": "graph.task"
       }
     },
@@ -34,14 +31,14 @@
       ],
       "alias": "root",
       "properties": {
-        "purpose": "graph.task with whole body '*', field merge, request and response headers",
-        "name": "unit-test-task-1"
+        "purpose": "graph.task input mapping rejects a reserved model metadata target",
+        "name": "unit-test-task-6"
       }
     }
   ],
   "connections": [
     {
-      "source": "demo-task",
+      "source": "forbidden-task",
       "relations": [
         {
           "type": "test",
@@ -58,7 +55,7 @@
           "properties": {}
         }
       ],
-      "target": "demo-task"
+      "target": "forbidden-task"
     }
   ]
 }

--- a/crates/knowledge-graph/tests/resources/graphs.yaml
+++ b/crates/knowledge-graph/tests/resources/graphs.yaml
@@ -25,6 +25,9 @@ graphs:
   - 'unit-test-task-3'
   - 'unit-test-task-4'
   - 'unit-test-task-5'
+  # deliberately invalid: an input mapping targets reserved model metadata
+  # (model.ttl) - CompileGraph must reject it and requests answer 404
+  - 'unit-test-task-6'
   - 'rust-foreach'
   - 'rust-join'
   - 'rust-join-retry'

--- a/crates/platform-core/src/automation/http_client.rs
+++ b/crates/platform-core/src/automation/http_client.rs
@@ -959,6 +959,13 @@ fn apply_headers(
             builder = builder.header(key.as_str(), value.trim());
         }
     }
+    // best practice (maintainer ruling): send a default 'Accept: */*' when the
+    // caller gives none — the Java engine's reactor-netty client does this
+    // implicitly, and the REST edge negotiates the response content-type from
+    // Accept, so the default keeps JSON decoding identical on both engines
+    if !merged.iter().any(|(k, _)| k.eq_ignore_ascii_case("accept")) {
+        builder = builder.header("accept", "*/*");
+    }
     // distributed trace propagation: this route is untraced by default
     // (skip.rpc.tracing, Java parity), so the trace rides the ENVELOPE and
     // the injected invocation headers, not the ambient trace state — exactly

--- a/crates/platform-core/tests/rest_automation.rs
+++ b/crates/platform-core/tests/rest_automation.rs
@@ -286,11 +286,16 @@ impl ComposableFunction for EchoChainCaller {
             .as_str()
             .unwrap_or_default()
             .to_string();
-        let echo = automation::AsyncHttpRequest::new()
+        let mut echo = automation::AsyncHttpRequest::new()
             .set_method("GET")
             .set_url("/api/echo/headers")
-            .set_target_host(&format!("http://127.0.0.1:{port}"))
-            .set_header("accept", "application/json");
+            .set_target_host(&format!("http://127.0.0.1:{port}"));
+        // pass an accept header on the inner hop only when the outer request
+        // asks for one (?accept=...) — the default-accept pin needs a hop
+        // with none, while the explicit-accept pin proves no override
+        if let Some(accept) = request["parameters"]["query"]["accept"].as_str() {
+            echo = echo.set_header("accept", accept);
+        }
         let po = PostOffice::new(&self.platform);
         let response = po
             .request(
@@ -1214,6 +1219,48 @@ async fn async_http_client_stamps_trace_context_under_both_names() {
         json["headers"]["x-trace-context"].as_str(),
         Some(stamped),
         "the same W3C value must be stamped under the custom traceparent header name"
+    );
+}
+
+/// Best practice (maintainer ruling): the async HTTP client sends a default
+/// 'Accept: */*' when the caller gives none — the Java engine's reactor-netty
+/// client does this implicitly, and the REST edge negotiates the response
+/// content-type from Accept, so the default keeps JSON decoding identical on
+/// both engines. An explicit accept is never overridden.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn async_http_client_sends_default_accept_when_caller_gives_none() {
+    let server = server().await;
+    // the inner hop sets NO accept -> the client's default rides the wire
+    let (status, _, body) = http(
+        server.port,
+        "GET",
+        &format!("/api/echo/chain?port={}", server.port),
+        &[("Accept", "application/json")],
+        "",
+    )
+    .await;
+    assert_eq!(status, 200, "chain body: {body}");
+    let json: serde_json::Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(
+        json["headers"]["accept"].as_str(),
+        Some("*/*"),
+        "the client must send the default Accept when the caller gives none: {json}"
+    );
+    // an explicit accept on the inner hop wins - the default never overrides
+    let (status, _, body) = http(
+        server.port,
+        "GET",
+        &format!("/api/echo/chain?port={}&accept=text/plain", server.port),
+        &[("Accept", "application/json")],
+        "",
+    )
+    .await;
+    assert_eq!(status, 200, "chain body: {body}");
+    let json: serde_json::Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(
+        json["headers"]["accept"].as_str(),
+        Some("text/plain"),
+        "an explicit accept must never be overridden by the default: {json}"
     );
 }
 

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -92,6 +92,18 @@
 | 73 | CompileGraph is the mandatory deployment gate (compiled-or-404, ADR-0010): manifest-carried `location` (flows.yaml convention; `location.graph.deployed` retired), property-aware mapping rejection (bare `input` = fetcher vocabulary), `model_validator` reused by the playground `run` pre-run check, executor lazy load deleted, `model.run` reserved at compile + runtime | 2026-07-30 | — | 293 |
 | 74 | Redis state store crate `extensions/minigraph-state-redis` (app-only, never the engine): `v1.redis.persist.model` SETEX / `v1.redis.retrieve.model` GETDEL, lazy `ConnectionManager` (redis-rs, the Lettuce analog), `redis.*` config family, contract tests through the real client vs an in-process RESP2 double | 2026-07-30 | — | 294 |
 | 75 | tutorial-14 (verbatim) + suspension docs + ADR twins: the three-checkpoint purchase workflow e2e over the real client wire path, live four-run drive vs redis-standalone (reply shape, log-context business cid, store-under-skill span topology), workflow-suspension guide + ten-skill tables + help/catalog surfaces + CHANGELOG migration note, ADR-0009/0010 proposed | 2026-07-30 | — | 295 |
+| 76 | Version-aware Redis consume (v4.11.1 lock-step R1): GETDEL on 6.2+, atomic MULTI/EXEC GET+DEL below — INFO probe once per manager with a startup strategy statement; shared parameterized RESP2 double + a separate-process legacy suite driving the fallback for real at 5.0.14 | 2026-08-01 | — | * |
+| 77 | Event Script task-level `ttl` override (v4.11.1 lock-step R2): compile rules + `resolve_child_ttl` with the delay-aware WARN; `delay` honored on flow:// launches, deferred dispatches cancelled at `end_flow`; nine Java fixtures verbatim + catch/retry/delay e2e twins | 2026-08-01 | — | * |
+| 78 | minigraph node `ttl` + model-metadata immutability (v4.11.1 lock-step R3): `get_effective_ttl` at all four read sites; canonical `RESERVED_MODEL_METADATA` runtime guard on all four model-writing paths; validator gate/pre-run rules (three-skill node-ttl message, metadata immutability incl. MAPPING: lines) | 2026-08-01 | — | * |
+| 79 | Dry-run watcher + companion drain + fetcher x-ttl (v4.11.1 lock-step R4): run-level watcher at model.ttl (CAS claim_terminal, owner-tagged slot), drain sized from model.ttl with truncation = ok:false, fetcher x-ttl stamp + mock MDM echo; docs mirror incl. the deadline-propagation half-port fix | 2026-08-01 | — | * |
+| 80 | Adversarial review round (v4.11.1 lock-step R5): 14 confirmed findings resolved — x-ttl budget ceils to whole seconds via 32-bit parse, 30s drain fallback, gate-message parity, i32 ttl bound + saturating math, wire-strategy journal proofs on both redis paths, watcher-slot release pin | 2026-08-01 | — | * |
+| 81 | tutorial-14: the manager approval becomes a real decision — approve / reject-with-reason / re-suspend wait loop; RESET-before-IF idiom; three-outcome e2e + loop stability; decide-before-you-suspend rule stated across the grammar surfaces | 2026-08-07 | — | * |
+| 82 | Suspension is a destination (ADR-0011 amending ADR-0009; Java ADR-0012 twin): edge and jump modes replace suspend=true, shape-based gate rules + teaching errors, tutorial-14 remodel, fixtures byte-identical, webapp replaced from the Java repo's latest UI | 2026-08-07 | — | * |
+| 83 | graph.task `model.*` input staging (Event Script parity) + tutorial-13 as an HTTP client by configuration: async.http.request, dynamic variables, `${...}` load-time substitution, explicit `headers.x-ttl`; v1.hello.task retired; dry-run companion twin | 2026-08-08 | — | * |
+
+\* From increment 76 the workspace gate is reported as green test **suites** (58 at
+v4.11.x) rather than a single cumulative test count — the multi-crate workspace runs
+per-suite binaries.
 
 Every increment ships with `cargo build` + `cargo test` + `cargo clippy --all-targets` +
 `cargo fmt --check` clean, and (from increment 4 on) a live run of the hello-world
@@ -2355,6 +2367,35 @@ parent's handler, the retry twin proves attempts=3/last_status=408/graceful give
 and both delay forms (numeric + model-variable) assert the deferred elapsed time.
 Workspace suites green / clippy 0 / fmt.
 
+## Increment 78 — minigraph node ttl + model-metadata immutability (2026-08-01)
+
+Lock-step half of the Java v4.11.1 graph-side deadline features. `get_effective_ttl`
+resolves a node's optional `ttl` (duration grammar, the suspend-node parser) over the
+propagated `model.ttl` at all four read sites (graph.extension, graph.api.fetcher,
+graph.task, and the suspend store call), so a shorter child deadline makes a child's
+timeout catchable in the calling graph. The canonical `RESERVED_MODEL_METADATA`
+runtime guard (`assert_mutable_model_target`) now covers all four model-writing paths —
+the graph layer's `model.*` RHS was previously UNGUARDED here, the same hole the Java
+review found — and `model_validator::validate()` enforces the node-ttl placement rule
+(a THREE-skill message — no `graph.js` in this port, a maintainer-ruled divergence) plus
+metadata immutability including `MAPPING:` statement lines at the CompileGraph gate and
+the playground pre-run check. All 42 manifest graphs of the day passed unchanged.
+
+## Increment 79 — dry-run watcher, companion drain, fetcher x-ttl + docs mirror (2026-08-01)
+
+Lock-step half of the Java v4.11.1 deadline-cleanup round. The traveler gains a
+run-level watcher at `model.ttl` carrying the Java review's correctness constraints by
+construction (CAS `claim_terminal` on every terminal path, owner-tagged watcher slot,
+disarm-before-reset, late-reply guard), so a hung dry-run ends with the canonical
+failure terminal instead of silence; the synchronous companion drain is sized from
+`model.ttl` and a truncated capture classifies as `ok:false`, never a silent success.
+The API fetcher stamps `x-ttl` on outbound requests (wire read-timeout aligned to the
+graph-side deadline) and the mock MDM service echoes the observed header for wire
+proofs. The docs mirror (8 files) rode with a docs-vs-code audit catch: deadline
+propagation was HALF-ported — the header view carried caller-wins x-ttl but the HTTP
+flow adapter derived its budget from the endpoint timeout — fixed with an HTTP-edge
+twin.
+
 ## Increment 80 — Adversarial review round: Java-parity hardening (2026-08-01)
 
 Four-lens review (concurrency/lifecycle, Java parity, correctness, test validity) with
@@ -2375,25 +2416,6 @@ findings confirmed as exact Java-parity residuals (documented, no change): the
 owner-token prefix window, the schedule-then-register deferred-dispatch window, and the
 unbounded-x-ttl divergence resolved by adopting Java's 32-bit parse. Workspace 58
 suites green / clippy 0 / fmt.
-
-## Increment 82 — suspension is a destination: edge and jump modes replace suspend=true (2026-08-07)
-
-Lock-step mirror of the Java reference engine's rationalization (Java PR #265, ADR-0012;
-this port's ADR-0011 amending ADR-0009). A suspension point is declared by graph shape:
-a working node with a drawn edge to `suspend` is an edge-mode checkpoint (redirect on
-`next`; resumed past, never re-executed; continuation edge mandatory), and a `graph.math`
-decision jumps to `suspend` from its IF-THEN-ELSE (jump mode; RE-EXECUTED against the new
-input on every resume — the wait loop with no auxiliary nodes and no RESET). The retired
-`suspend=true` property is a deprecation-WARN no-op; a routing-skill drawn edge to
-`suspend` and `exception=suspend` are rejected with teaching errors (Java-exact wording);
-a jump-only suspend node is island-anchored (`root → island → suspend`) for the no-orphan
-rule, with the island exempt from the continuation-edge rule (its edges are never
-traversed). Both walker lanes bifurcate resume by shape; the record and store contracts
-are unchanged (earlier records replay correctly). tutorial-14 remodeled byte-identical to
-Java (await-decision + RESET deleted); fixtures synced byte-identical incl. the jump-mode
-and retired-property compat shapes; the runtime suite gained the jump-mode re-execution
-loop and compat scenarios; docs/AI grammar rewritten as one story with the port's
-divergent passages preserved; webapp replaced from the Java repo's latest UI source.
 
 ## Increment 81 — tutorial-14: the manager approval becomes a real decision (2026-08-07)
 
@@ -2419,3 +2441,47 @@ grammar — a new design rule in the guide, the tutorial help, the AI grammar
 (minigraph-commands.json and the graph.suspend skill help) — and the validator/runtime
 error for suspend=true on a routing skill now explains the why and the fix instead of
 only the restriction (same wording as the Java engine).
+
+## Increment 82 — suspension is a destination: edge and jump modes replace suspend=true (2026-08-07)
+
+Lock-step mirror of the Java reference engine's rationalization (Java PR #265, ADR-0012;
+this port's ADR-0011 amending ADR-0009). A suspension point is declared by graph shape:
+a working node with a drawn edge to `suspend` is an edge-mode checkpoint (redirect on
+`next`; resumed past, never re-executed; continuation edge mandatory), and a `graph.math`
+decision jumps to `suspend` from its IF-THEN-ELSE (jump mode; RE-EXECUTED against the new
+input on every resume — the wait loop with no auxiliary nodes and no RESET). The retired
+`suspend=true` property is a deprecation-WARN no-op; a routing-skill drawn edge to
+`suspend` and `exception=suspend` are rejected with teaching errors (Java-exact wording);
+a jump-only suspend node is island-anchored (`root → island → suspend`) for the no-orphan
+rule, with the island exempt from the continuation-edge rule (its edges are never
+traversed). Both walker lanes bifurcate resume by shape; the record and store contracts
+are unchanged (earlier records replay correctly). tutorial-14 remodeled byte-identical to
+Java (await-decision + RESET deleted); fixtures synced byte-identical incl. the jump-mode
+and retired-property compat shapes; the runtime suite gained the jump-mode re-execution
+loop and compat scenarios; docs/AI grammar rewritten as one story with the port's
+divergent passages preserved; webapp replaced from the Java repo's latest UI source.
+
+## Increment 83 — graph.task model.* staging + tutorial-13 as an HTTP client by configuration (2026-08-08)
+
+Lock-step mirror of the Java reference engine's fix (Java PR #267). A `graph.task`
+`input[]` entry whose RHS starts with `model.` now stages a state-machine variable —
+guard-checked against reserved model metadata — instead of silently landing in the request
+body, so later entries can reference it as a dynamic variable (Event Script parity; the
+fetcher and extension input mappings already behaved this way — graph.task was the family
+outlier). tutorial-13 remodeled byte-identical to Java: `task=async.http.request` fetches a
+mock MDM profile, teaching model staging, `{model.person_id}` dynamic-variable resolution,
+`${rest.server.port:8080}` load-time substitution (the authored/exported model keeps the
+placeholder; `instantiate graph` resolves through the config reader exactly like the
+deployment compiler), the explicit `headers.x-ttl` HTTP timeout in milliseconds (the
+graph ttl bounds only the event call — X-TTL rides the wire, pinned by the mock's
+`observed_ttl` echo), and an explicit `headers.accept` as best practice. The accept probe
+surfaced a client-default divergence — the Java engine's reactor-netty sends an implicit
+`Accept: */*` while this port's client sent none, so the same model decoded JSON on one
+engine and returned raw bytes on the other — resolved by maintainer ruling: **the async
+HTTP client now sends a default `Accept: */*` when the caller gives none** (explicit
+accept never overridden; wire-echo pinned both ways in rest_automation).
+The `v1.hello.task` demo mock retired; unit-test-task-6 joins the
+deliberately-invalid manifest fixtures (an input mapping targeting `model.ttl` answers
+404); the playground suite gained the dry-run twin (import → instantiate → run through the
+sync companion, proving instantiate-time env-var resolution); help/catalog synced
+byte-identical; skills reference and HTTP-client guide teach the same story.

--- a/docs/guides/actuators-and-http-client.md
+++ b/docs/guides/actuators-and-http-client.md
@@ -242,6 +242,10 @@ For `POST`, `PUT`, and `PATCH` (other methods send no body):
     The Java client serializes a map body as XML when the content type says so; the XML writer
     is not ported — a map body is always JSON. Set the `content-type` header accordingly.
 
+When the caller sets no `accept` header, the client sends a default `Accept: */*` — matching
+the Java engine's HTTP client behavior — so a JSON response decodes into a map either way.
+Declaring `headers.accept` explicitly remains the best practice.
+
 ### Response body decoding
 
 The reply envelope carries the HTTP status, all response headers, and a body decoded by the
@@ -270,6 +274,7 @@ tasks:
       - 'text(GET) -> method'
       - 'text(http://127.0.0.1:8085) -> host'
       - 'text(application/json) -> headers.accept'
+      - 'text(5000) -> headers.x-ttl'
       - 'input.query.x1 -> parameters.query.x1'
     process: 'async.http.request'
     description: 'Call the external endpoint'
@@ -282,6 +287,20 @@ tasks:
 `method`, `host`, and `url` are the required keys; `headers.*`, `parameters.query.*`,
 `parameters.path.*`, `body`, and `cookies.*` are optional. See the
 [Flow Schema Reference](flow-schema-reference.md) for the mapping syntax.
+
+### HTTP timeout (X-TTL)
+
+The flow's `ttl` (or a task-level `ttl` override) bounds the **event call** to the
+`async.http.request` function — it cannot reach inside the function to govern the HTTP
+operation itself. Set the HTTP timeout explicitly with the reserved `X-TTL` request header,
+expressed in **milliseconds** (`text(5000) -> headers.x-ttl`). Without it, the client uses
+its own 30-second default, decoupled from your flow deadline.
+
+The same header also rides the outgoing request on the wire, so a downstream Mercury service
+adopts it as its processing deadline — the end-to-end deadline propagation described in
+[REST Automation](rest-automation.md). Give the HTTP call a budget shorter than the calling
+flow or graph deadline, so an HTTP timeout surfaces as a catchable error in the caller
+instead of the caller itself expiring first.
 
 ## See also
 

--- a/docs/guides/knowledge-graph/minigraph-commands.json
+++ b/docs/guides/knowledge-graph/minigraph-commands.json
@@ -525,10 +525,11 @@
       ],
       "notes": [
         "task={route} of a composable function (TypedLambdaFunction registered with @PreLoad)",
-        "input[] entries apply in order; RHS '*' merges the mapped value into the request body, 'header.{name}' sets a request header, any other key sets a body field",
-        "request body auto-converts when the function declares a PoJo input; concurrency 1-30 (default 3)"
+        "input[] entries apply in order; RHS '*' merges the mapped value into the request body, 'header.{name}' sets a request header, 'model.{key}' stages a state-machine variable that later entries reference as a dynamic variable e.g. text(/api/mdm/profile/{model.person_id}) - engine-managed model metadata rejected, any other key sets a body field",
+        "request body auto-converts when the function declares a PoJo input; concurrency 1-30 (default 3)",
+        "any registered route is callable - e.g. task=async.http.request drives the platform AsyncHttpClient by configuration with body keys host/url/method/headers.{name}/body (tutorial-13); node/model ttl bounds only the event call, so set the HTTP timeout explicitly via headers.x-ttl in MILLISECONDS (also propagates the deadline on the wire)"
       ],
-      "example": "skill=graph.task\ntask=v1.hello.task\ninput[]=input.body -> *\ninput[]=text(minigraph) -> header.x-app\noutput[]=result -> output.body"
+      "example": "skill=graph.task\ntask=async.http.request\ninput[]=input.body.person_id -> model.person_id\ninput[]=text(http://127.0.0.1:${rest.server.port:8080}) -> host\ninput[]=text(/api/mdm/profile/{model.person_id}) -> url\ninput[]=text(GET) -> method\ninput[]=text(application/json) -> headers.accept\ninput[]=text(5000) -> headers.x-ttl\noutput[]=result -> output.body"
     },
     {
       "route": "graph.join",

--- a/docs/guides/knowledge-graph/skills-reference.md
+++ b/docs/guides/knowledge-graph/skills-reference.md
@@ -254,23 +254,35 @@ skill=graph.task
 task=<function-route>
 input[]=input.body -> *                  # '*' merges the mapped value into the request body
 input[]=text(minigraph) -> header.x-app  # 'header.{name}' sets a request header
+input[]=input.body.id -> model.id        # 'model.{key}' stages a state-machine variable
 output[]=result -> output.body
 ```
 
-Worked example (invoking a deployed demo function):
+Worked example (tutorial-13 — any registered route is callable, so `async.http.request` turns
+the node into an HTTP client by configuration):
 
 ```
 create node hello-task
 with type Task
 with properties
 skill=graph.task
-task=v1.hello.task
-input[]=input.body -> *
+task=async.http.request
+input[]=input.body.person_id -> model.person_id
+input[]=text(http://127.0.0.1:${rest.server.port:8080}) -> host
+input[]=text(/api/mdm/profile/{model.person_id}) -> url
+input[]=text(GET) -> method
+input[]=text(application/json) -> headers.accept
+input[]=text(5000) -> headers.x-ttl
 output[]=result -> output.body
 ```
 
 `input[]` entries apply **in order**, so field mappings after a `*` merge into the request body,
-and the body auto-converts when the function declares a PoJo input. The result lands at
+and the body auto-converts when the function declares a PoJo input. A `model.{key}` target stages
+a **state-machine variable** instead of a body field, and later entries can reference it as a
+**dynamic variable** — `{model.person_id}` above resolves inside the `text(...)` constant, the
+same idiom as Event Script. The `${rest.server.port:8080}` reference is **environment/config
+substitution**, resolved when the model is loaded (at deployment compile, and at `instantiate
+graph` for a dry-run) while the authored and exported model keeps the placeholder. The result lands at
 `{node}.result` and response headers at `{node}.header` — in `output[]` mappings, **`result`
 (bare) is the function's whole result** and `result.{key}` a field of it (same rule as
 `graph.extension`). Optional `for_each[]` with `concurrency`
@@ -280,7 +292,11 @@ and the body auto-converts when the function declares a PoJo input. The result l
 **Gotchas:** the `task` route must exist at runtime or the node fails fast; a call is bounded by
 `model.ttl` (default 30 s) — or by the node's optional `ttl` property (duration syntax, e.g.
 `10s`), which overrides the propagated value for this node only, the same deadline override as
-[`graph.api.fetcher`](#api-fetcher) and [`graph.extension`](#extension). For multi-step
+[`graph.api.fetcher`](#api-fetcher) and [`graph.extension`](#extension). That deadline bounds the
+**event call** only — it cannot reach inside a generic function, so a function with its own
+downstream timeout contract takes it from the input mapping: the AsyncHttpClient reads
+`headers.x-ttl` in **milliseconds** as its HTTP timeout (default 30 s when absent) and propagates
+it on the wire as the `X-TTL` header. For multi-step
 orchestration, prefer [`graph.extension`](#extension) — `graph.task` is for a single function
 call. Writing the function itself:
 [function AI agent guide](../event-driven/ai-agent-guide.md) (`#[preload]` + `ComposableFunction`).


### PR DESCRIPTION
## What

Lock-step mirror of the Java reference engine's graph.task fix
(mercury-composable PR #267). A `graph.task` `input[]` entry whose RHS starts with
`model.` now stages a variable in the graph's state machine — guard-checked against
reserved model metadata — instead of silently landing in the request body under a
literal `model` key, so later entries reference it as a dynamic variable:
`input.body.person_id -> model.person_id` followed by
`text(/api/mdm/profile/{model.person_id}) -> url`. This matches the fetcher and
extension input mappings, which already supported the idiom; graph.task was the
family outlier on both engines.

tutorial-13 is remodeled byte-identical to Java as an HTTP client by configuration:
`task=async.http.request` fetches a mock MDM profile, teaching model staging, dynamic
variables, `${rest.server.port:8080}` load-time substitution (the authored and exported
model keeps the placeholder; `instantiate graph` resolves through the config reader
exactly like the deployment compiler), an explicit `headers.accept` as best practice,
and the explicit `headers.x-ttl` HTTP timeout in milliseconds. The `v1.hello.task` demo
mock is retired.

By maintainer ruling, the async HTTP client now sends a default `Accept: */*` when the
caller gives none — an explicit accept is never overridden, wire-echo pinned both ways.
Tests: the tutorial-13 deployed e2e (profile fetch + X-TTL wire echo + error
propagation), the unit-test-task-6 gate rejection (compiled-or-404), staging and
dotted-body-path pins, and the playground dry-run twin through the sync companion
proving instantiate-time env-var resolution. Docs: help and AI catalog byte-identical
with Java; skills reference and HTTP-client guide; CHANGELOG; Increment 83; webapp
bundle regenerated. The INCREMENTS ledger is also repaired: the missing increments 78
and 79 reconstructed from the session record, the section tail re-ordered to strict
ascending 76–83, and the Overview table extended. Workspace 305 tests green, clippy 0.

## Why

A field-style debugging session on the Java engine surfaced the staging gap (a
`model.*` RHS resolving to "null" in a later dynamic variable), and the Event Script
data-mapping surface is part of the cross-engine contract — flows and graph models are
engine-portable, so the fix and the remodeled tutorial ship in lock-step.

Mirroring the tutorial here surfaced a second, quieter divergence: the same graph model
decoded JSON on Java but returned raw bytes on this port, because Java's reactor-netty
client sends an implicit `Accept: */*` while this port's client sent none — and both
engines' REST edges deliberately omit the response content-type when a request carries
no Accept. The maintainer ruled the client should send the default as best practice,
making response content negotiation identical on both engines even for models that omit
the header.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>