### PR TITLE
Release v4.11.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
-## Unreleased
+## Version 4.11.8, 8/10/2026
+
+> Version 4.11.7 was a Java-only release (the Kafka flow adapter's `group.protocol=auto`),
+> so this engine steps from 4.11.6 directly to 4.11.8 to stay in version lock-step.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.11.6"
+version = "4.11.8"
 dependencies = [
  "async-trait",
  "log",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "event-script"
-version = "4.11.6"
+version = "4.11.8"
 dependencies = [
  "async-trait",
  "base64",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "event-script-macros"
-version = "4.11.6"
+version = "4.11.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -467,7 +467,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.11.6"
+version = "4.11.8"
 dependencies = [
  "async-trait",
  "event-script",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.11.6"
+version = "4.11.8"
 dependencies = [
  "async-trait",
  "log",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph"
-version = "4.11.6"
+version = "4.11.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph-macros"
-version = "4.11.6"
+version = "4.11.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -798,7 +798,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minigraph-playground"
-version = "4.11.6"
+version = "4.11.8"
 dependencies = [
  "async-trait",
  "event-script",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "minigraph-state-redis"
-version = "4.11.6"
+version = "4.11.8"
 dependencies = [
  "async-trait",
  "log",
@@ -985,7 +985,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "platform-core"
-version = "4.11.6"
+version = "4.11.8"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macros"
-version = "4.11.6"
+version = "4.11.8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.11.6"
+version = "4.11.8"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury-composable"


### PR DESCRIPTION
## What

Version bump 4.11.6 → 4.11.8 (workspace `Cargo.toml` + `Cargo.lock`) and the CHANGELOG
cut — v4.11.7 was a Java-only release (the Kafka flow adapter's `group.protocol=auto`),
so this engine steps from 4.11.6 directly to 4.11.8 to stay in version lock-step. No
code change — the release delivers the dry-run suspend/resume regression fix merged on
main (#204): stable graph identity for dry-run instances, with unnamed suspend/resume
models rejected at instantiation.

## Why

v4.11.6 introduced the graph-scoped store contract with the dry-run lane silently unable
to resume any suspended workflow (the production executor lane was never affected).
Suspend/resume is field-core and flows/models are engine-portable, so the fix ships on
both engines in lock-step. Workspace 58 suites / 305 tests, clippy clean, rustfmt clean.

Co-Authored-By: Claude Code <noreply@anthropic.com>