### PR TITLE
Dry-run graph identity: an unnamed draft is scoped 'untitled' instead of rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
+## Unreleased
+
+### Changed
+
+1. **A dry-run graph whose root node has no `name` is scoped as `untitled` instead of being
+   rejected.** v4.11.8 required a suspend/resume model to carry a root `name` before the playground
+   would instantiate it, because the fallback identity was a per-instantiation handle that no later
+   run could read. What the state store actually needs is an identity that is *stable across
+   instantiations*, not one derived from the model name — so an unnamed draft now falls back to the
+   stable constant `untitled` and simply works: it suspends and resumes like any named model,
+   sharing the `graph:untitled:{cid}` scope. Naming the root node (which the export path does
+   automatically, keeping it in sync with the graph's file/deployment id) still gives a draft its
+   own scope and remains the recommendation for anything you intend to deploy.
+
+---
 ## Version 4.11.8, 8/10/2026
 
 > Version 4.11.7 was a Java-only release (the Kafka flow adapter's `group.protocol=auto`),

--- a/crates/knowledge-graph/src/commands.rs
+++ b/crates/knowledge-graph/src/commands.rs
@@ -50,6 +50,7 @@ const NODE_NAME: &str = "node ";
 const NOT_FOUND: &str = " not found";
 const SESSION_TAG: &str = "Session ";
 const UNTYPED: &str = "untyped";
+const UNTITLED: &str = "untitled";
 const EXPIRY_MS: i64 = 20 * 1000;
 const MAX_BUFFER_SIZE: usize = 62 * 1024;
 const MAPPING_PROPERTIES: &[&str] = &["mapping", "input", "output", "for_each"];
@@ -1996,34 +1997,18 @@ async fn handle_import_node(
 }
 
 /// The suspend/resume store contract scopes records by graph + cid, so a dry-run instance
-/// must carry the model's STABLE identity - the root node's `name` property, which the
-/// export path keeps in sync with the graph's file/deployment id - never a per-instantiation
-/// handle (an ephemeral id makes every resume look up a key no suspend ever wrote, so a
-/// suspended dry-run workflow could only ever restart fresh). A draft whose root has no name
-/// yet has no stable identity to scope by: it keeps a unique playground handle, and
-/// `handle_instantiate` REJECTS it when the model uses suspend/resume - a silent ephemeral
-/// fallback there would break the resume mechanism invisibly.
+/// must carry an identity that is STABLE across instantiations - the root node's `name`
+/// property, which the export path keeps in sync with the graph's file/deployment id, or the
+/// constant `untitled` for a draft that has not been named yet. Never a per-instantiation
+/// handle: an ephemeral id makes every resume look up a key no suspend ever wrote, so a
+/// suspended dry-run workflow could only ever restart fresh.
 fn stable_graph_identity(graph: &MiniGraph) -> String {
-    root_name(graph).unwrap_or_else(|| format!("playground-{}", uuid::Uuid::new_v4().simple()))
-}
-
-/// The root node's non-blank `name` property, if any.
-fn root_name(graph: &MiniGraph) -> Option<String> {
     graph
         .get_root_node()
         .and_then(|root| root.get_property("name"))
         .and_then(|v| v.as_str().map(str::to_string))
         .filter(|name| !name.trim().is_empty())
-}
-
-/// True when any node carries the graph.suspend or graph.resume skill.
-fn uses_suspension(graph: &MiniGraph) -> bool {
-    graph.get_nodes().iter().any(|node| {
-        matches!(
-            node.get_property("skill").as_ref().and_then(|v| v.as_str()),
-            Some("graph.suspend") | Some("graph.resume")
-        )
-    })
+        .unwrap_or_else(|| UNTITLED.to_string())
 }
 
 async fn handle_instantiate(
@@ -2035,15 +2020,6 @@ async fn handle_instantiate(
     let Some(graph) = session::get_graph_model(in_route) else {
         return Ok(());
     };
-    // a suspend/resume model without a stable identity cannot be dry-run: its
-    // suspension record would be invisible to every later instantiation
-    if root_name(&graph).is_none() && uses_suspension(&graph) {
-        return Err(invalid(
-            "This graph model uses suspend/resume, so its workflow state needs a stable \
-             identity. Add a 'name' property to the root node (name=<graph-name>), then \
-             instantiate again.",
-        ));
-    }
     model::remove_instance(in_route);
     let filename = session::temp_graph_name(in_route);
     let file = temp_dir().join(format!("{filename}.json"));

--- a/crates/knowledge-graph/tests/graph_runtime.rs
+++ b/crates/knowledge-graph/tests/graph_runtime.rs
@@ -473,7 +473,7 @@ async fn graph_runtime_end_to_end() {
     companion_sync_inspect_error_shows_context(&platform).await;
     companion_sync_inspect_error_reports_recovery(&platform).await;
     companion_dry_run_resumes_across_instantiations(&platform).await;
-    companion_unnamed_suspend_graph_rejected_at_instantiation(&platform).await;
+    companion_unnamed_draft_resumes_across_instantiations(&platform).await;
     math_for_each_blocks_and_iteration(&platform).await;
     join_barrier_waits_for_a_retrying_branch(&platform).await;
     chained_join_counts_only_a_fired_upstream_join(&platform).await;
@@ -2838,10 +2838,13 @@ async fn companion_dry_run_resumes_across_instantiations(platform: &Platform) {
     );
 }
 
-/// Java `CompanionSyncTest.unnamedSuspendGraphIsRejectedAtInstantiation`: a
-/// suspend/resume model whose root has no `name` is REJECTED at instantiation
-/// (a silent ephemeral fallback would break the resume mechanism invisibly).
-async fn companion_unnamed_suspend_graph_rejected_at_instantiation(platform: &Platform) {
+/// Java `CompanionSyncTest.unnamedDraftResumesAcrossInstantiations`: the nameless
+/// twin - a draft sketched in the playground has no root `name` yet and must still
+/// suspend and resume, scoped under the stable constant `untitled`. This is the
+/// branch the regression lived in: the identity only has to be STABLE across
+/// instantiations, so anything per-instantiation writes a suspension no later run
+/// can read and silently restarts fresh instead of resuming.
+async fn companion_unnamed_draft_resumes_across_instantiations(platform: &Platform) {
     let po = PostOffice::new(platform);
     let sid = "ws-770016-1";
     let in_route = "ws.770016.1.in";
@@ -2883,25 +2886,94 @@ async fn companion_unnamed_suspend_graph_rejected_at_instantiation(platform: &Pl
         serde_json::from_str(&json).expect("response body is JSON")
     }
 
-    sync_cmd(platform, sid, "create node root\nwith type Root").await;
-    sync_cmd(platform, sid, "create node end\nwith type End").await;
-    sync_cmd(
+    let cid = "dry-run-untitled-1";
+    // consume-on-retrieve makes a leftover record indistinguishable from this test's own
+    let record = store_file("untitled", cid);
+    if record.exists() {
+        std::fs::remove_file(&record).expect("stale store record removed");
+    }
+    // sketch a suspend/resume draft with NO name on the root - the edge-mode shape:
+    // a drawn edge into the suspend node, plus the mandatory continuation edge
+    for command in [
+        "create node root\nwith type Root",
+        "create node end\nwith type End",
+        "create node resume\nwith type Resume\nwith properties\nskill=graph.resume\n\
+         task=v1.file.state.store",
+        "create node step-1\nwith type Suspensible\nwith properties\nskill=graph.task\n\
+         task=v1.counting.step\ninput[]=text(u-one) -> step\ninput[]=model.cid -> cid\n\
+         output[]=result.count -> model.step1_count",
+        "create node suspend\nwith type Suspend\nwith properties\nskill=graph.suspend\n\
+         task=v1.file.state.store\nttl=30s",
+        "create node step-2\nwith type Task\nwith properties\nskill=graph.task\n\
+         task=v1.counting.step\ninput[]=text(u-two) -> step\ninput[]=model.cid -> cid\n\
+         input[]=model.step1_count -> prior\noutput[]=result -> output.body",
+        "connect root to resume with test",
+        "connect resume to step-1 with test",
+        "connect step-1 to suspend with checkpoint",
+        "connect step-1 to step-2 with approved",
+        "connect suspend to end with test",
+        "connect step-2 to end with test",
+    ] {
+        sync_cmd(platform, sid, command).await;
+    }
+
+    // run 1: the nameless draft suspends at the checkpoint
+    let instantiated = sync_cmd(
         platform,
         sid,
-        "create node resume\nwith type Resume\nwith properties\nskill=graph.resume\ntask=v1.file.state.store",
+        &format!("instantiate graph\ntext({cid}) -> model.cid"),
     )
     .await;
-    sync_cmd(platform, sid, "connect root to resume with then").await;
-    sync_cmd(platform, sid, "connect resume to end with then").await;
-    let rejected = sync_cmd(platform, sid, "instantiate graph").await;
-    let text = rejected.to_string();
-    assert!(
-        text.contains("needs a stable identity"),
-        "the guard must teach the fix (name the root node): {rejected}"
+    assert_eq!(
+        instantiated["ok"],
+        serde_json::json!(true),
+        "a nameless draft must instantiate: {instantiated}"
+    );
+    let first = sync_cmd(platform, sid, "run").await;
+    assert_eq!(first["ok"], serde_json::json!(true), "run 1: {first}");
+    assert_eq!(
+        1,
+        step_count("u-one", cid),
+        "step-1 executes on the fresh run"
+    );
+    assert_eq!(
+        0,
+        step_count("u-two", cid),
+        "the suspension stops before step-2"
     );
     assert!(
-        !text.contains("Graph instance created"),
-        "no instance may be created for an unnamed suspend/resume model: {rejected}"
+        record.exists(),
+        "a nameless draft must persist under the stable 'untitled' scope, not a \
+         per-instantiation handle"
+    );
+
+    // run 2: a NEW instantiation with the same business cid resumes past the checkpoint
+    let again = sync_cmd(
+        platform,
+        sid,
+        &format!("instantiate graph\ntext({cid}) -> model.cid"),
+    )
+    .await;
+    assert_eq!(
+        again["ok"],
+        serde_json::json!(true),
+        "re-instantiate: {again}"
+    );
+    let second = sync_cmd(platform, sid, "run").await;
+    assert_eq!(second["ok"], serde_json::json!(true), "run 2: {second}");
+    assert_eq!(
+        1,
+        step_count("u-one", cid),
+        "the checkpoint must not re-execute"
+    );
+    assert_eq!(
+        1,
+        step_count("u-two", cid),
+        "the continuation must run on resume"
+    );
+    assert!(
+        !record.exists(),
+        "the record is consumed on resume (at-most-once)"
     );
 }
 


### PR DESCRIPTION
## What

Java lock-step (mercury-composable `f660ec32`). `stable_graph_identity` collapses to the root
node's `name` property or the new `const UNTITLED`; the rejection guard, `root_name`,
`uses_suspension` and the mirror test for the now-deleted Java rejection test are removed.

Adds the twin pin for the unnamed branch: a nameless suspend/resume draft sketched through
companion commands must suspend and then resume across a second instantiation — mutation-proven
against a per-instantiation handle. Workspace 58 suites / 305 tests, clippy clean, rustfmt clean.

## Why

v4.11.8 required a suspend/resume model to carry a root `name` before the playground would
instantiate it. That requirement was an artifact of the fix rather than of the store contract,
which needs the dry-run identity to be **stable across instantiations**, not derived from the
model name — so the guard was only protecting against the ephemeral `playground-{uuid}` fallback
that shipped beside it, at the cost of refusing to dry-run an unnamed draft.

Graph models are engine-portable and the Java engine is the reference implementation, so the same
nameless model must behave identically on both engines rather than instantiating on one and being
refused on the other — on a surface that is field-core and regression-critical.

Co-Authored-By: Claude Code <noreply@anthropic.com>