### PR TITLE
navigation gains the Operate & integrate and Orientation tabs (Java-site parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ the design rationale in [`docs/design/`](docs/design/).
 1. Documentation home page unified on the Java reference presentation (the layered-ascent
    table) and the docs site renamed "Composable for Rust" for family consistency with
    Composable for Java / Python / Node.js; engine and wrapper documentation now
-   cross-link.
+   cross-link. The navigation gains the Java site's "Operate & integrate" tab
+   (Observability, Event over HTTP, Polyglot Functions) and an Orientation tab, so the
+   tab row reads identically across the two engines' documentation sites.
 
 ---
 ## Version 4.11.11, 8/23/2026

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,18 +101,16 @@ validation:
 
 nav:
   - Home: index.md
-  - Getting Started: guides/getting-started.md
+  - Orientation:
+      - Getting Started: guides/getting-started.md
   - Foundations:
       - Architecture: guides/architecture.md
       - Methodology: guides/methodology.md
-      - Observability: guides/observability.md
   - "Layer 1 — Event-Driven":
       - Overview: guides/event-driven/index.md
       - Write Your First Function: guides/event-driven/write-your-first-function.md
       - Function Execution: guides/event-driven/function-execution.md
       - REST Automation: guides/rest-automation.md
-      - Event over HTTP: guides/event-over-http.md
-      - Polyglot Functions (Python & Node.js): guides/polyglot-functions.md
       - Function AI Agent Guide: guides/event-driven/ai-agent-guide.md
   - "Layer 2 — Event Script":
       - Overview: guides/event-script/index.md
@@ -129,6 +127,10 @@ nav:
       - Graph AI Agent Guide: guides/knowledge-graph/ai-agent-guide.md
       - MiniGraph Command Grammar: guides/knowledge-graph/command-reference.md
       - Built-in Skills: guides/knowledge-graph/skills-reference.md
+  - "Operate & integrate":
+      - Observability: guides/observability.md
+      - Event over HTTP: guides/event-over-http.md
+      - Polyglot Functions (Python & Node.js): guides/polyglot-functions.md
   - Reference:
       - Configuration Keys: guides/configuration-reference.md
       - Macros: guides/macros-reference.md


### PR DESCRIPTION
## What

A navigation-only restructure of the documentation site (2 files - mkdocs.yml nav and a
CHANGELOG sentence; no page content or URL changes):

- **New "Operate & integrate" tab**, matching the Java site's grouping:
  - *Observability* (moved from Foundations)
  - *Event over HTTP* (moved from Layer 1)
  - *Polyglot Functions (Python & Node.js)* (moved from Layer 1 - PR #214 had placed
    it there; the Java site carries it under Operate & integrate)
- **New "Orientation" tab** wrapping Getting Started, completing the tab-row parity.

The tab row now reads identically on both engines' documentation sites:
Home / Orientation / Foundations / Layer 1 / Layer 2 / Layer 3 / Operate & integrate /
Reference.

The Java members of Operate & integrate with no Rust counterpart by design (Spring
Boot, the Kafka family, Sync-over-Async, Build/Test/Deploy) are simply absent - the tab
holds the three pages that exist here.

## Why

Maintainer direction: a reader who knows the Java documentation should navigate this
site the same way. With the family now spanning four sites (Composable for Java / Rust /
Python / Node.js), same-shaped navigation is part of the presentation-parity requirement
- operate-class concerns live in one predictable place instead of being split across
Foundations and Layer 1.

Gate: `mkdocs build --strict` exit 0; the rendered tab row and the new tab's sidebar
grouping verified in a local serve of the built site. Page URLs unchanged, so no
inbound links (including the ai-contract-provider snapshot references) are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>