### PR TITLE
feat(event-script): f:setConfig plugin sets or overrides a config parameter at run-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
+## Unreleased
+
+### Added
+
+1. **Event Script `f:setConfig` plugin — set or override a configuration parameter at
+   run-time (lock-step with the Java engine).** The new built-in simple plugin stores a
+   key-value pair in the process override registry (this port's analog of a Java system
+   property), which takes precedence over the base configuration on every subsequent read.
+   Typical use: a start-up flow hydrates secrets from a cloud secret manager before dependent
+   components consume them. The key must be a non-empty string; the value can be any object
+   and is converted to text. Invalid input returns false without side effect.
+
+---
 ## Version 4.11.9, 8/11/2026
 
 ### Changed

--- a/crates/event-script/src/plugins.rs
+++ b/crates/event-script/src/plugins.rs
@@ -48,7 +48,7 @@ use crate::plugins_e8::value_type_name;
 /// The number of built-in `#[simple_plugin]` declarations the engine itself
 /// ships (this module + `plugins_e8`) — the startup floor the
 /// `SimplePluginLoader` asserts against linker elision.
-pub const BUILTIN_PLUGIN_COUNT: usize = 46;
+pub const BUILTIN_PLUGIN_COUNT: usize = 47;
 
 /// A plugin body (Java `PluginFunction.calculate`): evaluated argument values
 /// in, one value out; a descriptive error is the Java
@@ -409,6 +409,29 @@ fn plugin_get_last(args: &[Value]) -> Result<Value, String> {
             None => Err("Input cannot be empty to get last item from list".to_string()),
         },
         _ => Err("Input must be a list to get last item".to_string()),
+    }
+}
+
+/// `f:setConfig(key, value)` — set or override a configuration parameter at
+/// run-time (Java `SetConfigParameter`). The value lands in the process
+/// override registry — this port's `System.setProperty` analog — which every
+/// `ConfigReader` lookup consults first, so later `map(key)` constants and
+/// configuration reads see the update. The key must be a non-empty string;
+/// the value may be any object and is converted to text (Java
+/// `String.valueOf`). Invalid input returns false without side effect.
+#[simple_plugin("setConfig")]
+fn plugin_set_config(args: &[Value]) -> Result<Value, String> {
+    match args {
+        [Value::String(key), value] if !value.is_nil() => {
+            let key = key.as_str().unwrap_or_default();
+            if key.trim().is_empty() {
+                Ok(Value::Boolean(false))
+            } else {
+                platform_core::util::overrides::set(key, &get_text_value(value));
+                Ok(Value::Boolean(true))
+            }
+        }
+        _ => Ok(Value::Boolean(false)),
     }
 }
 #[cfg(test)]
@@ -907,5 +930,108 @@ mod tests {
             ),
             Err("Substring indexes are out of bounds: [0, 4]".to_string())
         );
+    }
+
+    /// Twin of the Java `SetConfigParameterTest`: two valid arguments set the
+    /// process override (the `System.setProperty` analog) and return true; a
+    /// non-string value is converted to text; invalid input returns false
+    /// without side effect.
+    #[test]
+    fn set_config_plugin_sets_override_and_validates_input() {
+        use platform_core::util::overrides;
+        assert!(contains_simple_plugin("setConfig"));
+        // happy path: the override is visible to every ConfigReader lookup
+        assert_eq!(
+            calculate(
+                "setConfig",
+                &[
+                    Value::from("set.config.plugin.direct"),
+                    Value::from("hello")
+                ]
+            ),
+            Ok(Value::Boolean(true))
+        );
+        assert_eq!(
+            overrides::get("set.config.plugin.direct"),
+            Some("hello".to_string())
+        );
+        // setting the same parameter again overrides the previous value
+        assert_eq!(
+            calculate(
+                "setConfig",
+                &[
+                    Value::from("set.config.plugin.direct"),
+                    Value::from("world")
+                ]
+            ),
+            Ok(Value::Boolean(true))
+        );
+        assert_eq!(
+            overrides::get("set.config.plugin.direct"),
+            Some("world".to_string())
+        );
+        // a non-string value is converted to text (Java String.valueOf)
+        assert_eq!(
+            calculate(
+                "setConfig",
+                &[Value::from("set.config.plugin.number"), Value::from(8088)]
+            ),
+            Ok(Value::Boolean(true))
+        );
+        assert_eq!(
+            overrides::get("set.config.plugin.number"),
+            Some("8088".to_string())
+        );
+        assert_eq!(
+            calculate(
+                "setConfig",
+                &[Value::from("set.config.plugin.flag"), Value::Boolean(true)]
+            ),
+            Ok(Value::Boolean(true))
+        );
+        assert_eq!(
+            overrides::get("set.config.plugin.flag"),
+            Some("true".to_string())
+        );
+        // invalid input returns false without side effect
+        assert_eq!(calculate("setConfig", &[]), Ok(Value::Boolean(false)));
+        assert_eq!(
+            calculate("setConfig", &[Value::from("key.only")]),
+            Ok(Value::Boolean(false))
+        );
+        assert_eq!(
+            calculate(
+                "setConfig",
+                &[Value::from("too"), Value::from("many"), Value::from("args")]
+            ),
+            Ok(Value::Boolean(false))
+        );
+        assert_eq!(
+            calculate(
+                "setConfig",
+                &[Value::from(100), Value::from("non-string-key")]
+            ),
+            Ok(Value::Boolean(false))
+        );
+        assert_eq!(
+            calculate("setConfig", &[Value::from(""), Value::from("empty-key")]),
+            Ok(Value::Boolean(false))
+        );
+        assert_eq!(
+            calculate("setConfig", &[Value::from("   "), Value::from("blank-key")]),
+            Ok(Value::Boolean(false))
+        );
+        assert_eq!(
+            calculate(
+                "setConfig",
+                &[Value::from("set.config.plugin.null.value"), Value::Nil]
+            ),
+            Ok(Value::Boolean(false))
+        );
+        assert_eq!(overrides::get("set.config.plugin.null.value"), None);
+        // test hygiene: leave no overrides behind
+        overrides::clear("set.config.plugin.direct");
+        overrides::clear("set.config.plugin.number");
+        overrides::clear("set.config.plugin.flag");
     }
 }

--- a/crates/event-script/tests/compiler.rs
+++ b/crates/event-script/tests/compiler.rs
@@ -97,6 +97,7 @@ fn loaded_flow_set_matches_the_java_engine() {
         "response-test",
         "retry-subflow-test",
         "sequential-test",
+        "set-config-parameter",
         "simple-circuit-breaker",
         "slow-subflow",
         "string-util",

--- a/crates/event-script/tests/flow_runtime.rs
+++ b/crates/event-script/tests/flow_runtime.rs
@@ -1192,6 +1192,36 @@ async fn flows_run_end_to_end_like_java() {
         Some(Value::from("SGVsbG8="))
     );
 
+    // --- the setConfig plugin flow (canonical fixture, byte-identical to the
+    // Java engine's set-config.yml): task one sets config parameters through
+    // f:setConfig, task two reads the overrides back through map(key)
+    // constants — proving the override registry is visible to every
+    // configuration read at run-time
+    let reply = run_flow(
+        &platform,
+        "set-config-parameter",
+        http_dataset(None, &[]),
+        "biz-cid-40",
+    )
+    .await;
+    let body = json_body(&reply);
+    assert_eq!(body["updated"], true);
+    assert_eq!(body["value_from_config"], "from-config-plugin");
+    // a numeric model variable is converted to text (Java String.valueOf)
+    assert_eq!(body["numeric_value"], true);
+    assert_eq!(body["numeric_from_config"], "8088");
+    // invalid usages return false and set nothing
+    assert_eq!(body["one_argument"], false);
+    assert_eq!(body["empty_key"], false);
+    assert_eq!(
+        platform_core::util::overrides::get("unit.test.config.override"),
+        Some("from-config-plugin".to_string())
+    );
+    assert_eq!(
+        platform_core::util::overrides::get("unit.test.config.incomplete"),
+        None
+    );
+
     // --- E-8: string operators (canonical fixture; body {text: "Hello..."})
     let mut dataset = http_dataset(None, &[]);
     if let Value::Map(entries) = &mut dataset {

--- a/crates/event-script/tests/resources/flows.yaml
+++ b/crates/event-script/tests/resources/flows.yaml
@@ -44,6 +44,7 @@ flows:
   - 'autostart.yml'
   - 'pluggableFunctions/arithmetic.yml'
   - 'pluggableFunctions/types.yml'
+  - 'pluggableFunctions/set-config.yml'
   - 'input-validation-1.yml'
   - 'input-validation-2.yml'
   - 'input-validation-3.yml'

--- a/crates/event-script/tests/resources/flows/pluggableFunctions/set-config.yml
+++ b/crates/event-script/tests/resources/flows/pluggableFunctions/set-config.yml
@@ -1,0 +1,36 @@
+flow:
+  id: 'set-config-parameter'
+  description: 'Set or override configuration parameter plugin test'
+  ttl: 10s
+
+first.task: 'set.config.task'
+
+tasks:
+  - name: 'set.config.task'
+    input:
+      - 'f:setConfig(text(unit.test.config.override), text(from-config-plugin)) -> model.updated'
+      - 'int(8088) -> model.port'
+      - 'f:setConfig(text(unit.test.config.numeric), model.port) -> model.numeric_value'
+      - 'f:setConfig(text(unit.test.config.incomplete)) -> model.one_argument'
+      - 'f:setConfig(text(), text(no-key)) -> model.empty_key'
+    process: 'no.op'
+    description: 'Set config parameters and exercise invalid usages'
+    output: []
+    execution: sequential
+    next:
+      - 'read.config.task'
+
+  - name: 'read.config.task'
+    input:
+      - 'model.updated -> updated'
+      - 'model.numeric_value -> numeric_value'
+      - 'model.one_argument -> one_argument'
+      - 'model.empty_key -> empty_key'
+      - 'map(unit.test.config.override) -> value_from_config'
+      - 'map(unit.test.config.numeric) -> numeric_from_config'
+    process: 'no.op'
+    description: 'Read back the overridden parameters through app configuration'
+    output:
+      - 'text(application/json) -> output.header.content-type'
+      - 'result -> output.body'
+    execution: end

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2561,3 +2561,18 @@ outstanding failure. Pinned by the byte-identical `unit-test-error-recovery` fix
 mapper reads the resolved context) in the executor lane and a tutorial-12 companion
 dry-run in the traveler lane. Docs: failure routing in the command reference, inspect and
 tutorial-12 and fetcher help, the AI catalog; webapp bundle regenerated.
+
+## Increment 87 — the setConfig plugin: run-time configuration override (2026-08-21)
+
+Lock-step mirror of the Java engine's new built-in simple plugin (`f:setConfig`), same
+day as the Java half. Two arguments — a non-empty string key and a value of any type,
+converted to text — land in the process override registry (`overrides::set`, this port's
+`System.setProperty` analog), which every `ConfigReader` lookup consults first, so later
+`map(key)` constants and configuration reads see the update; invalid input returns false
+without side effect. The typical use case is secret hydration: a start-up flow retrieves
+secrets from a cloud secret manager and sets them as configuration parameters before
+dependent components consume them. `BUILTIN_PLUGIN_COUNT` 46 → 47. Pinned by a
+`plugins.rs` unit twin of the Java `SetConfigParameterTest` and the byte-identical
+`set-config.yml` flow fixture (set in task one, read back through `map(key)` in task
+two) in the runtime suite. Docs: syntax.md catalog row + configuration override detail
+section; CHANGELOG Unreleased.

--- a/docs/guides/event-script/syntax.md
+++ b/docs/guides/event-script/syntax.md
@@ -1457,6 +1457,7 @@ For example:
 | **Type Conversion** | parseDate       | Parse a date string to ISO, Local or Milliseconds.                                                                    |
 | **Type Conversion** | parseDateTime   | Parse a date-time string to ISO, Local or Milliseconds.                                                               |
 | **Type Conversion** | validate        | Perform simple field validation. See details below.                                                                   |
+| **Configuration**   | setConfig       | A parameter name (non-empty string) and its value (any object, converted to text). Sets the value as a process override so that it takes precedence over the base configuration at run-time. Returns true when applied, false for invalid input. See details below. |
 
 !!! note "Rust port — `length` and `substring` count Unicode scalar values"
     String length and substring indexes address **whole characters** (Unicode scalar
@@ -1532,6 +1533,34 @@ throwing an validation error. For example,
 - f:validate(input.body.id, text(id; String; evaluate))
 
 Please note that the validation rule uses semicolon as separator because comma is used for tokenization.
+
+*Configuration override plugin*
+
+The 'setConfig' plugin sets or overrides a configuration parameter at run-time by saving it in the
+process override registry — this port's analog of a Java system property, also fed by `-Dkey=value`
+runtime arguments. Since an override takes precedence over the base application configuration, any
+subsequent configuration read — e.g. a `map(my.parameter)` constant in a data mapping statement or
+a `ConfigReader` lookup inside a composable function — will see the updated value.
+
+Syntax is "f:setConfig(key, value)". The key must be a non-empty string. The value can be any
+object — a text constant or a model variable — and it is converted to text because configuration
+parameter values are stored as strings.
+
+- f:setConfig(text(my.parameter), text(demo)) -> model.updated
+- f:setConfig(text(my.parameter), model.secret) -> model.updated
+
+It returns true when the parameter is set, or false when the key is missing or empty, or the
+value is null.
+
+The typical use case is secret hydration: a flow retrieves secrets from a cloud "secret manager"
+at start-up and sets them as configuration parameters for the rest of the application to consume.
+
+Please be careful about the application life cycle:
+
+1. The override applies to the whole application instance and stays effective until the
+   application restarts — not just for the calling flow instance.
+2. Components that have already consumed a parameter at start-up will not see the update.
+   Run the flow that sets the parameters before the dependent components read them.
 
 *JSON-Path helpers*
 


### PR DESCRIPTION
## What

Lock-step mirror of the Java engine's new built-in simple plugin `f:setConfig(key, value)`
(mercury-composable PR of the same day): set or override a configuration parameter at
run-time.

- **Plugin body:** the value lands in the process override registry (`overrides::set` —
  this port's `System.setProperty` analog), which every `ConfigReader` lookup consults
  first, so later `map(key)` constants and configuration reads see the update. Key =
  non-empty string; value = any object converted to text (Java `String.valueOf`); invalid
  input returns `false` without side effect.
- `BUILTIN_PLUGIN_COUNT` 46 → 47 (the linker-elision startup floor), and the
  loaded-flow-set parity pin gains the new canonical fixture.
- **Tests:** a `plugins.rs` unit twin of the Java `SetConfigParameterTest`, and the
  **byte-identical** `set-config.yml` flow fixture (set in task one, read back through
  `map(key)` in task two, numeric coercion included) asserted in the runtime suite.
- **Docs:** syntax.md Built-in Plugins catalog row + a "Configuration override plugin"
  detail section (Rust wording: the override registry, also fed by `-Dkey=value` runtime
  arguments); CHANGELOG Unreleased; INCREMENTS 87.

## Why

New built-in simple plugins ship on both engines or flows stop being portable — the flow
fixture in this PR is byte-identical to the Java engine's, and proves the same contract on
this engine. The port was small by design: the process override registry already mimics
Java's system-property precedence, so the plugin is a two-line body over an existing
mechanism.

The typical use case is secret hydration: a start-up flow retrieves secrets from a cloud
secret manager and sets them as configuration parameters before dependent components
consume them.

**Gates:** 58 suites / 306 tests passed, clippy 0, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>