### PR TITLE
graph.task reaches declarative Event-over-HTTP targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
+## Unreleased
+
+### Added
+
+1. `graph.task` accepts a task route declared as a declarative Event-over-HTTP target
+   (`yaml.event.over.http`) - a knowledge graph can invoke remote engine instances and
+   polyglot (python/node.js) function hosts as graph tasks. Lock-step with the Java
+   engine (which also adds a `PostOffice.getEventHttpTarget(route)` API).
+
+---
 ## Version 4.11.10, 8/21/2026
 
 ### Added

--- a/crates/knowledge-graph/src/skills.rs
+++ b/crates/knowledge-graph/src/skills.rs
@@ -357,7 +357,12 @@ pub async fn task(
             "{NODE_NAME}{node_name} does not have a 'task' route"
         )));
     };
-    if !platform.has_route(&route) {
+    // a task route is reachable when registered locally, or when declared as a
+    // declarative Event-over-HTTP target - the way python/node.js polyglot
+    // functions and remote engine instances join a graph
+    if !platform.has_route(&route)
+        && platform_core::automation::event_api::get_event_http_target(&route).is_none()
+    {
         return Err(invalid(format!(
             "{NODE_NAME}{node_name} - task '{route}' does not exist"
         )));

--- a/crates/knowledge-graph/tests/compiler.rs
+++ b/crates/knowledge-graph/tests/compiler.rs
@@ -53,15 +53,16 @@ fn manifest_listed_graphs_are_compiled() {
     // (incl. the jump-mode and retired-property compat shapes) + the 3 valid
     // ttl fixtures (node-ttl ok + the 2 x-ttl wire echoes) + the generic
     // exception-context fixture + the orchestrator pair + the dynamic-jump
-    // fixture (THEN:/DELAY: dynamic variables) + the error-recovery fixture; the 14
-    // deliberately-invalid fixtures
+    // fixture (THEN:/DELAY: dynamic variables) + the error-recovery fixture +
+    // the foreign-route fixture (task-7, a declarative event-over-http target);
+    // the 14 deliberately-invalid fixtures
     // (suspend err1-7, no-end, ttl err1-4, task-6, error-alias) are rejected
     // by the mandatory quality gate. Every graph a runtime test executes MUST
     // be listed here - deployed execution is compiled-or-404 (no lazy load)
     let mut all = graphs::get_all_graphs();
     all.sort();
     assert_eq!(
-        49,
+        50,
         all.len(),
         "expected all valid manifest graphs to compile: {all:?}"
     );

--- a/crates/knowledge-graph/tests/graph_runtime.rs
+++ b/crates/knowledge-graph/tests/graph_runtime.rs
@@ -442,6 +442,68 @@ fn body_map(reply: &EventEnvelope) -> MultiLevelMap {
     MultiLevelMap::from_value(reply.body().clone())
 }
 
+/// A minimal polyglot peer: an /api/event endpoint that decodes the relayed
+/// event envelope and answers with a reply envelope - the same wire contract
+/// a python or node.js function host speaks.
+async fn start_stub_peer(port: u16) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
+        .await
+        .expect("stub peer port");
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut buf: Vec<u8> = Vec::new();
+                let mut tmp = [0u8; 4096];
+                let header_end = loop {
+                    match socket.read(&mut tmp).await {
+                        Ok(0) | Err(_) => return,
+                        Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                    }
+                    if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                        break pos + 4;
+                    }
+                };
+                let head_text = String::from_utf8_lossy(&buf[..header_end]).to_lowercase();
+                let content_length: usize = head_text
+                    .lines()
+                    .find_map(|line| line.strip_prefix("content-length:"))
+                    .and_then(|v| v.trim().parse().ok())
+                    .unwrap_or(0);
+                while buf.len() < header_end + content_length {
+                    match socket.read(&mut tmp).await {
+                        Ok(0) | Err(_) => return,
+                        Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                    }
+                }
+                let request =
+                    EventEnvelope::from_bytes(&buf[header_end..header_end + content_length])
+                        .expect("relayed envelope");
+                let reply_body = Value::Map(vec![
+                    ("language".into(), "stub".into()),
+                    ("route".into(), request.to().unwrap_or("").into()),
+                    ("echo".into(), request.body().clone()),
+                ]);
+                let payload = EventEnvelope::new()
+                    .set_body(reply_body)
+                    .expect("reply body")
+                    .to_bytes()
+                    .expect("reply bytes");
+                let head = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/octet-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                    payload.len()
+                );
+                let _ = socket.write_all(head.as_bytes()).await;
+                let _ = socket.write_all(&payload).await;
+                let _ = socket.shutdown().await;
+            });
+        }
+    });
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn graph_runtime_end_to_end() {
     let platform = boot().await;
@@ -1427,6 +1489,32 @@ async fn graph_task_matches_java_semantics(platform: &Platform) {
     let mm = body_map(&reply);
     assert_eq!(Some(Value::from("recovered")), mm.get_element("message"));
     assert_eq!(Some(Value::from(400)), mm.get_element("status"));
+
+    // --- unit-test-task-7: a foreign route reached through the declarative
+    // event-over-http map (yaml.event.over.http) - the way python/node.js
+    // polyglot functions join a knowledge graph. The stub peer speaks the
+    // standard envelope wire format on /api/event.
+    start_stub_peer(8391).await; // matches stub.peer.port in application.yml
+    let reply = run_graph(
+        &platform,
+        "unit-test-task-7",
+        serde_json::json!({"text": "polyglot"}),
+        serde_json::json!({}),
+    )
+    .await;
+    assert_eq!(
+        200,
+        reply.status(),
+        "foreign route failed: {}",
+        event_script::conversions::to_json_string(reply.body())
+    );
+    let mm = body_map(&reply);
+    assert_eq!(Some(Value::from("stub")), mm.get_element("language"));
+    assert_eq!(
+        Some(Value::from("polyglot.stub.function")),
+        mm.get_element("route")
+    );
+    assert_eq!(Some(Value::from("polyglot")), mm.get_element("echo.text"));
 
     // --- unit-test-task-5: a missing task route fails fast
     let reply = run_graph(

--- a/crates/knowledge-graph/tests/resources/application.yml
+++ b/crates/knowledge-graph/tests/resources/application.yml
@@ -16,6 +16,11 @@ app.env: dev
 
 rest.server.port: 8090
 
+# Event-over-HTTP declarative map for the graph.task foreign-route pin
+# (graph_runtime.rs); the stub peer binds stub.peer.port in the test
+yaml.event.over.http: 'classpath:/event-over-http.yaml'
+stub.peer.port: 8391
+
 location.graph.temp: 'file:/tmp/graph'
 # the manifest carries the location of its own models ('location' entry,
 # default classpath:/graph) - location.graph.deployed is obsolete

--- a/crates/knowledge-graph/tests/resources/event-over-http.yaml
+++ b/crates/knowledge-graph/tests/resources/event-over-http.yaml
@@ -1,0 +1,3 @@
+event.http:
+  - route: 'polyglot.stub.function'
+    target: 'http://127.0.0.1:${stub.peer.port}/api/event'

--- a/crates/knowledge-graph/tests/resources/graph/unit-test-task-7.json
+++ b/crates/knowledge-graph/tests/resources/graph/unit-test-task-7.json
@@ -1,0 +1,59 @@
+{
+  "nodes": [
+    {
+      "types": [
+        "UnitTest"
+      ],
+      "alias": "end",
+      "properties": {}
+    },
+    {
+      "types": [
+        "Task"
+      ],
+      "alias": "foreign-task",
+      "properties": {
+        "task": "polyglot.stub.function",
+        "input": [
+          "input.body -> *"
+        ],
+        "output": [
+          "result -> output.body"
+        ],
+        "skill": "graph.task"
+      }
+    },
+    {
+      "types": [
+        "UnitTest"
+      ],
+      "alias": "root",
+      "properties": {
+        "purpose": "graph.task reaches a foreign route through the declarative event-over-http map",
+        "name": "unit-test-task-7"
+      }
+    }
+  ],
+  "connections": [
+    {
+      "source": "foreign-task",
+      "relations": [
+        {
+          "type": "test",
+          "properties": {}
+        }
+      ],
+      "target": "end"
+    },
+    {
+      "source": "root",
+      "relations": [
+        {
+          "type": "test",
+          "properties": {}
+        }
+      ],
+      "target": "foreign-task"
+    }
+  ]
+}

--- a/crates/knowledge-graph/tests/resources/graphs.yaml
+++ b/crates/knowledge-graph/tests/resources/graphs.yaml
@@ -28,6 +28,8 @@ graphs:
   # deliberately invalid: an input mapping targets reserved model metadata
   # (model.ttl) - CompileGraph must reject it and requests answer 404
   - 'unit-test-task-6'
+  # foreign route: the task exists only as a declarative event-over-http target
+  - 'unit-test-task-7'
   - 'rust-foreach'
   - 'rust-join'
   - 'rust-join-retry'

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2610,3 +2610,19 @@ discovery surface on both engines (`system/AGENTS.md` + the contract provider be
 Pure relocation: workspace member path, the consumer guide's link and module table,
 llms.txt and the CHANGELOG entry updated; the crate's relative paths (`../../crates`,
 `../../docs`) keep the same depth, so no code changes.
+
+## Increment 90 — graph.task reaches declarative event-over-http targets (2026-08-22)
+
+The polyglot initiative's only engine change (ratified D5): a `graph.task` route is now
+reachable when registered locally OR declared in the `yaml.event.over.http` map — the way
+python/node.js polyglot function hosts and remote engine instances are addressed as if
+local. Flows already behaved this way (no pre-check); the graph lane's existence guard
+(`skills.rs`) additionally consults `event_api::get_event_http_target`, and the teaching
+error for genuinely unknown routes is unchanged (unit-test-task-5 still pins it).
+
+Pin: `unit-test-task-7` (fixture byte-identical to the Java engine's) — a graph.task node
+reaches a route that exists only as an event-over-http target, served by a stub
+`/api/event` peer speaking the envelope wire format; proven failing against the unfixed
+guard first. The compiled-set parity pin grew 49 → 50 (it caught the new fixture
+immediately, as designed). Java lock-step: same guard relaxation plus a
+`PostOffice.getEventHttpTarget(route)` passthrough.


### PR DESCRIPTION
## What

- `graph.task`'s existence guard accepts a task route that is not registered locally when
  it is declared in the declarative Event-over-HTTP map (`yaml.event.over.http`) - the
  guard in `skills.rs` additionally consults the public
  `automation::event_api::get_event_http_target`. The teaching error for genuinely
  unknown routes is unchanged (the unit-test-task-5 pin still covers it).
- Pin: `unit-test-task-7` (fixture byte-identical to the Java engine's) - a graph.task
  node reaches a route that exists ONLY as an event-over-http target, served by a stub
  `/api/event` peer (raw tokio TCP) that decodes the relayed envelope and replies on the
  envelope wire format - the same contract a python/node.js function host speaks. Proven
  failing against the unfixed guard first (same "does not exist" signature with the map
  demonstrably loaded).
- The compiled-set parity pin caught the new fixture immediately and grew 49 → 50, as
  designed.
- CHANGELOG Unreleased entry; INCREMENTS 90.

## Why

This is the only engine change of the ratified polyglot initiative (D5), in lock-step
with the Java engine (companion PR
https://github.com/Accenture/mercury-composable/pull/292): Event Script flows already
reach declarative Event-over-HTTP targets with zero code, but the graph lane pre-checks
route existence against the local registry only - so knowledge graphs could not call the
new python/node.js polyglot function hosts (or remote engine instances) that flows
already can. The surgical guard relaxation closes that gap and keeps graphs and flows
symmetric on the polyglot surface. Port divergence, documented: no PostOffice passthrough
is needed here (Java adds `PostOffice.getEventHttpTarget`) - the skill calls the public
`event_api` accessor directly. `graph.suspend`'s store-task guard deliberately stays
local-only.

## Verification

- New e2e proven against unfixed code first, green after the fix.
- Workspace: 63 suites green, clippy 0, fmt clean.
- Fixture and error message identical to the Java engine per the cross-engine parity
  convention.

Co-Authored-By: Claude Code <noreply@anthropic.com>