### PR TITLE
Release v4.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,23 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
-## Unreleased
+## Version 4.11.6, 8/10/2026
+
+### Changed
+
+1. **BREAKING: the suspend/resume state-store contract is scoped by graph + cid.** The
+   persistence envelope gains a `graph` field (`{cid, graph, node, ttl, model, seen,
+   run}`), the retrieve body becomes `{cid, graph}`, and the Redis store keys records
+   `graph:{graph_id}:{cid}` (formerly `graph:state:{cid}`) — so the same business
+   correlation ID suspends independently in each domain's graph and in each subgraph, and
+   a resume only ever sees records written by its own graph. **Upgrade note:** records
+   persisted under the old key are not visible after the upgrade — a resume behaves as a
+   fresh transaction (the same observable behavior as an expired record). Let suspended
+   workflows complete before upgrading, or accept the fresh start; custom store
+   implementations must adopt the `graph` field (the shipped stores reject a request
+   without it). (ADR-0012)
 
 ### Added
-
-0. **Dynamic variables now resolve in every statement command — completing the generic
-   error handler.** `NEXT:` and `THEN:`/`ELSE:` jump targets, `RESET:` list entries and
-   `DELAY:` values in `graph.math` statements resolve `{namespace.key}` references at
-   execution time, so a generic handler can retry *whichever node routed to it*:
-   `RESET: {error.source}, error-handler` + `NEXT: {error.source}` (and pace with a
-   computed `DELAY: {model.backoff}`). Previously only `MAPPING`/`COMPUTE` expressions and
-   `IF` conditions substituted. An unresolved variable renders `null`: a `RESET:` entry is
-   a safe no-op, a `DELAY:` is skipped, and a jump target fails the run loudly.
-   tutorial-12's error-handler and clear-exception nodes now teach the generic idiom.
 
 1. **Generic exception context for `exception=` handlers — one handler can serve every
    node.** When a failed node routes to its exception handler, the engine now stages
@@ -53,19 +57,15 @@ the design rationale in [`docs/design/`](docs/design/).
    resumes it. Documented in the workflow-suspension guide with the reference model pair
    `unit-test-orchestrator` / `unit-test-sub-suspend`. (ADR-0012)
 
-### Changed
-
-1. **BREAKING: the suspend/resume state-store contract is scoped by graph + cid.** The
-   persistence envelope gains a `graph` field (`{cid, graph, node, ttl, model, seen,
-   run}`), the retrieve body becomes `{cid, graph}`, and the Redis store keys records
-   `graph:{graph_id}:{cid}` (formerly `graph:state:{cid}`) — so the same business
-   correlation ID suspends independently in each domain's graph and in each subgraph, and
-   a resume only ever sees records written by its own graph. **Upgrade note:** records
-   persisted under the old key are not visible after the upgrade — a resume behaves as a
-   fresh transaction (the same observable behavior as an expired record). Let suspended
-   workflows complete before upgrading, or accept the fresh start; custom store
-   implementations must adopt the `graph` field (the shipped stores reject a request
-   without it). (ADR-0012)
+3. **Dynamic variables now resolve in every statement command — completing the generic
+   error handler.** `NEXT:` and `THEN:`/`ELSE:` jump targets, `RESET:` list entries and
+   `DELAY:` values in `graph.math` statements resolve `{namespace.key}` references at
+   execution time, so a generic handler can retry *whichever node routed to it*:
+   `RESET: {error.source}, error-handler` + `NEXT: {error.source}` (and pace with a
+   computed `DELAY: {model.backoff}`). Previously only `MAPPING`/`COMPUTE` expressions and
+   `IF` conditions substituted. An unresolved variable renders `null`: a `RESET:` entry is
+   a safe no-op, a `DELAY:` is skipped, and a jump target fails the run loudly.
+   tutorial-12's error-handler and clear-exception nodes now teach the generic idiom.
 
 ---
 ## Version 4.11.5, 8/9/2026

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.11.5"
+version = "4.11.6"
 dependencies = [
  "async-trait",
  "log",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "event-script"
-version = "4.11.5"
+version = "4.11.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "event-script-macros"
-version = "4.11.5"
+version = "4.11.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -467,7 +467,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.11.5"
+version = "4.11.6"
 dependencies = [
  "async-trait",
  "event-script",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.11.5"
+version = "4.11.6"
 dependencies = [
  "async-trait",
  "log",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph"
-version = "4.11.5"
+version = "4.11.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph-macros"
-version = "4.11.5"
+version = "4.11.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -798,7 +798,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minigraph-playground"
-version = "4.11.5"
+version = "4.11.6"
 dependencies = [
  "async-trait",
  "event-script",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "minigraph-state-redis"
-version = "4.11.5"
+version = "4.11.6"
 dependencies = [
  "async-trait",
  "log",
@@ -985,7 +985,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "platform-core"
-version = "4.11.5"
+version = "4.11.6"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macros"
-version = "4.11.5"
+version = "4.11.6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.11.5"
+version = "4.11.6"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury-composable"


### PR DESCRIPTION
## What

Version bump 4.11.5 → 4.11.6 (workspace `Cargo.toml` + `Cargo.lock` refresh) and the
CHANGELOG cut for the 4.11.6 release. No code change — the release consolidates the
arcs already merged on main in lock-step with the Java engine: graph-scoped workflow
state with the **BREAKING** store contract (#200, ADR-0012), business-cid inheritance
enabling the orchestrator pattern (#200, ADR-0012), generic exception context for
`exception=` handlers including recovery semantics (#200, #202, ADR-0013), and dynamic
variables in every statement command (#201).

## Why

The field team's suspend/resume review (2026-08-10) surfaced two structural asks —
correlation-ID-only store references collide across domains and subgraphs, and per-node
exception-handler clones make graphs busy — and the follow-up regression pass surfaced
two more findings. All four shipped same-day on both engines; this release keeps the
Rust engine in lock-step with the Java reference at v4.11.6.

The CHANGELOG leads with the breaking change and its upgrade note: records persisted
under the old `graph:state:{cid}` key are not visible after the upgrade — a resume
behaves as a fresh transaction. Let suspended workflows complete before upgrading, or
accept the fresh start; custom store implementations must adopt the `graph` field.

Co-Authored-By: Claude Code <noreply@anthropic.com>