### PR TITLE
chore(release): v4.11.10 - version bump and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
-## Unreleased
+## Version 4.11.10, 8/21/2026
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ai-contract-provider"
-version = "4.11.9"
+version = "4.11.10"
 dependencies = [
  "async-trait",
  "event-script",
@@ -114,7 +114,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.11.9"
+version = "4.11.10"
 dependencies = [
  "async-trait",
  "log",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "event-script"
-version = "4.11.9"
+version = "4.11.10"
 dependencies = [
  "async-trait",
  "base64",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "event-script-macros"
-version = "4.11.9"
+version = "4.11.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -483,7 +483,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.11.9"
+version = "4.11.10"
 dependencies = [
  "async-trait",
  "event-script",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.11.9"
+version = "4.11.10"
 dependencies = [
  "async-trait",
  "log",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph"
-version = "4.11.9"
+version = "4.11.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph-macros"
-version = "4.11.9"
+version = "4.11.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -814,7 +814,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minigraph-playground"
-version = "4.11.9"
+version = "4.11.10"
 dependencies = [
  "async-trait",
  "event-script",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "minigraph-state-redis"
-version = "4.11.9"
+version = "4.11.10"
 dependencies = [
  "async-trait",
  "log",
@@ -1001,7 +1001,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "platform-core"
-version = "4.11.9"
+version = "4.11.10"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macros"
-version = "4.11.9"
+version = "4.11.10"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.11.9"
+version = "4.11.10"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury-composable"


### PR DESCRIPTION
## What

Release cut for v4.11.10: workspace version 4.11.9 → 4.11.10 (Cargo.toml + Cargo.lock) and
the CHANGELOG Unreleased section becomes **Version 4.11.10, 8/21/2026**.

## Why

Ships two merged items, both lock-step with the Java engine's v4.11.10 (released today):
the Event Script `f:setConfig` plugin (run-time configuration override via the process
override registry, for secret hydration), and the `system/ai-contract-provider` AI
discovery app — the version-matched operational contract with REST discovery endpoints and
the offline `mercury-platform` Agent Skill export, at the same `system/` path as the Java
module.

**Gate:** 63 suites / 317 tests, clippy 0, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>