### PR TITLE
docs: polyglot functions chapter, ADR-0014, home page unified as Comp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`docs/design/`](docs/design/).
 
 ---
+## Unreleased
+
+### Added
+
+1. Polyglot Functions documentation chapter (`guides/polyglot-functions.md`) - writing
+   composable functions in Python and Node.js with the official Event-over-HTTP wrappers
+   (docs: accenture.github.io/mercury-python and accenture.github.io/mercury-nodejs),
+   with the zero-code demo extended to the wrapper demo apps. ADR-0014 (Proposed) records
+   the peers-not-subprocesses design; the interop test report gains the polyglot wrapper
+   round (2026-08-22 acceptance drives).
+
+### Changed
+
+1. Documentation home page unified on the Java reference presentation (the layered-ascent
+   table) and the docs site renamed "Composable for Rust" for family consistency with
+   Composable for Java / Python / Node.js; engine and wrapper documentation now
+   cross-link.
+
+---
 ## Version 4.11.11, 8/23/2026
 
 ### Added

--- a/docs/arch-decisions/ADR.md
+++ b/docs/arch-decisions/ADR.md
@@ -26,6 +26,58 @@ or *Deprecated* (no longer relevant), with its text left in place.
 
 ---
 
+## ADR-0014 — Polyglot functions are Event-over-HTTP peers, not subprocesses or ports {#adr-0014}
+**Status:** Proposed · **Date:** 2026-08-22 · **Serves:** vision-mercury · **Formalizes:** polyglot-event-over-http-design
+<!-- id: adr-0014 | status: proposed -->
+
+**Abstract.** Functions written in Python and Node.js join Event Script flows and
+MiniGraph knowledge graphs as long-lived **Event API peers**: each official wrapper
+([mercury-python](https://github.com/Accenture/mercury-python),
+[mercury-nodejs](https://github.com/Accenture/mercury-nodejs)) hosts `POST /api/event`
+with the engines' exact semantics and speaks the standard envelope wire format, verified
+against the golden conformance vectors this engine shares with the Java engine. The
+engine addresses a polyglot route through the existing declarative
+`yaml.event.over.http` map, so a flow task or `graph.task` node calls a Python or
+Node.js function exactly as if it were local, with trace context, the `my_cid` →
+`my_correlation_id` injection, and the portable error contract (handler errors ride
+HTTP 200 with envelope status; transport errors keep 400/403/404/408 with
+engine-identical messages) intact. The wrapper scope is fenced: envelope codec, Event
+API host, `preload` registry, thin `PostOffice` client, a primitive in-process event bus
+(per-route FIFO mailboxes with faithful `instances`; no spill tier, no queue cap), the
+engines' actuator endpoints, the minimalist utilities (configuration with the
+`resources/` convention and `-Dkey=value` overrides, engine-format logging with
+`log.format=text|json|compact`, trace context), and a dev runner — **no orchestration**:
+flows, graphs, persistence, and pub/sub stay on the engines. **Rust realization:** the
+single engine change is the `graph.task` route-existence guard consulting the
+declarative map (`event_api::get_event_http_target` in `skills.rs`), shipped lock-step
+with the Java engine in v4.11.11. The initiative's design record
+(`polyglot-event-over-http-design`) lives in the Java repository's shared memory; the
+wire conformance vectors are the acceptance gate for every wrapper, and each wrapper
+release extends the interop test report.
+
+**Rationale.** The alternative designs were a full language port and an engine-managed
+subprocess runner, and both were investigated. A full port re-implements the composable
+core (event bus, flow engine, graph engine) per language — this repository *is* such a
+port and demonstrates the cost profile: staying current is a sustained engineering
+commitment, justified for Rust as a first-class engine, unjustifiable per scripting
+language (the legacy Node.js port fell ~2 years behind and was retired). A subprocess
+runner (functions as child processes over stdio) was prototyped on the Java engine and
+shelved: kernel-thread isolation per in-flight call, process-tree lifecycle management,
+and per-call interpreter startup create an operational stability surface the peer model
+does not have. The peer model reuses what already works: the function contract is
+route-name + envelope (nothing in it names a language), the Event API endpoint already
+carries it across instances and across engines, and the declarative map already
+abstracts location. Keeping orchestration out of the wrappers preserves the
+architecture's one boundary — the engine tier owns sequencing, retries, and
+back-pressure (a leaf host fails fast by deadline instead of hoarding work) — and keeps
+each wrapper small enough to stay in lock-step through a conformance suite rather than a
+porting effort. Engine-consistent utilities and actuator endpoints are part of the
+decision, not convenience: polyglot installations put every language's telemetry, logs,
+probes, and dashboards in front of one DevSecOps team, so presentation parity is a field
+requirement extended from the two engines to the wrapper family. The Node.js wrapper is
+also the sanctioned answer to the retired legacy port — a fresh re-port was never going
+to stay current; a thin protocol wrapper can.
+
 ## ADR-0013 — Generic exception context: one handler serves every `exception=` route {#adr-0013}
 **Status:** Proposed · **Date:** 2026-08-10 · **Serves:** vision-mercury · **Formalizes:** field-graph-scoped-state-and-error-context-rust
 <!-- id: adr-0013 | status: proposed -->

--- a/docs/guides/event-over-http.md
+++ b/docs/guides/event-over-http.md
@@ -385,6 +385,11 @@ The mirror direction works the same way: the Java composable-example (port 8100)
 or the Java lambda-example — interchangeably. Point `peer.demo.host` / `peer.demo.port`
 at any peer that exposes the routes.
 
+The swap extends beyond the two engines: the official **Python and Node.js wrappers**
+register the same `hello.declarative` route in their demo apps and default to the same
+port 8085, so the identical `curl` executes a Python or Node.js function with zero
+changes — see [Polyglot Functions](polyglot-functions.md).
+
 The full cross-language matrix — both directions, both patterns, RPC and async, error
 semantics and trace continuity — was exercised by live bidirectional interop drives
 between the two engines; the permanent record is the
@@ -396,6 +401,8 @@ between the two engines; the permanent record is the
 - [Interop Test Report (Java ⇄ Rust)](../test-reports/event-over-http-interop.md) — the live
   bidirectional validation of both patterns, with span-level trace evidence and the
   learnings kept as a playbook for future language ports.
+- [Polyglot Functions](polyglot-functions.md) — write the functions themselves in Python
+  or Node.js and call them through this mechanism.
 - [REST Automation](rest-automation.md) — declarative HTTP endpoints, no controllers.
 - [EventEnvelope](event-envelope-reference.md) — the envelope and the standard wire format.
 - [Observability Model](observability.md) — the span tree and the application log context.

--- a/docs/guides/polyglot-functions.md
+++ b/docs/guides/polyglot-functions.md
@@ -1,0 +1,156 @@
+# Polyglot Functions
+
+**Polyglot functions** let you write a composable function in **Python** or **Node.js**
+and wire it into this engine's Event Script flows and MiniGraph knowledge graphs with
+**zero orchestration code** in the foreign language. The mechanism is the declarative
+[Event over HTTP](event-over-http.md) map — the wrappers below are long-lived Event API
+peers, not language ports.
+
+> **Versions** — Event Script flows call polyglot functions on any engine that speaks the
+> standard wire format; MiniGraph `graph.task` requires engine **v4.11.11+** (both the
+> Rust and Java engines shipped the guard change in that release).
+
+## Why peers, not ports
+
+A Mercury function is addressed by a route-name string and receives an `EventEnvelope` —
+nothing in that contract says "Rust" or "Java". So the shortest path to another language
+is not porting the composable core (this repository *is* such a port, and knows the
+cost), it is letting a function in that language **speak the same envelope over the
+existing Event API endpoint**:
+
+| Package | Repository | Documentation |
+|---------|------------|---------------|
+| Composable for Python | [Accenture/mercury-python](https://github.com/Accenture/mercury-python) | <https://accenture.github.io/mercury-python/> |
+| Composable for Node.js | [Accenture/mercury-nodejs](https://github.com/Accenture/mercury-nodejs) | <https://accenture.github.io/mercury-nodejs/> |
+
+Each wrapper hosts `POST /api/event` with the engines' exact semantics, registers
+functions with the engines' `preload` contract (route name, `instances`, private
+visibility), and carries a thin `PostOffice` client, a primitive in-process event bus for
+leaf-side composition, and the minimalist utilities (configuration with the `resources/`
+convention and `-Dkey=value` overrides, engine-format logging with
+`log.format=text|json|compact`, trace context). The envelope codec implements the
+language-neutral [standard wire format](event-envelope-reference.md) and is verified
+against the same golden conformance vectors this engine shares with the Java engine.
+
+What the wrappers deliberately do **not** contain: flows, graphs, persistence, pub/sub.
+Orchestration — sequencing, branching, retries, compensation — stays in Event Script and
+MiniGraph on the engine, where it is declarative, inspectable, and governed. A polyglot
+function is a **unit of work**; the architecture keeps it that way.
+
+## Wiring: one map entry per route
+
+On the engine application, a polyglot route is declared exactly like any remote route —
+`application.yml`:
+
+```yaml
+yaml.event.over.http: 'classpath:/event-over-http.yaml'
+```
+
+`event-over-http.yaml`:
+
+```yaml
+event.http:
+  - route: 'hello.declarative'
+    target: 'http://${peer.demo.host:127.0.0.1}:${peer.demo.port}/api/event'
+```
+
+Any flow task or `graph.task` node that names `hello.declarative` now executes the Python
+(or Node.js) function — the flow and the graph neither know nor care.
+
+### The zero-code demo, third language
+
+The [Event over HTTP zero-code demo](event-over-http.md#zero-code-demo-hello-flow-to-hello-world)
+already swaps its Rust callee for the Java lambda-example with no changes. The polyglot
+wrappers extend the same swap: their demo apps register the same public
+`hello.declarative` route, and the wrapper's default port is 8085 — hello-world's slot.
+
+1. Start hello-flow as in the demo walk-through (`cargo run -p hello-flow`).
+2. Instead of hello-world, start the Python demo (from a clone of mercury-python, after
+   its documented setup):
+
+    ```shell
+    mercury-serve examples/demo_app.py -Drest.server.port=8085
+    ```
+
+    or the Node.js demo (from a clone of mercury-nodejs, after `npm install` and
+    `npm run build`):
+
+    ```shell
+    node dist/src/cli.js examples/demo-app.mjs -Drest.server.port=8085
+    ```
+
+    (The `-Dkey=value` override syntax is the engines' own — the wrappers carry the same
+    configuration conventions, so operating them feels identical.)
+
+3. Run the declarative demo endpoint:
+
+    ```shell
+    curl -s -X POST -H "content-type: application/json" \
+         -d '{"hello": "world"}' http://127.0.0.1:8100/api/event/http/declarative
+    ```
+
+The reply now carries `"language": "python"` (or `"node.js"`), and the wrapper's log line
+shows the **engine's trace id** in the engine-consistent log format. The acceptance
+drives behind this pattern — the golden-vector conformance run, the cross-wrapper drive,
+and an unchanged engine flow executing the Python function — are recorded in the
+[interop report's polyglot wrapper round](../test-reports/event-over-http-interop.md#the-polyglot-wrapper-round-2026-08-22).
+
+## Calling from a knowledge graph
+
+`graph.task` invokes composable functions from graph nodes, and a declarative
+Event-over-HTTP target is a composable function. From engine **v4.11.11** the
+route-existence guard consults the declarative map
+(`event_api::get_event_http_target` in this engine), so a deployed graph can name a
+polyglot route directly:
+
+```text
+skill=graph.task, task=hello.declarative
+```
+
+On engines before v4.11.11 the guard only checked local routes and a graph naming a
+remote target failed validation — upgrade both engines to at least v4.11.11 before
+pointing graphs at polyglot functions.
+
+## The contract, end to end
+
+The function contract is the engines' own, restated in each wrapper's documentation
+(start at the wrapper's *AI agent guide* for the token-efficient version):
+
+- **Input** — `(headers, body)` exactly as an engine function sees them; reserved engine
+  headers are cleaned at ingress; the caller's business correlation id arrives as the
+  read-only `my_correlation_id` header.
+- **Errors are portable** — a wrapper `AppException(400, "missing 'text'")` becomes a
+  400 envelope on HTTP 200 (handler errors ride HTTP 200 with envelope status, exactly
+  like the engines); the calling flow's `exception:` task or the graph's `error.*`
+  context fires as if the function were local. Transport-level failures keep the engine
+  status codes: 403 private target, 404 unknown route, 408 timeout.
+- **Trace continuity** — the engine's trace id and path ride the wire; wrapper telemetry
+  and log lines join the same aggregated trace, and trace annotations return on the
+  reply envelope.
+- **Timeouts** — the flow's `ttl` (or the graph's) bounds the call; on breach the engine
+  receives the standard 408 and the exception path decides recovery. Back-pressure and
+  retries belong to the engine tier by design — the wrappers keep no spill queue.
+- **Wire format** — the wrappers speak the **standard** envelope format only (the
+  engines' default for Event over HTTP); the classic compact format is rejected with a
+  teaching error.
+
+## Operating a polyglot installation
+
+The wrappers serve the engines' actuator endpoints on the same port as `/api/event` —
+`/info`, `/info/routes`, `/env`, `/health`, `/livenessprobe` with the `type=info` /
+`type=health` health-function contract. Kubernetes probes, dashboards, and log
+aggregation treat a Python or Node.js app exactly like an engine app: one operational
+surface, no per-language tooling — the same presentation-parity requirement the two
+engines hold each other to.
+
+## See also
+
+- [Event over HTTP](event-over-http.md) — the underlying mechanism, endpoint security,
+  and the full demo walk-through.
+- [Composable for Python](https://accenture.github.io/mercury-python/) and
+  [Composable for Node.js](https://accenture.github.io/mercury-nodejs/) — write the
+  functions: handler styles, local composition, testing, AI agent guides.
+- [Interop Test Report](../test-reports/event-over-http-interop.md) — the conformance
+  evidence, including the polyglot wrapper round.
+- [EventEnvelope](event-envelope-reference.md) — the envelope and the standard wire
+  format.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,47 +1,39 @@
-# mercury
+# Mercury Composable for Rust
 
-**A Rust port of [mercury-composable](https://github.com/Accenture/mercury-composable) —
-Accenture's event-driven, composable application platform — delivered bottom-up:
-foundation → user interface.**
+Mercury Composable lets you build backend applications as **composable, event-driven systems** —
+and, increasingly, as **Active Knowledge Graphs** you evolve by *editing a model* rather than
+rewriting code. Functions are fully decoupled — they know each other only by route name, wired
+through event envelopes — so orchestration is **configuration, not code**. This is the official
+**Rust implementation**: the event-driven core descends from the **Scala/Akka actor model**,
+realized here on **tokio** async/await, with the canonical
+[Java engine](https://accenture.github.io/mercury-composable/) as the behavior specification —
+same three layers, same flow YAML, behavior-synced release by release.
 
-Self-contained **functions** (actors) addressed only by **route name** exchange immutable
-**`EventEnvelope`** messages over an **in-memory event bus**. Orchestration is configuration,
-not code. At the top, an **active knowledge graph** *is* the application.
+> **New here?** Start with **[Getting Started](guides/getting-started.md)**.
 
-## The three layers
+## A layered ascent
 
-```mermaid
-flowchart TB
-    KG["Active Knowledge Graph<br/>a graph model executes behavior —
-    skills on nodes, zero code for the common case"]
-    ES["Event Script<br/>YAML flows sequence functions per transaction —
-    orchestration as configuration"]
-    PC["platform-core<br/>functions · route names · EventEnvelope ·
-    in-memory event bus · Platform · PostOffice · REST automation"]
-    KG --> ES --> PC
-```
+Mercury grew in three layers. Each builds on the one beneath it, and you can mix them in a single
+application — drop down a layer exactly where you need more control, and no further.
 
-<div class="grid cards" markdown>
+| Layer | You express behavior as… | What you write |
+|:------|:--------------------------|:---------------|
+| **Event-driven**<br>[Platform Core](guides/event-driven/index.md) | decoupled functions reacting<br>to events | Rust functions,<br>addressed by route name |
+| **Composable**<br>[Event Script](guides/event-script/index.md) | YAML flows that choreograph<br>functions | ~50% config,<br>50% code |
+| **Semantic**<br>[Active Knowledge Graph](guides/knowledge-graph/index.md) | a graph whose nodes *execute*<br>during traversal | a model —<br>little or no code |
 
-- **platform-core** — the event-driven foundation. Stateless functions registered by
-  dot-separated route names, N worker instances each, RPC and fire-and-forget messaging,
-  configuration management, structured logging, distributed tracing, and a declarative HTTP
-  boundary where **`rest.yaml` *is* the router**.
+## Knowledge Graph as application
 
-- **Event Script** — composable orchestration. A YAML DSL sequences functions for a
-  transaction with a per-transaction state machine, `input`/`output` data mapping, and
-  execution types — the flow configuration is identical to the Java original, so flows port
-  unchanged.
-
-- **Active knowledge graph** — the semantic layer. A graph model executes behavior through
-  skills embedded on nodes during traversal, with a live **Playground** (port 8085) where
-  humans and AI agents co-author graphs in real time.
-
-</div>
+The newest layer is a paradigm shift: model business intent, enterprise knowledge, and system
+behavior as **one executable [Active Knowledge Graph](guides/knowledge-graph/index.md)**. Behavior
+runs as the graph is traversed, so changing what a system *does* means refining the model,
+certifying it, and deploying the updated model — not rewriting and redeploying code. Humans and AI
+companions co-author the same model in a live
+[Playground](guides/knowledge-graph/playground-and-companion.md).
 
 ## Why a Rust port
 
-The same destination as mercury-composable (Java), re-reached in Rust: **AI-assisted Semantic
+The same destination as the Java engine, re-reached in Rust: **AI-assisted Semantic
 Application Development**, on a lightweight, fast foundation
 (the ported event bus benchmarks at ~155K RPC ops/s at 6 µs round-trip). The port is
 **faithful by design** — the Java project remains the canonical behavior specification
@@ -49,13 +41,26 @@ Application Development**, on a lightweight, fast foundation
 (tokio instead of virtual threads, compile-time registration instead of classpath scanning,
 no Kafka service mesh, no Spring).
 
+## Building with an AI agent
+
+Mercury's DSLs ship **agent-ready specifications** — a rule-based grammar plus a machine-readable
+catalog — so an AI agent can generate correct artifacts *deterministically*, without inferring from
+examples or reading engine source:
+
+- [MiniGraph commands](guides/knowledge-graph/ai-agent-guide.md) — build graphs via the companion endpoint.
+- [Event Script flows](guides/event-script/ai-agent-guide.md) — author flow YAML.
+- [Composable functions](guides/event-driven/ai-agent-guide.md) — the Rust authoring contract.
+
+A machine-readable map of the whole site lives at [`llms.txt`](llms.txt) — engine-verified; a
+fresh agent can build graphs from it with zero out-of-band context.
+
 ## Explore the docs
 
 - **Get started** — [Getting Started](guides/getting-started.md)
 - **Guides** — [Event-driven Functions](guides/event-driven/index.md) ·
   [Event Script Flows](guides/event-script/index.md) ·
   [REST Automation](guides/rest-automation.md) · [Event over HTTP](guides/event-over-http.md) ·
-  [Observability](guides/observability.md)
+  [Polyglot Functions](guides/polyglot-functions.md) · [Observability](guides/observability.md)
 - **Knowledge Graph** — [Knowledge Graph as Application](guides/knowledge-graph/index.md) ·
   [Build Your First Graph](guides/knowledge-graph/build-your-first-graph.md) ·
   [Workflow Suspension](guides/knowledge-graph/workflow-suspension.md) ·
@@ -66,9 +71,6 @@ no Kafka service mesh, no Spring).
 - **Reference** — [Macros](guides/macros-reference.md) ·
   [Configuration](guides/configuration-reference.md) · [Event Envelope](guides/event-envelope-reference.md) ·
   [Flow Schema](guides/flow-schema-reference.md) · [API Overview](guides/api-overview.md)
-- **AI agents** start at [`docs/llms.txt`](llms.txt) — the machine-readable map of the
-  agent-optimized documentation set (engine-verified; a fresh agent can build graphs from it
-  with zero out-of-band context). Every layer section carries its own AI agent guide.
 
 ## Project
 
@@ -80,6 +82,10 @@ no Kafka service mesh, no Spring).
   YAML, behavior-synced with this engine:
   [github.com/Accenture/mercury-composable](https://github.com/Accenture/mercury-composable)
   · [documentation](https://accenture.github.io/mercury-composable/)
+- **Polyglot functions:** write functions in **Python** or **Node.js** and call them from
+  flows and graphs — see [Polyglot Functions](guides/polyglot-functions.md):
+  [Composable for Python](https://accenture.github.io/mercury-python/)
+  · [Composable for Node.js](https://accenture.github.io/mercury-nodejs/)
 
 !!! note "Rust port"
     Throughout this site, boxes like this mark the places where the Rust port deliberately

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -66,6 +66,11 @@ Needed when a flow task or a graph's `graph.task` calls a custom function:
 - [Function AI agent guide](guides/event-driven/ai-agent-guide.md) — the Rust authoring contract:
   `#[preload]` attribute, `ComposableFunction`/`TypedFunction` traits, pre-write checklist,
   PostOffice RPC patterns, serialization rules, worked example with rest.yaml wiring.
+- [Polyglot Functions](guides/polyglot-functions.md) — write functions in Python or Node.js as
+  Event-over-HTTP peers instead: official wrappers (docs: accenture.github.io/mercury-python,
+  accenture.github.io/mercury-nodejs) with the engines' preload/envelope/actuator/log contracts;
+  flows call them via yaml.event.over.http; graph.task requires engine v4.11.11+; orchestration
+  stays on the engine (no flows/graphs in wrappers).
 
 ## Design & project docs (human-facing)
 - `docs/design/` — port design notes (platform-core, event-script, knowledge-graph, and

--- a/docs/test-reports/event-over-http-interop.md
+++ b/docs/test-reports/event-over-http-interop.md
@@ -20,8 +20,9 @@ This report is a permanent record. It documents what was tested, the evidence co
 and — in the interest of honest engineering — the defects the drives surfaced and how each
 was fixed and re-verified. Everything here is reproducible from the shipped examples by
 following the [Event over HTTP](../guides/event-over-http.md#zero-code-demo-hello-flow-to-hello-world) walk-through.
-It is also kept as a **playbook for future language ports** (e.g. Python) — see the
-learnings section at the end.
+It is also kept as a **playbook for future language ports** — see the learnings section
+at the end; the [polyglot wrapper round](#the-polyglot-wrapper-round-2026-08-22) records
+the playbook's first execution, bringing Python and Node.js into the family.
 
 ## Background: the wire-format validation drive
 
@@ -384,10 +385,47 @@ engines flipped in lock-step with their precedence regressions inverted, and not
 drive's ce_traceparent-only scenario (the gateway simulation) is unaffected: the custom
 name remains the carrier whenever the standard header does not survive the intermediary.
 
+## The polyglot wrapper round (2026-08-22)
+
+The playbook below was executed for real when the **polyglot initiative** brought Python
+and Node.js into the family — not as engine ports but as lightweight **Event-over-HTTP
+wrappers** ([mercury-python](https://github.com/Accenture/mercury-python),
+[mercury-nodejs](https://github.com/Accenture/mercury-nodejs); see the
+[Polyglot Functions](../guides/polyglot-functions.md) guide). Evidence from the
+acceptance drives, conducted 2026-08-22 against engine v4.11.10:
+
+1. **Golden conformance vectors first — item 1 of the playbook, literally.** Both
+   wrappers' standard-format codecs are verified against the same golden vectors the
+   Java and Rust engines share, carried verbatim in each wrapper's test suite. The
+   classic compact format is detected and rejected with a teaching error (the wrappers
+   are standard-only by design).
+2. **Cross-wrapper drive.** Python ⇄ Node.js live in both directions — RPC replies,
+   trace context, and reply annotations intact across both hops.
+3. **The flagship drive: an unchanged engine flow executed a Python function.** The
+   Java composable-example's shipped `event-over-http-declarative` Event Script flow —
+   the zero-code demo of this report's earlier rounds (this engine's parallel:
+   [hello-flow to hello-world](../guides/event-over-http.md#zero-code-demo-hello-flow-to-hello-world))
+   — ran against the Python demo host in the callee's slot (same port 8085, same public
+   `hello.declarative` route), with **zero engine change and zero engine configuration
+   change**. The reply carried `"language": "python"`; the flow's business correlation
+   id arrived injected as the read-only `my_correlation_id` header (the `my_cid` tag
+   contract); `x-flow-id` and the flow's `x-ttl` were delivered; and the Python host's
+   log line showed the **engine's trace id** in the engine-consistent log format —
+   presentation parity extending to the wrapper family (playbook items 3 and 5).
+4. **The one engine change shipped separately, in lock-step.** `graph.task`'s
+   route-existence guard now consults the `yaml.event.over.http` map on both engines
+   (Rust [PR #212](https://github.com/Accenture/mercury/pull/212), Java
+   [PR #292](https://github.com/Accenture/mercury-composable/pull/292)), released in
+   **v4.11.11** — deployed knowledge graphs can name polyglot routes directly.
+
+Per the initiative's conformance ruling, this report gains a round like this one with
+each wrapper release: the golden vectors are the per-release gate, and a live
+engine-flow-to-wrapper drive is the acceptance proof.
+
 ## Learnings for future language ports
 
-This validation arc is the playbook for bringing the next language (e.g. Python) into the
-family:
+This validation arc is the playbook that brought Python and Node.js into the family (the
+wrapper round above) and remains the checklist for the next language:
 
 1. **Golden conformance vectors first.** The wire format is proven byte-identically with
    vectors shared verbatim between repositories — no prose interpretation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
-site_name: mercury
+site_name: Composable for Rust
 site_description: >-
-  Rust port of mercury-composable — Accenture's event-driven, composable
-  application platform: platform-core, Event Script, and the active
-  knowledge graph, delivered bottom-up in Rust.
+  The official Rust implementation of Mercury Composable — Accenture's
+  event-driven, composable application platform: platform-core, Event Script,
+  and the active knowledge graph.
 site_url: https://accenture.github.io/mercury/
 site_author: Eric Law
 
@@ -112,6 +112,7 @@ nav:
       - Function Execution: guides/event-driven/function-execution.md
       - REST Automation: guides/rest-automation.md
       - Event over HTTP: guides/event-over-http.md
+      - Polyglot Functions (Python & Node.js): guides/polyglot-functions.md
       - Function AI Agent Guide: guides/event-driven/ai-agent-guide.md
   - "Layer 2 — Event Script":
       - Overview: guides/event-script/index.md

--- a/system/ai-contract-provider/resources/skill/files.list
+++ b/system/ai-contract-provider/resources/skill/files.list
@@ -30,6 +30,7 @@ references/guides/knowledge-graph/workflow-suspension.md
 references/guides/macros-reference.md
 references/guides/methodology.md
 references/guides/observability.md
+references/guides/polyglot-functions.md
 references/guides/registration-metadata-contract.md
 references/guides/reserved-names-and-headers.md
 references/guides/rest-automation.md


### PR DESCRIPTION
## What

The P4 documentation for the polyglot initiative on this engine, plus the home-page
unification (docs-only, 8 files):

- **New chapter `guides/polyglot-functions.md`** (Layer 1, after Event over HTTP): the
  twin of the Java engine's new chapter in this repo's voice — why Event-over-HTTP
  **peers, not ports** (this repository *is* a port and knows the cost profile); the
  wrapper family table ([Composable for Python](https://accenture.github.io/mercury-python/),
  [Composable for Node.js](https://accenture.github.io/mercury-nodejs/)); the zero-code
  demo extended — the wrapper demos register `hello.declarative` and default to port
  8085, hello-world's slot, so hello-flow swaps callees with the identical `curl`; the
  `graph.task` **v4.11.11 floor** with the Rust realization named
  (`event_api::get_event_http_target`); the end-to-end contract and polyglot operations.
- **ADR-0014 (Proposed)** — the peers-not-subprocesses design, with the Rust realization
  section (the guard change in `skills.rs`, shipped lock-step in v4.11.11) and the
  pointer to the initiative's design record in the Java repository's memory.
- **Interop report: "The polyglot wrapper round (2026-08-22)"** — the same
  honest-evidence section as the Java report copy, with this repo's links and anchors.
- **Home page unified on the Java reference presentation** (maintainer direction):
  `docs/index.md` now opens like the Java home — the narrative paragraph, the
  **"A layered ascent" table** (with "Rust functions, addressed by route name"), the
  Knowledge Graph section — while keeping the port-specific "Why a Rust port" section
  and the port-divergence note. The Project section links the whole family (Java engine
  + both wrappers). The site is renamed **"Composable for Rust"** so the family reads
  Composable for Java / Rust / Python / Node.js.
- Cross-links: Event-over-HTTP guide, `llms.txt` (Layer 1 gains the polyglot line), and
  CHANGELOG Unreleased entries (Added + Changed).

## Why

P4 of the polyglot initiative - documentation for AI and Human, in lock-step with the
Java engine per the presentation-parity convention. The home-page unification makes the
two engines' documentation read as one family for developers and DevSecOps teams who see
both, and gives every site the same layered-ascent orientation plus cross-links to the
wrapper docs.

Gate: `mkdocs build --strict` exit 0; the home page served locally and visually verified
against the Java reference (table, chapter links, wrapper links all render); new anchors
verified in the built HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>