### PR TITLE
version 4.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
-## Unreleased
+## Version 4.11.5, 8/9/2026
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.11.4"
+version = "4.11.5"
 dependencies = [
  "async-trait",
  "log",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "event-script"
-version = "4.11.4"
+version = "4.11.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "event-script-macros"
-version = "4.11.4"
+version = "4.11.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -467,7 +467,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.11.4"
+version = "4.11.5"
 dependencies = [
  "async-trait",
  "event-script",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.11.4"
+version = "4.11.5"
 dependencies = [
  "async-trait",
  "log",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph"
-version = "4.11.4"
+version = "4.11.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph-macros"
-version = "4.11.4"
+version = "4.11.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -798,7 +798,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minigraph-playground"
-version = "4.11.4"
+version = "4.11.5"
 dependencies = [
  "async-trait",
  "event-script",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "minigraph-state-redis"
-version = "4.11.4"
+version = "4.11.5"
 dependencies = [
  "async-trait",
  "log",
@@ -985,7 +985,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "platform-core"
-version = "4.11.4"
+version = "4.11.5"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macros"
-version = "4.11.4"
+version = "4.11.5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.11.4"
+version = "4.11.5"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury-composable"


### PR DESCRIPTION
## What

Release v4.11.5 in lock-step with the Java reference engine: workspace version
4.11.4 → 4.11.5 with the Cargo.lock refresh, and the CHANGELOG cut to
"Version 4.11.5, 8/9/2026". Contents since v4.11.4:

- **Added** — the async HTTP client sends a default `Accept: */*` when the caller gives
  none (maintainer ruling; Java reactor-netty parity), so response content negotiation
  behaves identically on both engines (#197).
- **Fixed** — `graph.task` input mapping supports `model.{key}` staging targets,
  restoring Event Script parity for dynamic variables (#197).
- **Changed** — tutorial-13 remodeled as an HTTP client by configuration (explicit
  `headers.accept` + `headers.x-ttl`; the `v1.hello.task` mock retired) (#197), and the
  suspend/resume docs reframed around checkpoint and decision nodes with the two
  motivating wait scenarios (#198).

Release gate: workspace 305 tests green.

## Why

Both engines ship v4.11.5 together so the field runs identical graph models, identical
tutorials and identical teaching surfaces across the polyglot fleet — the graph.task
staging fix, the HTTP-client tutorial and the suspension vocabulary are one story on
both engines.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>