### PR TITLE
HTTP response streaming - progressive rendering over the multi-shot reply route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,33 @@ the design rationale in [`docs/design/`](docs/design/).
 
 ### Added
 
-1. Polyglot Functions documentation chapter (`guides/polyglot-functions.md`) - writing
+1. **HTTP response streaming** - a function can stream an HTTP response progressively
+   (token segments, progress events) by sending a sequence of events to the caller's
+   reply route until an end-of-transmission signal, using the reserved envelope header
+   `x-event-stream: data | eof | exception` (internal protocol - the wire carries only
+   standard HTTP). Server-Sent Events framing for `text/event-stream` (typed events via
+   `x-event-name`, terminal `done` event with trailing metadata, in-band `error` events,
+   configurable keep-alive pings via `event.stream.keep.alive`); chunked transfer with
+   JSON Lines for other content types. Declare a streaming endpoint with `stream: true`
+   in rest.yaml - the request checks out a dedicated ordered reply lane
+   (`async.http.response.stream.{n}`) from a pool of 500 for its lifetime: per-request
+   strict FIFO with cross-request concurrency, and HTTP-503 back-pressure when the pool
+   is exhausted. New `EventStreamWriter` producer API; idle timeouts fail streams
+   in-band; client disconnects drop late segments as no-ops. A runnable demo ships in
+   examples/hello-world (`GET /api/hello/sse` plus the `scripts/sse-client.mjs`
+   progressive-rendering client). Engine-identical with the Java engine's feature
+   (Java PR #299). See the HTTP Response Streaming guide (ADR-0015).
+
+### Changed
+
+1. The `/info/routes` actuator endpoint renders pool-style route families compactly:
+   routes differing only by a trailing numeric suffix, with uniform instances and
+   contiguous numbering, collapse into one display entry (e.g. the 500 streaming reply
+   lanes appear as `"async.http.response.stream.0 - 499": 1`), and the rendered routing
+   view is cached for 10 minutes. Display-only - the routing table is unchanged.
+   (Java engine parity.)
+
+2. Polyglot Functions documentation chapter (`guides/polyglot-functions.md`) - writing
    composable functions in Python and Node.js with the official Event-over-HTTP wrappers
    (docs: accenture.github.io/mercury-python and accenture.github.io/mercury-nodejs),
    with the zero-code demo extended to the wrapper demo apps. ADR-0014 (Proposed) records

--- a/crates/platform-core/src/actuator.rs
+++ b/crates/platform-core/src/actuator.rs
@@ -201,21 +201,11 @@ impl ComposableFunction for ActuatorServices {
                 // is exactly {app, routing}. BTreeMap keeps the output
                 // deterministic (Java's HashMap ordering is arbitrary; JSON
                 // object order is not contractual, but stable beats random).
-                let mut public = std::collections::BTreeMap::new();
-                let mut private = std::collections::BTreeMap::new();
-                for route in context.platform.routes() {
-                    let instances = context.platform.instances(&route).unwrap_or(1);
-                    if context.platform.is_private(&route).unwrap_or(true) {
-                        private.insert(route, instances);
-                    } else {
-                        public.insert(route, instances);
-                    }
-                }
                 EventEnvelope::new()
                     .set_header("content-type", "application/json")
                     .set_body(serde_json::json!({
                         "app": context.app_block(),
-                        "routing": {"public": public, "private": private},
+                        "routing": local_routing(&context.platform),
                     }))
             }
             ActuatorKind::Info => {
@@ -389,4 +379,92 @@ async fn check_services(
 }
 
 // `elapsed_time` moved to `crate::util` (increment 71): it is now shared by
-// the `/info` uptime rendering here and the ManagedCache create log.
+// the `/info` uptime rendering here and the ManagedCache create log.\n\n/// The rendered local routing view, split by visibility with pool-style
+/// route families compressed. The routing table changes infrequently, so the
+/// rendered view is cached for 10 minutes to skip repeated computation under
+/// actuator polling — an ad-hoc runtime registration may take up to the
+/// window to appear, which is acceptable for the operator view (Java
+/// ActuatorServices parity).
+fn local_routing(platform: &crate::platform::Platform) -> serde_json::Value {
+    use std::sync::OnceLock;
+    static CACHE: OnceLock<std::sync::Arc<crate::util::managed_cache::ManagedCache>> =
+        OnceLock::new();
+    let cache = CACHE.get_or_init(|| {
+        crate::util::managed_cache::ManagedCache::create_cache("local.routing.info", 10 * 60 * 1000)
+    });
+    if let Some(cached) = cache.get("local.routing") {
+        if let Some(value) = cached.downcast_ref::<serde_json::Value>() {
+            return value.clone();
+        }
+    }
+    let mut public = std::collections::BTreeMap::new();
+    let mut private = std::collections::BTreeMap::new();
+    for route in platform.routes() {
+        let instances = platform.instances(&route).unwrap_or(1);
+        if platform.is_private(&route).unwrap_or(true) {
+            private.insert(route, instances);
+        } else {
+            public.insert(route, instances);
+        }
+    }
+    let value = serde_json::json!({
+        "public": compress_route_families(public),
+        "private": compress_route_families(private),
+    });
+    cache.put("local.routing", value.clone());
+    value
+}
+
+/// Render pool-style route families compactly (Java `ActuatorServices.
+/// compressRouteFamilies`): routes that differ only by a trailing numeric
+/// suffix, with uniform instances and contiguous canonical numbering (no
+/// leading zeros), collapse into one display entry — e.g. the 500 streaming
+/// reply lanes render as `"async.http.response.stream.0 - 499": 1`.
+/// Irregular families and singletons render individually with their names
+/// preserved exactly. Display-only — the routing table itself is unchanged.
+fn compress_route_families(
+    routes: std::collections::BTreeMap<String, usize>,
+) -> std::collections::BTreeMap<String, usize> {
+    let mut result = std::collections::BTreeMap::new();
+    let mut families: std::collections::BTreeMap<String, std::collections::BTreeMap<u64, usize>> =
+        std::collections::BTreeMap::new();
+    for (route, instances) in routes {
+        let family = route.rfind('.').and_then(|dot| {
+            let suffix = &route[dot + 1..];
+            if !suffix.is_empty() && suffix.len() < 10 && suffix.bytes().all(|b| b.is_ascii_digit())
+            {
+                let n: u64 = suffix.parse().ok()?;
+                // canonical digits only, so individual names are preserved exactly
+                (suffix == n.to_string()).then(|| (route[..dot + 1].to_string(), n))
+            } else {
+                None
+            }
+        });
+        match family {
+            Some((base, n)) => {
+                families.entry(base).or_default().insert(n, instances);
+            }
+            None => {
+                result.insert(route, instances);
+            }
+        }
+    }
+    for (base, members) in families {
+        let min = *members.keys().next().expect("non-empty family");
+        let max = *members.keys().last().expect("non-empty family");
+        let uniform = members
+            .values()
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+            == 1;
+        if members.len() > 1 && uniform && members.len() as u64 == max - min + 1 {
+            let instances = *members.values().next().expect("non-empty family");
+            result.insert(format!("{base}{min} - {max}"), instances);
+        } else {
+            for (n, instances) in members {
+                result.insert(format!("{base}{n}"), instances);
+            }
+        }
+    }
+    result
+}

--- a/crates/platform-core/src/automation/mod.rs
+++ b/crates/platform-core/src/automation/mod.rs
@@ -31,7 +31,8 @@ pub use event_api::{
 pub use http_client::{AsyncHttpRequest, ASYNC_HTTP_REQUEST};
 pub use routing::{AssignedRoute, CorsInfo, HeaderInfo, RouteInfo, RoutingTable};
 pub use server::{
-    server_address, start_http_server, AsyncHttpResponseService, ASYNC_HTTP_RESPONSE,
-    MY_CORRELATION_ID,
+    available_lanes, checkout_lane, release_lane, server_address, start_http_server,
+    AsyncHttpResponseService, StreamLaneService, ASYNC_HTTP_RESPONSE,
+    ASYNC_HTTP_RESPONSE_STREAM_PREFIX, MY_CORRELATION_ID,
 };
 pub use ws_server::register_ws_service;

--- a/crates/platform-core/src/automation/routing.rs
+++ b/crates/platform-core/src/automation/routing.rs
@@ -58,6 +58,10 @@ pub struct RouteInfo {
     /// Event-script flow binding (grammar `flow:`): the flow id injected as
     /// the `x-flow-id` request header for `http.flow.adapter` (increment E-3).
     pub flow: Option<String>,
+    /// `stream: true` — the response is a multi-shot event stream: the request
+    /// checks out a dedicated ordered reply lane for its lifetime and the edge
+    /// renders segments progressively (Java `RouteInfo.streamResponse`).
+    pub stream_response: bool,
     segments: Vec<Segment>,
 }
 
@@ -445,6 +449,7 @@ fn parse_route(
         None => None,
     };
     let tracing = matches!(entry.get("tracing"), Some(ConfigValue::Bool(true)));
+    let stream_response = matches!(entry.get("stream"), Some(ConfigValue::Bool(true)));
     Ok(RouteInfo {
         service,
         methods,
@@ -458,13 +463,14 @@ fn parse_route(
         correlation_id_header: text("correlation.id.header"),
         traceparent_header: text("traceparent.header"),
         flow: text("flow"),
+        stream_response,
         segments,
     })
 }
 
 /// Parse a duration like `30s`, `500ms`, `2m` (default 30 s; clamped 1 s–5 m,
-/// Java parity).
-fn parse_timeout(value: Option<&str>) -> Duration {
+/// Java parity). Shared with the HTTP boundary for `event.stream.keep.alive`.
+pub(crate) fn parse_timeout(value: Option<&str>) -> Duration {
     let parsed = value.and_then(|text| {
         let text = text.trim().to_lowercase();
         if let Some(ms) = text.strip_suffix("ms") {

--- a/crates/platform-core/src/automation/server.rs
+++ b/crates/platform-core/src/automation/server.rs
@@ -38,17 +38,22 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex, OnceLock};
+use std::task::{Context, Poll};
+use std::time::Duration;
 
 use async_trait::async_trait;
+use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
-use hyper::body::Bytes;
+use hyper::body::{Bytes, Frame};
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::envelope::EventEnvelope;
+use crate::event_stream;
 use crate::function::{AppError, ComposableFunction};
 use crate::platform::Platform;
 use crate::post_office::PostOffice;
@@ -57,7 +62,7 @@ use crate::util::app_config_reader::AppConfigReader;
 use crate::util::config_reader::ConfigReader;
 use crate::util::w3c_trace;
 
-use super::routing::{AssignedRoute, RoutingTable};
+use super::routing::{AssignedRoute, RouteInfo, RoutingTable};
 
 /// Reserved read-only request header exposing the business correlation-id to
 /// the target function (Java `HttpRouter.MY_CORRELATION_ID`).
@@ -66,6 +71,142 @@ pub const MY_CORRELATION_ID: &str = "my_correlation_id";
 /// Route of the HTTP response-correlation service (Java
 /// `AsyncHttpClient.ASYNC_HTTP_RESPONSE`).
 pub const ASYNC_HTTP_RESPONSE: &str = "async.http.response";
+
+/// Route-name prefix of the streaming reply-lane pool (Java
+/// `AsyncHttpClient.ASYNC_HTTP_RESPONSE_STREAM_PREFIX`). A streaming request
+/// checks out one dedicated single-instance lane for its lifetime, so its
+/// segments render in strict FIFO order while different requests stream
+/// concurrently through their own lanes.
+pub const ASYNC_HTTP_RESPONSE_STREAM_PREFIX: &str = "async.http.response.stream.";
+
+/// Shared by `async.http.response` and the streaming reply-lane pool
+/// (one lane per instance — Java `AppStarter.RESPONSE_HANDLER_INSTANCES`).
+const RESPONSE_HANDLER_INSTANCES: usize = 500;
+
+/// Buffered segment events per in-flight stream (producer → renderer).
+const STREAM_EVENT_BUFFER: usize = 64;
+/// Buffered wire frames per in-flight stream (renderer → socket).
+const STREAM_FRAME_BUFFER: usize = 64;
+
+/// The response body type: complete payloads and progressive streams share
+/// one boxed body so every handler path composes (Java: vert.x chunked writes).
+type HttpBody = BoxBody<Bytes, std::convert::Infallible>;
+
+/// A complete in-memory response body.
+fn full(bytes: Bytes) -> HttpBody {
+    BoxBody::new(Full::new(bytes))
+}
+
+/// Available streaming reply lanes — a LIFO stack (the "ready" signal pattern
+/// of the reactive manager/worker design): checkout takes the most recently
+/// released lane; release returns it. Filled once at server start.
+fn lane_pool() -> &'static Mutex<Vec<String>> {
+    static POOL: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+    POOL.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Check out a dedicated ordered reply lane for one streaming request.
+/// Returns None when the pool is exhausted.
+pub fn checkout_lane() -> Option<String> {
+    lane_pool().lock().expect("lane pool poisoned").pop()
+}
+
+/// Return a reply lane to the pool — called when the owning request ends,
+/// and at startup to fill the pool.
+pub fn release_lane(route: String) {
+    lane_pool().lock().expect("lane pool poisoned").push(route);
+}
+
+/// The number of reply lanes currently available for checkout.
+pub fn available_lanes() -> usize {
+    lane_pool().lock().expect("lane pool poisoned").len()
+}
+
+/// In-flight streaming HTTP contexts — each entry forwards segment events
+/// from the request's reply lane to its renderer task (Java: the
+/// AsyncContextHolder + EventStreamState pair).
+fn pending_streams() -> &'static Mutex<HashMap<String, mpsc::Sender<EventEnvelope>>> {
+    static PENDING: OnceLock<Mutex<HashMap<String, mpsc::Sender<EventEnvelope>>>> = OnceLock::new();
+    PENDING.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Remove a streaming context and return its lane to the pool. The map
+/// removal is the exactly-once gate (Java `HttpRouter.closeContext`).
+fn cleanup_stream(context_id: &str, lane: &str) {
+    let removed = pending_streams()
+        .lock()
+        .expect("pending streams poisoned")
+        .remove(context_id);
+    if removed.is_some() {
+        release_lane(lane.to_string());
+    }
+}
+
+/// The streaming reply-lane service — one shared handler behind every
+/// `async.http.response.stream.{n}` route (each registered with a single
+/// instance, so per-request segment order is preserved end-to-end). It
+/// forwards each event into the owning request's renderer; a missing context
+/// (completed, timed out or disconnected) makes late segments no-op drops.
+pub struct StreamLaneService;
+
+#[async_trait]
+impl ComposableFunction for StreamLaneService {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        if let Some(context_id) = input.correlation_id().map(str::to_string) {
+            let sender = pending_streams()
+                .lock()
+                .expect("pending streams poisoned")
+                .get(&context_id)
+                .cloned();
+            if let Some(sender) = sender {
+                // bounded back-pressure toward the renderer; a dropped
+                // receiver (client gone) turns this into a no-op drop
+                let _ = sender.send(input).await;
+            }
+        }
+        Ok(EventEnvelope::new())
+    }
+}
+
+/// A channel-backed streaming response body: the renderer task pushes wire
+/// frames; hyper pulls them as the socket drains. Dropping the sender ends
+/// the response body.
+struct ChannelBody {
+    rx: mpsc::Receiver<Frame<Bytes>>,
+}
+
+impl hyper::body::Body for ChannelBody {
+    type Data = Bytes;
+    type Error = std::convert::Infallible;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Bytes>, Self::Error>>> {
+        self.rx.poll_recv(cx).map(|frame| frame.map(Ok))
+    }
+}
+
+/// SSE keep-alive comment interval in ms (`event.stream.keep.alive`,
+/// default 30s; 0 disables — Java parity).
+fn keep_alive_ms() -> u64 {
+    static KEEP_ALIVE: OnceLock<u64> = OnceLock::new();
+    *KEEP_ALIVE.get_or_init(|| {
+        let config = AppConfigReader::get_instance();
+        let text = config.get_property_or("event.stream.keep.alive", "30s");
+        let trimmed = text.trim().to_lowercase();
+        if trimmed == "0" || trimmed == "0s" || trimmed == "0ms" || trimmed == "0m" {
+            0
+        } else {
+            super::routing::parse_timeout(Some(&trimmed)).as_millis() as u64
+        }
+    })
+}
 
 /// Reserved `my_*` metadata headers that must never reach the HTTP wire
 /// (Java `WorkerHandler.copyResponseHeaders` protected-metadata handling).
@@ -157,14 +298,37 @@ pub async fn start_http_server(platform: &Platform) -> Result<SocketAddr, AppErr
     // (Java AppStarter registers AsyncHttpResponse with the server, private,
     // 500 instances); idempotent — tolerate a concurrent registration
     if !platform.has_route(ASYNC_HTTP_RESPONSE) {
-        if let Err(e) =
-            platform.register_private(ASYNC_HTTP_RESPONSE, Arc::new(AsyncHttpResponseService), 500)
-        {
+        if let Err(e) = platform.register_private(
+            ASYNC_HTTP_RESPONSE,
+            Arc::new(AsyncHttpResponseService),
+            RESPONSE_HANDLER_INSTANCES,
+        ) {
             if !platform.has_route(ASYNC_HTTP_RESPONSE) {
                 return Err(e);
             }
         }
     }
+    // streaming responses use a pool of dedicated single-instance reply lanes:
+    // a streaming request checks out one lane for its lifetime (strict FIFO for
+    // its segments) and returns it when its context closes; the pool size
+    // matches the async.http.response instances, and an idle lane costs only a
+    // little memory (Java AppStarter parity). Registration runs on EVERY server
+    // start — a re-registration rebinds the route workers to the current
+    // runtime (the per-test-runtime idiom of this port) — but the POOL is
+    // filled exactly once per process: get_or_init blocks a concurrent second
+    // server start until the fill completes, so the pool can never be refilled
+    // or double-filled while requests are in flight
+    let stream_responder = Arc::new(StreamLaneService);
+    for lane in 0..RESPONSE_HANDLER_INSTANCES {
+        let lane_route = format!("{ASYNC_HTTP_RESPONSE_STREAM_PREFIX}{lane}");
+        platform.register_private(&lane_route, stream_responder.clone(), 1)?;
+    }
+    static POOL_FILLED: OnceLock<()> = OnceLock::new();
+    POOL_FILLED.get_or_init(|| {
+        for lane in 0..RESPONSE_HANDLER_INSTANCES {
+            release_lane(format!("{ASYNC_HTTP_RESPONSE_STREAM_PREFIX}{lane}"));
+        }
+    });
     let rest_yaml = config.get_property_or("yaml.rest.automation", "classpath:/rest.yaml");
     let reader = ConfigReader::load(&rest_yaml)
         .map_err(|e| AppError::new(500, format!("Unable to load {rest_yaml} - {e}")))?;
@@ -233,7 +397,7 @@ async fn handle(
     state: Arc<RouterState>,
     request: Request<hyper::body::Incoming>,
     peer: SocketAddr,
-) -> Result<Response<Full<Bytes>>, hyper::Error> {
+) -> Result<Response<HttpBody>, hyper::Error> {
     // websocket upgrade on a registered `/ws/{name}/{token}` path takes the
     // connection out of the HTTP request/response cycle (Java parity)
     if super::ws_server::is_ws_upgrade(&request) {
@@ -241,7 +405,8 @@ async fn handle(
             &state.platform,
             request,
             peer.ip().to_string(),
-        ));
+        )
+        .map(BoxBody::new));
     }
     let method = request.method().as_str().to_uppercase();
     let path = request.uri().path().to_string();
@@ -292,9 +457,7 @@ async fn handle(
         for (name, value) in &cors.options {
             response = response.header(name, value);
         }
-        return Ok(response
-            .body(Full::new(Bytes::new()))
-            .expect("static response"));
+        return Ok(response.body(full(Bytes::new())).expect("static response"));
     }
     match process(
         &state, assigned, method, path, query_text, headers, body_bytes, peer,
@@ -316,7 +479,7 @@ async fn process(
     mut headers: HashMap<String, String>,
     body_bytes: Bytes,
     peer: SocketAddr,
-) -> Result<Response<Full<Bytes>>, AppError> {
+) -> Result<Response<HttpBody>, AppError> {
     let info = assigned.info;
     // request-header transforms
     if let Some(header_info) = &info.headers {
@@ -540,54 +703,75 @@ async fn process(
             http_request = http_request.set_session_info(key, value);
         }
     }
-    // CALLBACK dispatch (Java HttpRouter parity): the endpoint service is
-    // invoked with reply_to = async.http.response and cid = the HTTP context
-    // id — its worker self-records its span (no RPC suppression), and the
-    // response leg is a visible function span. The business correlation-id
-    // rides the my_correlation_id envelope header instead of the cid slot.
-    let context_id = uuid::Uuid::new_v4().simple().to_string();
-    let (tx, rx) = oneshot::channel();
-    pending_responses()
-        .lock()
-        .expect("pending http contexts poisoned")
-        .insert(context_id.clone(), tx);
-    let event = build_event(
-        &info.service,
-        &http_request,
-        &cid,
-        &trace_id,
-        &trace_path,
-        &parent_span,
-    )?
-    .set_correlation_id(&context_id)
-    .set_reply_to(ASYNC_HTTP_RESPONSE);
-    if let Err(e) = po.send(event).await {
+    let is_head = method == "HEAD";
+    // a streaming endpoint (rest.yaml `stream: true`) uses the multi-shot
+    // reply route; HEAD requests never stream (Java parity)
+    let result = if info.stream_response && !is_head {
+        match stream_dispatch(
+            state,
+            info,
+            &http_request,
+            &cid,
+            &cid_header,
+            &trace_id,
+            &trace_path,
+            &parent_span,
+            accept.clone(),
+        )
+        .await?
+        {
+            StreamOutcome::Streaming(response) => return Ok(response),
+            StreamOutcome::SingleShot(envelope) => envelope,
+        }
+    } else {
+        // CALLBACK dispatch (Java HttpRouter parity): the endpoint service is
+        // invoked with reply_to = async.http.response and cid = the HTTP context
+        // id — its worker self-records its span (no RPC suppression), and the
+        // response leg is a visible function span. The business correlation-id
+        // rides the my_correlation_id envelope header instead of the cid slot.
+        let context_id = uuid::Uuid::new_v4().simple().to_string();
+        let (tx, rx) = oneshot::channel();
         pending_responses()
             .lock()
             .expect("pending http contexts poisoned")
-            .remove(&context_id);
-        return Err(e);
-    }
-    let result = match tokio::time::timeout(info.timeout, rx).await {
-        Ok(Ok(envelope)) => envelope,
-        Ok(Err(_)) => {
-            return Err(AppError::new(500, "Response channel closed unexpectedly"));
-        }
-        Err(_) => {
+            .insert(context_id.clone(), tx);
+        let event = build_event(
+            &info.service,
+            &http_request,
+            &cid,
+            &trace_id,
+            &trace_path,
+            &parent_span,
+        )?
+        .set_correlation_id(&context_id)
+        .set_reply_to(ASYNC_HTTP_RESPONSE);
+        if let Err(e) = po.send(event).await {
             pending_responses()
                 .lock()
                 .expect("pending http contexts poisoned")
                 .remove(&context_id);
-            return Err(AppError::new(
-                408,
-                format!("Timeout for {} ms", info.timeout.as_millis()),
-            ));
+            return Err(e);
+        }
+        match tokio::time::timeout(info.timeout, rx).await {
+            Ok(Ok(envelope)) => envelope,
+            Ok(Err(_)) => {
+                return Err(AppError::new(500, "Response channel closed unexpectedly"));
+            }
+            Err(_) => {
+                pending_responses()
+                    .lock()
+                    .expect("pending http contexts poisoned")
+                    .remove(&context_id);
+                return Err(AppError::new(
+                    408,
+                    format!("Timeout for {} ms", info.timeout.as_millis()),
+                ));
+            }
         }
     };
     // map the response envelope back to HTTP (Java AsyncHttpResponse:
     // updateHeadersAndContentType + updateHeaders)
     let status = status_of(result.status());
-    let is_head = method == "HEAD";
     let mut content_type: Option<String> = None;
     let mut set_cookies: Vec<String> = Vec::new();
     let mut response_headers: HashMap<String, String> = HashMap::new();
@@ -659,8 +843,463 @@ async fn process(
     // a HEAD response never carries a body (Java: isHeadMethod skips content)
     let payload = if is_head { Bytes::new() } else { payload };
     response
-        .body(Full::new(payload))
+        .body(full(payload))
         .map_err(|e| AppError::new(500, e.to_string()))
+}
+
+/// Outcome of a streaming dispatch: a committed progressive response, or the
+/// first event turned out to be an ordinary single-shot reply.
+/// (A short-lived by-value carrier - the size difference between variants is
+/// one stack move per request, not worth a heap allocation.)
+#[allow(clippy::large_enum_variant)]
+enum StreamOutcome {
+    Streaming(Response<HttpBody>),
+    SingleShot(EventEnvelope),
+}
+
+/// The first event's stream marker: `Ok(Some(marker))` for a valid
+/// `x-event-stream` value, `Ok(None)` when the header is absent (single-shot),
+/// `Err(())` for a present-but-invalid value (drop the event, Java parity).
+fn stream_marker(event: &EventEnvelope) -> Result<Option<&'static str>, ()> {
+    for (name, value) in event.headers() {
+        if name.eq_ignore_ascii_case(event_stream::X_EVENT_STREAM) {
+            return match value.to_lowercase().as_str() {
+                event_stream::DATA => Ok(Some(event_stream::DATA)),
+                event_stream::EOF => Ok(Some(event_stream::EOF)),
+                event_stream::EXCEPTION => Ok(Some(event_stream::EXCEPTION)),
+                _ => Err(()),
+            };
+        }
+    }
+    Ok(None)
+}
+
+/// Error text from an exception event body (Java `EventStreamRenderer.errorMessage`).
+fn stream_error_message(event: &EventEnvelope) -> String {
+    match event.body() {
+        rmpv::Value::Map(entries) => entries
+            .iter()
+            .find(|(key, _)| key.as_str() == Some("message"))
+            .map(|(_, value)| stream_text(value))
+            .unwrap_or_else(|| "Stream failed".to_string()),
+        rmpv::Value::Nil => "Stream failed".to_string(),
+        other => stream_text(other),
+    }
+}
+
+/// The fallback content type for a streaming response from the request's
+/// Accept header (Java `EventStreamRenderer.negotiateContentType`).
+fn negotiate_stream_type(accept: Option<&str>) -> String {
+    let Some(accept) = accept else {
+        return "application/json".to_string();
+    };
+    if accept.contains("*/*") || accept.contains("application/json") {
+        "application/json".to_string()
+    } else if accept.contains("text/event-stream") {
+        "text/event-stream".to_string()
+    } else if accept.contains("text/html") {
+        "text/html".to_string()
+    } else if accept.contains("application/xml") {
+        "application/xml".to_string()
+    } else {
+        "text/plain".to_string()
+    }
+}
+
+/// A segment body as line-oriented text: strings ride as-is; binary as UTF-8;
+/// structured bodies render as COMPACT one-line JSON — stream framing is
+/// line-oriented on both engines (Java uses the compact Gson for frames).
+fn stream_text(body: &rmpv::Value) -> String {
+    match body {
+        rmpv::Value::Nil => String::new(),
+        rmpv::Value::String(text) => text.as_str().unwrap_or_default().to_string(),
+        rmpv::Value::Binary(bytes) => String::from_utf8_lossy(bytes).to_string(),
+        other => {
+            let stripped = crate::serializer::strip_nulls(other);
+            let json = serde_json::to_value(&stripped).unwrap_or_default();
+            serde_json::to_string(&json).unwrap_or_default()
+        }
+    }
+}
+
+/// One SSE frame: optional `event:` line, one `data:` line per text line
+/// (multi-line data splits per the SSE specification), then a blank line.
+fn sse_frame(event_name: Option<&str>, text: &str) -> Bytes {
+    let mut frame = String::new();
+    if let Some(name) = event_name.filter(|n| !n.is_empty()) {
+        frame.push_str("event: ");
+        frame.push_str(name);
+        frame.push('\n');
+    }
+    for line in text.split('\n') {
+        frame.push_str("data: ");
+        frame.push_str(line);
+        frame.push('\n');
+    }
+    frame.push('\n');
+    Bytes::from(frame)
+}
+
+/// One chunked-mode segment: strings and bytes append verbatim; structured
+/// bodies stream as JSON Lines (one compact JSON object per line).
+fn chunk_bytes(body: &rmpv::Value) -> Bytes {
+    match body {
+        rmpv::Value::Nil => Bytes::new(),
+        rmpv::Value::String(text) => Bytes::from(text.as_str().unwrap_or_default().to_string()),
+        rmpv::Value::Binary(bytes) => Bytes::from(bytes.clone()),
+        other => {
+            let mut line = stream_text(other);
+            line.push('\n');
+            Bytes::from(line)
+        }
+    }
+}
+
+/// The `x-event-name` companion header (SSE `event:` field), if any.
+fn stream_event_name(event: &EventEnvelope) -> Option<&str> {
+    event
+        .headers()
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(event_stream::X_EVENT_NAME))
+        .map(|(_, value)| value.as_str())
+}
+
+/// Dispatch to a streaming endpoint: check out a dedicated ordered reply
+/// lane, send the request with `reply_to` = that lane, and turn the event
+/// sequence into a progressive HTTP response. The first event decides the
+/// shape: unmarked = ordinary single-shot; `exception` before the head = a
+/// normal HTTP error; `data`/`eof` commit the head and start the renderer.
+#[allow(clippy::too_many_arguments)]
+async fn stream_dispatch(
+    state: &RouterState,
+    info: &RouteInfo,
+    http_request: &crate::automation::AsyncHttpRequest,
+    cid: &str,
+    cid_header: &str,
+    trace_id: &Option<String>,
+    trace_path: &str,
+    parent_span: &Option<String>,
+    accept: Option<String>,
+) -> Result<StreamOutcome, AppError> {
+    // a streaming endpoint borrows a dedicated ordered reply lane for the
+    // lifetime of the request - an empty pool means full streaming capacity
+    let Some(lane) = checkout_lane() else {
+        return Err(AppError::new(503, "Streaming response pool exhausted"));
+    };
+    let po = PostOffice::new(&state.platform);
+    let context_id = uuid::Uuid::new_v4().simple().to_string();
+    let (tx, mut rx) = mpsc::channel::<EventEnvelope>(STREAM_EVENT_BUFFER);
+    pending_streams()
+        .lock()
+        .expect("pending streams poisoned")
+        .insert(context_id.clone(), tx);
+    let event = build_event(
+        &info.service,
+        http_request,
+        cid,
+        trace_id,
+        trace_path,
+        parent_span,
+    )?
+    .set_correlation_id(&context_id)
+    .set_reply_to(&lane);
+    if let Err(e) = po.send(event).await {
+        cleanup_stream(&context_id, &lane);
+        return Err(e);
+    }
+    // await the first event; the endpoint timeout is the idle allowance
+    let (first, marker) = loop {
+        match tokio::time::timeout(info.timeout, rx.recv()).await {
+            Ok(Some(envelope)) => match stream_marker(&envelope) {
+                Ok(Some(marker)) => break (envelope, Some(marker)),
+                Ok(None) => break (envelope, None),
+                Err(()) => {
+                    // present-but-invalid marker: drop the event (Java parity)
+                    log::warn!(
+                        "Dropping event for {context_id} - invalid {} signal",
+                        event_stream::X_EVENT_STREAM
+                    );
+                }
+            },
+            Ok(None) => {
+                cleanup_stream(&context_id, &lane);
+                return Err(AppError::new(500, "Response channel closed unexpectedly"));
+            }
+            Err(_) => {
+                cleanup_stream(&context_id, &lane);
+                return Err(AppError::new(
+                    408,
+                    format!("Timeout for {} ms", info.timeout.as_millis()),
+                ));
+            }
+        }
+    };
+    let Some(marker) = marker else {
+        // the endpoint answered single-shot - render exactly as before
+        cleanup_stream(&context_id, &lane);
+        return Ok(StreamOutcome::SingleShot(first));
+    };
+    if marker == event_stream::EXCEPTION {
+        // failure before the head is committed - render a normal HTTP error
+        cleanup_stream(&context_id, &lane);
+        let status = if first.status() >= 400 {
+            first.status()
+        } else {
+            500
+        };
+        return Err(AppError::new(status, stream_error_message(&first)));
+    }
+    // ---- the first data/eof event commits the HTTP head ----
+    if first
+        .headers()
+        .keys()
+        .any(|k| k.eq_ignore_ascii_case("x-stream-id"))
+    {
+        // mutual exclusivity rule: x-event-stream wins over a stray x-stream-id
+        log::warn!("Ignoring x-stream-id on a streaming response for {context_id}");
+    }
+    let mut response_headers: HashMap<String, String> = HashMap::new();
+    let mut set_cookies: Vec<String> = Vec::new();
+    let mut content_type: Option<String> = None;
+    let mut idle_override: Option<Duration> = None;
+    for (name, value) in first.headers() {
+        let key = name.to_lowercase();
+        match key.as_str() {
+            // reserved envelope headers - never on the wire
+            event_stream::X_EVENT_STREAM | event_stream::X_EVENT_NAME | "x-stream-id" => {}
+            // idle-allowance override in seconds (producer head control)
+            "x-ttl" => {
+                if let Ok(seconds) = value.trim().parse::<u64>() {
+                    if seconds > 0 {
+                        idle_override = Some(Duration::from_secs(seconds));
+                    }
+                }
+            }
+            "content-type" => content_type = Some(value.to_lowercase()),
+            "set-cookie" => {
+                set_cookies.extend(value.split('|').map(|c| c.trim().to_string()));
+            }
+            _ => {
+                response_headers.insert(key, value.clone());
+            }
+        }
+    }
+    // the rest.yaml response transform applies to the streamed head exactly
+    // as it does to a single-shot response (single-shot parity)
+    if let Some(header_info) = &info.headers {
+        header_info.response.apply(&mut response_headers);
+    }
+    // echo the business correlation-id; a function-set header of the same name wins
+    response_headers
+        .entry(cid_header.to_string())
+        .or_insert_with(|| cid.to_string());
+    if let Some(cors) = &info.cors {
+        for (name, value) in &cors.headers {
+            response_headers.insert(name.to_lowercase(), value.clone());
+        }
+    }
+    let content_type = content_type.unwrap_or_else(|| negotiate_stream_type(accept.as_deref()));
+    let sse = content_type.starts_with("text/event-stream");
+    if sse {
+        // default for SSE - an explicit event header or transform add wins
+        response_headers
+            .entry("cache-control".to_string())
+            .or_insert_with(|| "no-cache".to_string());
+    }
+    let idle = idle_override.unwrap_or(info.timeout);
+    let mut builder = Response::builder().status(status_of(first.status()));
+    for (name, value) in &response_headers {
+        builder = builder.header(name, value);
+    }
+    for cookie in set_cookies {
+        if !cookie.is_empty() {
+            builder = builder.header("set-cookie", cookie);
+        }
+    }
+    builder = builder.header("content-type", &content_type);
+    let (body_tx, body_rx) = mpsc::channel::<Frame<Bytes>>(STREAM_FRAME_BUFFER);
+    let response = builder
+        .body(BoxBody::new(ChannelBody { rx: body_rx }))
+        .map_err(|e| AppError::new(500, e.to_string()))?;
+    tokio::spawn(render_stream(
+        rx, body_tx, sse, idle, context_id, lane, first, marker,
+    ));
+    Ok(StreamOutcome::Streaming(response))
+}
+
+/// What the renderer observed while waiting for the next segment event.
+/// (A short-lived by-value carrier on the per-segment path - boxing the
+/// envelope would trade one stack move for a heap allocation per segment.)
+#[allow(clippy::large_enum_variant)]
+enum Waited {
+    Event(EventEnvelope),
+    Idle,
+    Closed,
+}
+
+/// Wait for the next event within the idle allowance, emitting SSE keep-alive
+/// comments while the producer is quiet (best-effort; pings never extend the
+/// idle allowance).
+async fn next_stream_event(
+    rx: &mut mpsc::Receiver<EventEnvelope>,
+    body_tx: &mpsc::Sender<Frame<Bytes>>,
+    sse: bool,
+    idle: Duration,
+) -> Waited {
+    let ping_every = keep_alive_ms();
+    let idle_deadline = tokio::time::sleep(idle);
+    tokio::pin!(idle_deadline);
+    loop {
+        if sse && ping_every > 0 {
+            let ping = tokio::time::sleep(Duration::from_millis(ping_every));
+            tokio::pin!(ping);
+            tokio::select! {
+                received = rx.recv() => {
+                    return match received {
+                        Some(event) => Waited::Event(event),
+                        None => Waited::Closed,
+                    };
+                }
+                _ = &mut idle_deadline => return Waited::Idle,
+                _ = &mut ping => {
+                    let _ = body_tx.try_send(Frame::data(Bytes::from_static(b": ping\n\n")));
+                }
+            }
+        } else {
+            tokio::select! {
+                received = rx.recv() => {
+                    return match received {
+                        Some(event) => Waited::Event(event),
+                        None => Waited::Closed,
+                    };
+                }
+                _ = &mut idle_deadline => return Waited::Idle,
+            }
+        }
+    }
+}
+
+/// Push one wire frame with back-pressure, bounded by the idle allowance —
+/// a client that stops reading beyond it gets truncated (the missing
+/// terminal event is the in-band truncation signal). Returns false when the
+/// stream can no longer be written (client gone or too slow).
+async fn push_frame(
+    body_tx: &mpsc::Sender<Frame<Bytes>>,
+    idle: Duration,
+    context_id: &str,
+    bytes: Bytes,
+) -> bool {
+    if bytes.is_empty() {
+        return true;
+    }
+    match tokio::time::timeout(idle, body_tx.send(Frame::data(bytes))).await {
+        Ok(Ok(())) => true,
+        Ok(Err(_)) => {
+            log::debug!("Client disconnected from event stream {context_id}");
+            false
+        }
+        Err(_) => {
+            log::error!("Closing event stream for {context_id} - client too slow");
+            false
+        }
+    }
+}
+
+/// The per-request renderer: consumes segment events from the reply lane and
+/// writes SSE or chunked frames until end of transmission, an in-band error,
+/// an idle timeout, or a gone/too-slow client. Always returns the lane to
+/// the pool at the end (Java: closeContext, the termination funnel).
+#[allow(clippy::too_many_arguments)]
+async fn render_stream(
+    mut rx: mpsc::Receiver<EventEnvelope>,
+    body_tx: mpsc::Sender<Frame<Bytes>>,
+    sse: bool,
+    idle: Duration,
+    context_id: String,
+    lane: String,
+    first: EventEnvelope,
+    first_marker: &'static str,
+) {
+    let mut pending = Some((first, first_marker));
+    loop {
+        let (event, marker) = match pending.take() {
+            Some(next) => next,
+            None => match next_stream_event(&mut rx, &body_tx, sse, idle).await {
+                Waited::Event(event) => match stream_marker(&event) {
+                    Ok(Some(marker)) => (event, marker),
+                    Ok(None) | Err(()) => {
+                        log::warn!(
+                            "Dropping event for {context_id} - invalid {} signal",
+                            event_stream::X_EVENT_STREAM
+                        );
+                        continue;
+                    }
+                },
+                Waited::Idle => {
+                    // fail the stream in-band (Java housekeeper parity)
+                    if sse {
+                        let error = serde_json::json!({
+                            "status": 408,
+                            "message": format!("Timeout for {} seconds", idle.as_secs()),
+                            "type": "error",
+                        });
+                        let frame = sse_frame(Some("error"), &error.to_string());
+                        let _ = push_frame(&body_tx, idle, &context_id, frame).await;
+                    }
+                    break;
+                }
+                Waited::Closed => break,
+            },
+        };
+        match marker {
+            event_stream::DATA => {
+                let bytes = if sse {
+                    if matches!(event.body(), rmpv::Value::Nil) {
+                        Bytes::new()
+                    } else {
+                        sse_frame(stream_event_name(&event), &stream_text(event.body()))
+                    }
+                } else {
+                    chunk_bytes(event.body())
+                };
+                if !push_frame(&body_tx, idle, &context_id, bytes).await {
+                    break;
+                }
+            }
+            event_stream::EOF => {
+                if sse {
+                    let text = if matches!(event.body(), rmpv::Value::Nil) {
+                        "{}".to_string()
+                    } else {
+                        stream_text(event.body())
+                    };
+                    let frame = sse_frame(Some("done"), &text);
+                    let _ = push_frame(&body_tx, idle, &context_id, frame).await;
+                }
+                break;
+            }
+            _ => {
+                // in-band failure after the head is committed: SSE renders an
+                // error event; chunked mode truncates (Java parity)
+                if sse {
+                    let status = if event.status() >= 400 {
+                        event.status()
+                    } else {
+                        500
+                    };
+                    let error = serde_json::json!({
+                        "status": status,
+                        "message": stream_error_message(&event),
+                        "type": "error",
+                    });
+                    let frame = sse_frame(Some("error"), &error.to_string());
+                    let _ = push_frame(&body_tx, idle, &context_id, frame).await;
+                }
+                break;
+            }
+        }
+    }
+    cleanup_stream(&context_id, &lane);
 }
 
 fn build_event(
@@ -843,7 +1482,7 @@ async fn serve_static(
     headers: &HashMap<String, String>,
     peer: SocketAddr,
     head_only: bool,
-) -> Option<Response<Full<Bytes>>> {
+) -> Option<Response<HttpBody>> {
     let (bytes, filename) = resolve_static_file(path)?;
     let static_content = state.table.static_content();
     let no_cache = super::routing::matched_element(&static_content.no_cache_pages, path);
@@ -873,7 +1512,7 @@ async fn serve_static(
                             if let (Some(content_type), false) = (content_type, has_content_type) {
                                 response = response.header("content-type", content_type);
                             }
-                            return response.body(Full::new(payload)).ok();
+                            return response.body(full(payload)).ok();
                         }
                     }
                     Err(e) => {
@@ -922,7 +1561,7 @@ async fn serve_static(
             return Response::builder()
                 .status(StatusCode::NOT_MODIFIED)
                 .header("content-length", "0")
-                .body(Full::new(Bytes::new()))
+                .body(full(Bytes::new()))
                 .ok();
         }
         response = response.header("ETag", etag);
@@ -932,7 +1571,7 @@ async fn serve_static(
     } else {
         Bytes::from(bytes)
     };
-    response.body(Full::new(payload)).ok()
+    response.body(full(payload)).ok()
 }
 
 /// Resolve a request path to a file under `resources/public`
@@ -1098,12 +1737,12 @@ fn mime_for(extension: &str) -> &'static str {
 }
 
 /// The Java error shape: `{"status": n, "message": "...", "type": "error"}`.
-fn error_response(status: i32, message: &str) -> Response<Full<Bytes>> {
+fn error_response(status: i32, message: &str) -> Response<HttpBody> {
     let body = serde_json::json!({"status": status, "message": message, "type": "error"});
     Response::builder()
         .status(StatusCode::from_u16(status as u16).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR))
         .header("content-type", "application/json")
-        .body(Full::new(Bytes::from(body.to_string())))
+        .body(full(Bytes::from(body.to_string())))
         .expect("static response")
 }
 

--- a/crates/platform-core/src/event_stream.rs
+++ b/crates/platform-core/src/event_stream.rs
@@ -1,0 +1,216 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! HTTP response streaming — the producer side of the multi-shot reply route
+//! (Java `EventStreamWriter`).
+//!
+//! Streaming is native to the event system: a caller provides a `reply_to`
+//! address and the callee may send it as many events as it likes. A streaming
+//! HTTP response is a *sequence* of events to the caller's reply route, each
+//! marked with the reserved envelope header `x-event-stream: data | eof |
+//! exception`, until end of transmission. The marker is internal protocol
+//! consumed by the REST automation edge — it never appears on the HTTP wire.
+//! The first data event commits the HTTP head (status, content type, optional
+//! idle-allowance override); writes after close are dropped.
+
+use crate::envelope::EventEnvelope;
+use crate::function::AppError;
+use crate::platform::Platform;
+use crate::post_office::PostOffice;
+
+/// Reserved envelope header marking one event of a streaming HTTP response
+/// (Java `EventStreamWriter.X_EVENT_STREAM`). Values: [`DATA`], [`EOF`],
+/// [`EXCEPTION`]. Absence of the header = single-shot response.
+pub const X_EVENT_STREAM: &str = "x-event-stream";
+
+/// Optional companion header naming a data segment — maps to the SSE
+/// `event:` field (Java `EventStreamWriter.X_EVENT_NAME`).
+pub const X_EVENT_NAME: &str = "x-event-name";
+
+/// One segment of the stream.
+pub const DATA: &str = "data";
+/// End of transmission (optional body = trailing metadata).
+pub const EOF: &str = "eof";
+/// In-band failure (body = `{status, message}`).
+pub const EXCEPTION: &str = "exception";
+
+/// Producer helper for a streaming HTTP response — thin sugar over plain
+/// event sends to the caller's reply route (Java `EventStreamWriter`).
+pub struct EventStreamWriter {
+    po: PostOffice,
+    reply_to: String,
+    correlation_id: Option<String>,
+    first_status: i32,
+    first_content_type: Option<String>,
+    first_ttl_seconds: u64,
+    head_sent: bool,
+    closed: bool,
+}
+
+impl EventStreamWriter {
+    /// Create a writer for a reply route and correlation id.
+    ///
+    /// Returns HTTP-400 when the reply route is empty — a streaming producer
+    /// without a reply address has nowhere to stream.
+    pub fn new(
+        platform: &Platform,
+        reply_to: &str,
+        correlation_id: Option<&str>,
+    ) -> Result<Self, AppError> {
+        if reply_to.is_empty() {
+            return Err(AppError::new(
+                400,
+                "Streaming producer requires a reply_to address",
+            ));
+        }
+        Ok(Self {
+            po: PostOffice::new(platform),
+            reply_to: reply_to.to_string(),
+            correlation_id: correlation_id.map(str::to_string),
+            first_status: 200,
+            first_content_type: None,
+            first_ttl_seconds: 0,
+            head_sent: false,
+            closed: false,
+        })
+    }
+
+    /// Create a writer from the incoming request envelope (the usual form for
+    /// an interceptor function).
+    pub fn from_request(platform: &Platform, request: &EventEnvelope) -> Result<Self, AppError> {
+        Self::new(
+            platform,
+            request.reply_to().unwrap_or(""),
+            request.correlation_id(),
+        )
+    }
+
+    /// Optional head control carried by the first outgoing event: response
+    /// status and content type. Later events cannot change the head.
+    pub fn first(&mut self, status: i32, content_type: &str) -> &mut Self {
+        self.first_status = status;
+        self.first_content_type = Some(content_type.to_string());
+        self
+    }
+
+    /// Head control plus an idle-allowance override in seconds between
+    /// segments (rides the first event as the `x-ttl` envelope header).
+    pub fn first_with_ttl(
+        &mut self,
+        status: i32,
+        content_type: &str,
+        ttl_seconds: u64,
+    ) -> &mut Self {
+        self.first_ttl_seconds = ttl_seconds;
+        self.first(status, content_type)
+    }
+
+    /// Send one `data` segment (String, bytes or map — any serializable body).
+    pub async fn write<T: serde::Serialize>(&mut self, segment: T) -> Result<(), AppError> {
+        self.send(segment, None).await
+    }
+
+    /// Send one named segment — the name maps to the SSE `event:` field.
+    pub async fn write_named<T: serde::Serialize>(
+        &mut self,
+        event_name: &str,
+        segment: T,
+    ) -> Result<(), AppError> {
+        self.send(segment, Some(event_name)).await
+    }
+
+    /// Declare end of transmission.
+    pub async fn close(&mut self) -> Result<(), AppError> {
+        self.close_with(serde_json::Value::Null).await
+    }
+
+    /// Declare end of transmission with trailing metadata (rendered as the
+    /// terminal SSE event's data; ignored in chunked mode).
+    pub async fn close_with<T: serde::Serialize>(&mut self, metadata: T) -> Result<(), AppError> {
+        if self.closed {
+            return Ok(());
+        }
+        self.closed = true;
+        let event = self.envelope(EOF, metadata, None)?;
+        self.po.send(event).await
+    }
+
+    /// Declare an in-band failure and end the stream.
+    pub async fn fail(&mut self, error: &AppError) -> Result<(), AppError> {
+        if self.closed {
+            return Ok(());
+        }
+        self.closed = true;
+        let status = if error.status() >= 400 {
+            error.status()
+        } else {
+            500
+        };
+        let body = serde_json::json!({"status": status, "message": error.message()});
+        let event = self.envelope(EXCEPTION, body, None)?.set_status(status);
+        self.po.send(event).await
+    }
+
+    /// True when the stream has been closed or failed.
+    pub fn is_closed(&self) -> bool {
+        self.closed
+    }
+
+    async fn send<T: serde::Serialize>(
+        &mut self,
+        body: T,
+        event_name: Option<&str>,
+    ) -> Result<(), AppError> {
+        if self.closed {
+            log::debug!(
+                "Segment to {} dropped - stream already closed",
+                self.reply_to
+            );
+            return Ok(());
+        }
+        let event = self.envelope(DATA, body, event_name)?;
+        self.po.send(event).await
+    }
+
+    fn envelope<T: serde::Serialize>(
+        &mut self,
+        marker: &str,
+        body: T,
+        event_name: Option<&str>,
+    ) -> Result<EventEnvelope, AppError> {
+        let mut event = EventEnvelope::new()
+            .set_to(&self.reply_to)
+            .set_header(X_EVENT_STREAM, marker)
+            .set_body(body)?;
+        if let Some(cid) = &self.correlation_id {
+            event = event.set_correlation_id(cid);
+        }
+        if let Some(name) = event_name.filter(|n| !n.is_empty()) {
+            event = event.set_header(X_EVENT_NAME, name);
+        }
+        if !self.head_sent {
+            self.head_sent = true;
+            event = event.set_status(self.first_status);
+            if let Some(content_type) = &self.first_content_type {
+                event = event.set_header("content-type", content_type);
+            }
+            if self.first_ttl_seconds > 0 {
+                event = event.set_header("x-ttl", &self.first_ttl_seconds.to_string());
+            }
+        }
+        Ok(event)
+    }
+}

--- a/crates/platform-core/src/lib.rs
+++ b/crates/platform-core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod actuator;
 pub mod app_starter;
 pub mod automation;
 pub mod envelope;
+pub mod event_stream;
 pub mod function;
 pub mod graph;
 pub(crate) mod inbox;
@@ -79,6 +80,7 @@ macro_rules! auto_start_main {
     };
 }
 pub use envelope::EventEnvelope;
+pub use event_stream::EventStreamWriter;
 pub use function::{AppError, ComposableFunction, TypedAdapter, TypedFunction};
 pub use graph::{MiniGraph, SimpleConnection, SimpleNode, SimpleRelationship};
 pub use platform::{FunctionOptions, Platform};

--- a/crates/platform-core/tests/actuator.rs
+++ b/crates/platform-core/tests/actuator.rs
@@ -215,6 +215,19 @@ async fn info_routes_reports_the_local_routing_table() {
     // a known PRIVATE route: the reserved RPC reply listener every platform
     // carries (500 instances, temporary.inbox)
     assert_eq!(json["routing"]["private"]["temporary.inbox"], 500);
+    // pool-style route families render as ONE compact entry (display-only
+    // compression, Java parity): the 500 streaming reply lanes collapse into
+    // "async.http.response.stream.0 - 499" and the individual names vanish
+    assert_eq!(
+        json["routing"]["private"]["async.http.response.stream.0 - 499"],
+        1
+    );
+    assert!(json["routing"]["private"]
+        .get("async.http.response.stream.0")
+        .is_none());
+    assert!(json["routing"]["private"]
+        .get("async.http.response.stream.499")
+        .is_none());
     // the port's optional blocks do not exist — Java's omit-when-empty
     assert!(json.get("journal").is_none());
     assert!(json.get("route_substitution").is_none());

--- a/crates/platform-core/tests/event_stream.rs
+++ b/crates/platform-core/tests/event_stream.rs
@@ -1,0 +1,790 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! End-to-end tests for HTTP response streaming: a callee streams events to
+//! the caller's reply_to (a dedicated ordered reply lane checked out from the
+//! pool for the request's lifetime) until end of transmission, and the edge
+//! renders them progressively — SSE framing for text/event-stream,
+//! chunked/NDJSON otherwise. The wire carries only standard HTTP.
+//! (Java `EventStreamResponseTest` twin.)
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, Once};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use platform_core::platform::FunctionOptions;
+use platform_core::{
+    automation, event_stream, overrides, resources, AppConfigReader, AppError, ComposableFunction,
+    EventEnvelope, EventStreamWriter, Platform, PostOffice,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+const REST_YAML: &str = r#"
+rest:
+  # Streaming response endpoint (multi-shot reply route). "stream: true"
+  # checks out a dedicated ordered reply lane so token segments render in the
+  # exact order the callee sent them. The endpoint's response header
+  # transform must apply to the streamed head like a single-shot response.
+  - service: "hello.event.stream"
+    methods: ['GET']
+    url: "/api/hello/stream"
+    timeout: 15s
+    stream: true
+    headers: header_2
+
+headers:
+  - id: header_2
+    response:
+      add: ["x-stream-transform: applied"]
+      drop: ['x-secret-header']
+"#;
+
+const PACE_MS: u64 = 250;
+
+/// Test producer for HTTP response streaming — the callee side of the
+/// multi-shot reply route. Modes are selected by the "mode" query parameter
+/// (Java `MockEventStreamService` twin).
+struct MockEventStream {
+    platform: Platform,
+}
+
+#[async_trait]
+impl ComposableFunction for MockEventStream {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let request: serde_json::Value = input.body_as()?;
+        let mode = request["parameters"]["query"]["mode"]
+            .as_str()
+            .unwrap_or("sse")
+            .to_string();
+        let mut out = EventStreamWriter::from_request(&self.platform, &input)?;
+        match mode.as_str() {
+            "sse" => {
+                out.first(200, "text/event-stream");
+                out.write("Hello").await?;
+                tokio::time::sleep(Duration::from_millis(PACE_MS)).await;
+                out.write("token stream").await?;
+                tokio::time::sleep(Duration::from_millis(PACE_MS)).await;
+                out.close_with(serde_json::json!({"segments": 2})).await?;
+            }
+            "sse-named" => {
+                out.first(200, "text/event-stream");
+                out.write_named("tokens", serde_json::json!({"n": 1}))
+                    .await?;
+                out.write_named("tokens", serde_json::json!({"n": 2}))
+                    .await?;
+                out.close().await?;
+            }
+            "sse-multiline" => {
+                out.first(200, "text/event-stream");
+                out.write("line1\nline2").await?;
+                out.close().await?;
+            }
+            "ndjson" => {
+                // no first() - content type falls back to Accept negotiation
+                for i in 1..=3 {
+                    out.write(serde_json::json!({"seq": i})).await?;
+                }
+                out.close_with(serde_json::json!({"ignored": true})).await?;
+            }
+            "chunk" => {
+                out.first(200, "text/plain");
+                out.write("alpha").await?;
+                out.write("beta").await?;
+                out.close().await?;
+            }
+            "error" => {
+                out.first(200, "text/event-stream");
+                out.write("partial").await?;
+                out.fail(&AppError::new(503, "backend on fire")).await?;
+            }
+            "error-first" => {
+                out.fail(&AppError::new(503, "no backend")).await?;
+            }
+            "stall" => {
+                // one-second idle allowance, then silence - the edge must
+                // fail the stream in-band
+                out.first_with_ttl(200, "text/event-stream", 1);
+                out.write("one").await?;
+            }
+            "ping" => {
+                // the keep-alive comments flow while the producer is quiet
+                // after the head is committed
+                out.first(200, "text/event-stream");
+                out.write("early").await?;
+                tokio::time::sleep(Duration::from_millis(2500)).await;
+                out.write("late").await?;
+                out.close().await?;
+            }
+            "empty-close" => {
+                out.close_with(serde_json::json!({"done": true})).await?;
+            }
+            "slow-paced" => {
+                // total duration exceeds the 1s idle allowance, but every gap
+                // is within it: each arriving segment extends the stream's life
+                out.first_with_ttl(200, "text/event-stream", 1);
+                for i in 1..=3 {
+                    out.write(format!("segment-{i}")).await?;
+                    tokio::time::sleep(Duration::from_millis(700)).await;
+                }
+                out.close().await?;
+            }
+            "burst" => {
+                // 50 unpaced 8KB segments - strict FIFO is guaranteed by the
+                // request's dedicated reply lane, and the payload size forces
+                // frame back-pressure so the drain path is exercised
+                out.first(200, "text/plain");
+                let padding = "x".repeat(8192);
+                for i in 1..=50 {
+                    out.write(format!("{i}|{padding}\n")).await?;
+                }
+                out.close().await?;
+            }
+            "headers" => {
+                // raw first event carrying custom headers - the endpoint's
+                // response header transform must add/drop exactly as for a
+                // single-shot response; a stray x-stream-id is ignored
+                let po = PostOffice::new(&self.platform);
+                po.send(
+                    EventEnvelope::new()
+                        .set_to(input.reply_to().unwrap_or_default())
+                        .set_correlation_id(input.correlation_id().unwrap_or_default())
+                        .set_header(event_stream::X_EVENT_STREAM, event_stream::DATA)
+                        .set_header("x-stream-id", "stream.fake.in")
+                        .set_header("x-secret-header", "hide-me")
+                        .set_header("x-custom-note", "visible")
+                        .set_header("content-type", "text/event-stream")
+                        .set_status(200)
+                        .set_body("transformed")?,
+                )
+                .await?;
+                out.close().await?;
+            }
+            "single-shot" => {
+                // an unmarked reply on a streaming endpoint renders exactly
+                // as an ordinary single-shot response
+                let po = PostOffice::new(&self.platform);
+                po.send(
+                    EventEnvelope::new()
+                        .set_to(input.reply_to().unwrap_or_default())
+                        .set_correlation_id(input.correlation_id().unwrap_or_default())
+                        .set_header("content-type", "text/plain")
+                        .set_status(200)
+                        .set_body("regular response")?,
+                )
+                .await?;
+            }
+            other => {
+                out.fail(&AppError::new(400, format!("unknown mode {other}")))
+                    .await?;
+            }
+        }
+        Ok(EventEnvelope::new())
+    }
+}
+
+/// Start a fresh server inside this test's runtime (the rest_automation.rs
+/// pattern): port 0 keeps parallel servers from colliding; platform state and
+/// the reply-lane pool are process-wide.
+async fn server() -> u16 {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        resources::prepend_resource_root("tests/resources");
+        let rest_file =
+            std::env::temp_dir().join(format!("rest-stream-{}.yaml", std::process::id()));
+        std::fs::write(&rest_file, REST_YAML).unwrap();
+        overrides::set(
+            "yaml.rest.automation",
+            &format!("file:{}", rest_file.display()),
+        );
+        overrides::set("rest.server.port", "0");
+        // test configuration: fast keep-alive so quiet streams show pings
+        overrides::set("event.stream.keep.alive", "1s");
+        let _ = AppConfigReader::get_instance();
+    });
+    let platform = Platform::new();
+    if !platform.has_route("hello.event.stream") {
+        let _ = platform.register_with_options(
+            "hello.event.stream",
+            Arc::new(MockEventStream {
+                platform: platform.clone(),
+            }),
+            10,
+            FunctionOptions {
+                zero_traced: false,
+                interceptor: true,
+                private: true,
+            },
+        );
+    }
+    let addr = automation::start_http_server(&platform)
+        .await
+        .expect("http server");
+    addr.port()
+}
+
+/// One received line with its arrival time.
+struct TimedLine {
+    line: String,
+    at: Instant,
+}
+
+/// Decode as much of an HTTP/1.1 chunked body as has arrived (incomplete
+/// trailing chunks are ignored until more bytes arrive).
+fn decode_chunked(raw: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while let Some(nl) = raw[i..].windows(2).position(|w| w == b"\r\n") {
+        let size_text = String::from_utf8_lossy(&raw[i..i + nl]);
+        let size_text = size_text.split(';').next().unwrap_or("").trim().to_string();
+        let Ok(size) = usize::from_str_radix(&size_text, 16) else {
+            break;
+        };
+        if size == 0 {
+            break;
+        }
+        let start = i + nl + 2;
+        if raw.len() < start + size + 2 {
+            break;
+        }
+        out.extend_from_slice(&raw[start..start + size]);
+        i = start + size + 2;
+    }
+    out
+}
+
+/// Issue a GET and read the response progressively, timestamping every line
+/// as it arrives (the Java BodyHandlers.ofLines + nanoTime pattern). Returns
+/// (status, lowercased head block, timed lines).
+async fn stream_request(port: u16, path: &str, accept: &str) -> (u16, String, Vec<TimedLine>) {
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("connect");
+    let request = format!(
+        "GET {path} HTTP/1.1\r\nHost: localhost\r\nAccept: {accept}\r\nConnection: close\r\n\r\n"
+    );
+    stream.write_all(request.as_bytes()).await.expect("write");
+    let mut raw: Vec<u8> = Vec::new();
+    let mut buf = [0u8; 8192];
+    let mut lines: Vec<TimedLine> = Vec::new();
+    let mut seen = 0usize;
+    let mut head_text = String::new();
+    let mut decoded_text = String::new();
+    loop {
+        let n = tokio::time::timeout(Duration::from_secs(20), stream.read(&mut buf))
+            .await
+            .expect("read timed out")
+            .unwrap_or(0);
+        if n == 0 {
+            break;
+        }
+        raw.extend_from_slice(&buf[..n]);
+        let now = Instant::now();
+        let Some(pos) = raw.windows(4).position(|w| w == b"\r\n\r\n") else {
+            continue;
+        };
+        if head_text.is_empty() {
+            head_text = String::from_utf8_lossy(&raw[..pos]).to_lowercase();
+        }
+        let body_raw = &raw[pos + 4..];
+        let decoded = if head_text.contains("transfer-encoding: chunked") {
+            decode_chunked(body_raw)
+        } else {
+            body_raw.to_vec()
+        };
+        decoded_text = String::from_utf8_lossy(&decoded).to_string();
+        // record newly completed lines with this read's arrival time
+        let complete: Vec<&str> = match decoded_text.rfind('\n') {
+            Some(last) => decoded_text[..last].split('\n').collect(),
+            None => Vec::new(),
+        };
+        for line in complete.iter().skip(seen) {
+            lines.push(TimedLine {
+                line: line.to_string(),
+                at: now,
+            });
+        }
+        seen = complete.len();
+    }
+    // flush a trailing line without a newline (chunked text mode)
+    let tail_start = decoded_text.rfind('\n').map(|last| last + 1).unwrap_or(0);
+    if tail_start < decoded_text.len() {
+        lines.push(TimedLine {
+            line: decoded_text[tail_start..].to_string(),
+            at: Instant::now(),
+        });
+    }
+    let status: u16 = head_text
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse().ok())
+        .unwrap_or(0);
+    (status, head_text, lines)
+}
+
+fn plain(lines: &[TimedLine]) -> Vec<String> {
+    lines.iter().map(|l| l.line.clone()).collect()
+}
+
+// ---- tests ----
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sse_segments_arrive_progressively_with_terminal_done_event() {
+    let port = server().await;
+    let (status, head, lines) =
+        stream_request(port, "/api/hello/stream?mode=sse", "text/event-stream").await;
+    assert_eq!(status, 200);
+    assert!(head.contains("content-type: text/event-stream"), "{head}");
+    assert!(head.contains("cache-control: no-cache"), "{head}");
+    assert!(
+        !head.contains("content-length"),
+        "a stream has no content length: {head}"
+    );
+    let body = plain(&lines);
+    let first = body.iter().position(|l| l == "data: Hello");
+    let second = body.iter().position(|l| l == "data: token stream");
+    let done = body.iter().position(|l| l == "event: done");
+    let (first, second, done) = (
+        first.expect("first segment"),
+        second.expect("second segment"),
+        done.expect("done event"),
+    );
+    assert!(
+        first < second && second < done,
+        "ordered SSE frames: {body:?}"
+    );
+    assert!(
+        body.contains(&"data: {\"segments\":2}".to_string()),
+        "eof body rides the done event: {body:?}"
+    );
+    // the producer paces segments 250 ms apart - a buffered response would
+    // arrive all at once
+    let elapsed = lines[done].at.duration_since(lines[first].at);
+    assert!(
+        elapsed >= Duration::from_millis(300),
+        "progressive delivery expected, elapsed {elapsed:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn named_segments_become_typed_sse_events() {
+    let port = server().await;
+    let (_, _, lines) = stream_request(
+        port,
+        "/api/hello/stream?mode=sse-named",
+        "text/event-stream",
+    )
+    .await;
+    let body = plain(&lines);
+    let name = body
+        .iter()
+        .position(|l| l == "event: tokens")
+        .expect("typed event");
+    assert_eq!(
+        body[name + 1],
+        "data: {\"n\":1}",
+        "typed event framing: {body:?}"
+    );
+    assert!(body.contains(&"event: done".to_string()), "{body:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multi_line_segment_splits_into_successive_data_lines() {
+    let port = server().await;
+    let (_, _, lines) = stream_request(
+        port,
+        "/api/hello/stream?mode=sse-multiline",
+        "text/event-stream",
+    )
+    .await;
+    let body = plain(&lines);
+    let first = body
+        .iter()
+        .position(|l| l == "data: line1")
+        .expect("first line");
+    assert_eq!(
+        body[first + 1],
+        "data: line2",
+        "SSE multi-line framing: {body:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn structured_segments_stream_as_json_lines_in_chunked_mode() {
+    let port = server().await;
+    let (status, head, lines) = stream_request(port, "/api/hello/stream?mode=ndjson", "*/*").await;
+    assert_eq!(status, 200);
+    assert!(head.contains("content-type: application/json"), "{head}");
+    let body: Vec<String> = plain(&lines)
+        .into_iter()
+        .filter(|l| !l.is_empty())
+        .collect();
+    assert_eq!(body.len(), 3, "one JSON object per line: {body:?}");
+    for (i, line) in body.iter().enumerate() {
+        let map: serde_json::Value = serde_json::from_str(line).expect("json line");
+        assert_eq!(map["seq"], (i + 1) as i64);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn text_segments_append_in_chunked_mode() {
+    let port = server().await;
+    let (status, head, lines) =
+        stream_request(port, "/api/hello/stream?mode=chunk", "text/plain").await;
+    assert_eq!(status, 200);
+    assert!(head.contains("content-type: text/plain"), "{head}");
+    assert!(!head.contains("content-length"), "{head}");
+    let text: String = plain(&lines).join("");
+    assert_eq!(text, "alphabeta");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mid_stream_failure_arrives_as_in_band_error_event() {
+    let port = server().await;
+    let (status, _, lines) =
+        stream_request(port, "/api/hello/stream?mode=error", "text/event-stream").await;
+    // the head is committed by the first segment, so the status stays 200
+    assert_eq!(status, 200);
+    let body = plain(&lines);
+    assert!(body.contains(&"data: partial".to_string()), "{body:?}");
+    let error = body
+        .iter()
+        .position(|l| l == "event: error")
+        .expect("in-band error event");
+    assert!(body[error + 1].contains("backend on fire"), "{body:?}");
+    assert!(body[error + 1].contains("503"), "{body:?}");
+    assert!(
+        !body.contains(&"event: done".to_string()),
+        "a failed stream has no done event"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failure_before_first_segment_is_a_normal_http_error() {
+    let port = server().await;
+    let (status, _, lines) = stream_request(
+        port,
+        "/api/hello/stream?mode=error-first",
+        "application/json",
+    )
+    .await;
+    assert_eq!(status, 503);
+    let text = plain(&lines).join("");
+    assert!(text.contains("no backend"), "{text}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn eof_only_stream_renders_terminal_event_immediately() {
+    let port = server().await;
+    let (status, head, lines) = stream_request(
+        port,
+        "/api/hello/stream?mode=empty-close",
+        "text/event-stream",
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert!(head.contains("content-type: text/event-stream"), "{head}");
+    let body = plain(&lines);
+    let done = body
+        .iter()
+        .position(|l| l == "event: done")
+        .expect("done event");
+    assert!(body[done + 1].contains("\"done\":true"), "{body:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn keep_alive_comments_flow_while_the_producer_is_quiet() {
+    // test configuration sets event.stream.keep.alive=1s; the producer is
+    // quiet for 2.5s after its first segment
+    let port = server().await;
+    let (_, _, lines) =
+        stream_request(port, "/api/hello/stream?mode=ping", "text/event-stream").await;
+    let body = plain(&lines);
+    assert!(
+        body.contains(&": ping".to_string()),
+        "keep-alive comment expected: {body:?}"
+    );
+    assert!(body.contains(&"data: late".to_string()), "{body:?}");
+    assert!(body.contains(&"event: done".to_string()), "{body:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stalled_producer_times_out_in_band() {
+    // the producer declares a one-second idle allowance (x-ttl) then goes
+    // silent; the edge must fail the stream in-band
+    let started = Instant::now();
+    let port = server().await;
+    let (_, _, lines) =
+        stream_request(port, "/api/hello/stream?mode=stall", "text/event-stream").await;
+    let body = plain(&lines);
+    assert!(body.contains(&"data: one".to_string()), "{body:?}");
+    let error = body
+        .iter()
+        .position(|l| l == "event: error")
+        .expect("in-band timeout expected");
+    assert!(
+        body[error + 1].contains("Timeout for 1 seconds"),
+        "{body:?}"
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(10),
+        "the idle allowance should fail the stream quickly, took {:?}",
+        started.elapsed()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn arriving_segments_extend_the_idle_allowance() {
+    // 3 segments 700ms apart under a 1s idle ttl: total 2.1s > ttl, but every
+    // gap is within it - the per-segment arrival must keep the stream alive
+    let port = server().await;
+    let (_, _, lines) = stream_request(
+        port,
+        "/api/hello/stream?mode=slow-paced",
+        "text/event-stream",
+    )
+    .await;
+    let body = plain(&lines);
+    assert!(body.contains(&"data: segment-3".to_string()), "{body:?}");
+    assert!(
+        body.contains(&"event: done".to_string()),
+        "the paced stream must complete: {body:?}"
+    );
+    assert!(!body.contains(&"event: error".to_string()), "{body:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn burst_segments_render_in_strict_fifo_order() {
+    // 50 unpaced segments - the request's dedicated reply lane (a
+    // single-instance route) must preserve exact FIFO order
+    let port = server().await;
+    let (status, _, lines) =
+        stream_request(port, "/api/hello/stream?mode=burst", "text/plain").await;
+    assert_eq!(status, 200);
+    let body: Vec<String> = plain(&lines)
+        .into_iter()
+        .filter(|l| !l.is_empty())
+        .collect();
+    assert_eq!(body.len(), 50, "all segments delivered");
+    for (i, line) in body.iter().enumerate() {
+        let sequence = line.split('|').next().unwrap_or("");
+        assert_eq!(sequence, (i + 1).to_string(), "strict segment order");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_streams_render_independently_and_in_order() {
+    // four parallel 50-segment bursts: each request checks out its own
+    // dedicated reply lane, so segments stay in strict FIFO while the
+    // requests stream concurrently
+    let port = server().await;
+    let mut tasks = Vec::new();
+    for _ in 0..4 {
+        tasks.push(tokio::spawn(async move {
+            let (_, _, lines) =
+                stream_request(port, "/api/hello/stream?mode=burst", "text/plain").await;
+            plain(&lines)
+                .into_iter()
+                .filter(|l| !l.is_empty())
+                .collect::<Vec<String>>()
+        }));
+    }
+    for task in tasks {
+        let body = task.await.expect("burst task");
+        assert_eq!(body.len(), 50, "all segments delivered");
+        for (i, line) in body.iter().enumerate() {
+            let sequence = line.split('|').next().unwrap_or("");
+            assert_eq!(sequence, (i + 1).to_string(), "strict per-request order");
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn response_header_transform_applies_to_the_streamed_head() {
+    // the endpoint declares "headers: header_2" (add x-stream-transform, drop
+    // x-secret-header) - the streamed head must honor it like a single-shot
+    // response; the stray x-stream-id is ignored (marker precedence)
+    let port = server().await;
+    let (status, head, lines) =
+        stream_request(port, "/api/hello/stream?mode=headers", "text/event-stream").await;
+    assert_eq!(status, 200);
+    assert!(
+        head.contains("x-stream-transform: applied"),
+        "add directive: {head}"
+    );
+    assert!(!head.contains("x-secret-header"), "drop directive: {head}");
+    assert!(
+        head.contains("x-custom-note: visible"),
+        "passthrough: {head}"
+    );
+    assert!(
+        !head.contains("x-stream-id"),
+        "reserved header never on the wire: {head}"
+    );
+    let body = plain(&lines);
+    assert!(body.contains(&"data: transformed".to_string()), "{body:?}");
+    assert!(body.contains(&"event: done".to_string()), "{body:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unmarked_reply_on_a_streaming_endpoint_renders_single_shot() {
+    let port = server().await;
+    let (status, head, lines) =
+        stream_request(port, "/api/hello/stream?mode=single-shot", "text/plain").await;
+    assert_eq!(status, 200);
+    assert!(head.contains("content-type: text/plain"), "{head}");
+    assert_eq!(plain(&lines).join(""), "regular response");
+}
+
+// ---- producer contract (Java EventStreamWriterTest twin) ----
+
+struct CaptureRoute {
+    received: Arc<Mutex<Vec<EventEnvelope>>>,
+}
+
+#[async_trait]
+impl ComposableFunction for CaptureRoute {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        self.received.lock().expect("capture mutex").push(input);
+        Ok(EventEnvelope::new())
+    }
+}
+
+async fn captured_count(received: &Arc<Mutex<Vec<EventEnvelope>>>, at_least: usize) {
+    for _ in 0..100 {
+        if received.lock().expect("capture mutex").len() >= at_least {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("expected {at_least} captured segments");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn writer_speaks_the_multi_shot_reply_route_protocol() {
+    let platform = Platform::new();
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let route = "capture.stream.protocol";
+    let _ = platform.register_with_options(
+        route,
+        Arc::new(CaptureRoute {
+            received: received.clone(),
+        }),
+        1,
+        FunctionOptions {
+            zero_traced: false,
+            interceptor: true,
+            private: true,
+        },
+    );
+    let mut out = EventStreamWriter::new(&platform, route, Some("cid-100")).expect("writer");
+    out.first_with_ttl(200, "text/event-stream", 30);
+    assert!(!out.is_closed());
+    out.write("Hello").await.expect("write");
+    out.write_named("tokens", serde_json::json!({"n": 2}))
+        .await
+        .expect("write");
+    out.close_with(serde_json::json!({"usage": 42}))
+        .await
+        .expect("close");
+    assert!(out.is_closed());
+    out.write("late segment must be dropped")
+        .await
+        .expect("drop");
+    out.fail(&AppError::new(500, "fail after close is a no-op"))
+        .await
+        .expect("no-op");
+    captured_count(&received, 3).await;
+    let events = received.lock().expect("capture mutex");
+    assert_eq!(events.len(), 3, "segments after close must be dropped");
+    let first = &events[0];
+    assert_eq!(first.correlation_id(), Some("cid-100"));
+    assert_eq!(
+        first.header(event_stream::X_EVENT_STREAM),
+        Some(event_stream::DATA)
+    );
+    assert_eq!(first.header("content-type"), Some("text/event-stream"));
+    assert_eq!(first.header("x-ttl"), Some("30"));
+    assert_eq!(first.status(), 200);
+    let second = &events[1];
+    assert_eq!(second.header(event_stream::X_EVENT_NAME), Some("tokens"));
+    assert_eq!(
+        second.header("content-type"),
+        None,
+        "head control rides the first event only"
+    );
+    let eof = &events[2];
+    assert_eq!(
+        eof.header(event_stream::X_EVENT_STREAM),
+        Some(event_stream::EOF)
+    );
+    let metadata: serde_json::Value = eof.body_as().expect("eof body");
+    assert_eq!(metadata["usage"], 42);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fail_maps_exceptions_to_the_in_band_error_contract() {
+    let platform = Platform::new();
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let route = "capture.stream.failure";
+    let _ = platform.register_with_options(
+        route,
+        Arc::new(CaptureRoute {
+            received: received.clone(),
+        }),
+        1,
+        FunctionOptions {
+            zero_traced: false,
+            interceptor: true,
+            private: true,
+        },
+    );
+    let mut out = EventStreamWriter::new(&platform, route, Some("cid-200")).expect("writer");
+    out.fail(&AppError::new(429, "slow down"))
+        .await
+        .expect("fail");
+    assert!(out.is_closed());
+    captured_count(&received, 1).await;
+    let events = received.lock().expect("capture mutex");
+    let error = &events[0];
+    assert_eq!(
+        error.header(event_stream::X_EVENT_STREAM),
+        Some(event_stream::EXCEPTION)
+    );
+    assert_eq!(error.status(), 429);
+    let body: serde_json::Value = error.body_as().expect("error body");
+    assert_eq!(body["status"], 429);
+    assert_eq!(body["message"], "slow down");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn writer_requires_a_reply_route() {
+    let platform = Platform::new();
+    assert!(EventStreamWriter::new(&platform, "", Some("cid")).is_err());
+    let request_without_reply_to = EventEnvelope::new();
+    assert!(EventStreamWriter::from_request(&platform, &request_without_reply_to).is_err());
+}

--- a/crates/platform-core/tests/event_stream_pool.rs
+++ b/crates/platform-core/tests/event_stream_pool.rs
@@ -1,0 +1,195 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Reply-lane pool behavior for HTTP response streaming: checkout/release
+//! balance, LIFO reuse, and deterministic HTTP-503 back-pressure when the
+//! pool is exhausted. These tests manipulate the process-wide pool, so they
+//! live in their own test binary and serialize among themselves through a
+//! shared guard.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Once, OnceLock};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use platform_core::platform::FunctionOptions;
+use platform_core::{
+    automation, overrides, resources, AppConfigReader, AppError, ComposableFunction, EventEnvelope,
+    EventStreamWriter, Platform,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+const REST_YAML: &str = r#"
+rest:
+  - service: "hello.pool.stream"
+    methods: ['GET']
+    url: "/api/pool/stream"
+    timeout: 15s
+    stream: true
+"#;
+
+/// Streams two text segments and closes.
+struct ChunkStream {
+    platform: Platform,
+}
+
+#[async_trait]
+impl ComposableFunction for ChunkStream {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let mut out = EventStreamWriter::from_request(&self.platform, &input)?;
+        out.first(200, "text/plain");
+        out.write("alpha").await?;
+        out.write("beta").await?;
+        out.close().await?;
+        Ok(EventEnvelope::new())
+    }
+}
+
+/// The pool is process-wide state - tests in this binary run one at a time.
+fn pool_guard() -> &'static tokio::sync::Mutex<()> {
+    static GUARD: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    GUARD.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+async fn server() -> u16 {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        resources::prepend_resource_root("tests/resources");
+        let rest_file = std::env::temp_dir().join(format!("rest-pool-{}.yaml", std::process::id()));
+        std::fs::write(&rest_file, REST_YAML).unwrap();
+        overrides::set(
+            "yaml.rest.automation",
+            &format!("file:{}", rest_file.display()),
+        );
+        overrides::set("rest.server.port", "0");
+        let _ = AppConfigReader::get_instance();
+    });
+    let platform = Platform::new();
+    if !platform.has_route("hello.pool.stream") {
+        let _ = platform.register_with_options(
+            "hello.pool.stream",
+            Arc::new(ChunkStream {
+                platform: platform.clone(),
+            }),
+            10,
+            FunctionOptions {
+                zero_traced: false,
+                interceptor: true,
+                private: true,
+            },
+        );
+    }
+    let addr = automation::start_http_server(&platform)
+        .await
+        .expect("http server");
+    addr.port()
+}
+
+async fn http_get(port: u16, path: &str) -> (u16, String) {
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("connect");
+    let request = format!(
+        "GET {path} HTTP/1.1\r\nHost: localhost\r\nAccept: text/plain\r\nConnection: close\r\n\r\n"
+    );
+    stream.write_all(request.as_bytes()).await.expect("write");
+    let mut raw = Vec::new();
+    tokio::time::timeout(Duration::from_secs(20), stream.read_to_end(&mut raw))
+        .await
+        .expect("read timed out")
+        .expect("read");
+    let text = String::from_utf8_lossy(&raw).to_string();
+    let status: u16 = text
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse().ok())
+        .unwrap_or(0);
+    (status, text)
+}
+
+/// Wait briefly for in-flight releases to settle back into the pool.
+async fn settle_to(expected: usize) -> usize {
+    for _ in 0..50 {
+        if automation::available_lanes() >= expected {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    automation::available_lanes()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pool_exhaustion_rejects_with_http_503_and_recovers() {
+    let port = server().await;
+    let _guard = pool_guard().lock().await;
+    // drain the reply-lane pool: a streaming endpoint without an available
+    // lane is rejected immediately with HTTP-503 (deterministic back-pressure)
+    let mut drained = Vec::new();
+    while let Some(lane) = automation::checkout_lane() {
+        drained.push(lane);
+    }
+    assert!(!drained.is_empty(), "the pool should have lanes to drain");
+    let (status, text) = http_get(port, "/api/pool/stream").await;
+    for lane in drained {
+        automation::release_lane(lane);
+    }
+    assert_eq!(status, 503);
+    assert!(text.contains("Streaming response pool exhausted"), "{text}");
+    // capacity restored - the same endpoint streams normally again
+    let (status, text) = http_get(port, "/api/pool/stream").await;
+    assert_eq!(status, 200);
+    assert!(text.contains("alpha"), "{text}");
+    assert!(text.contains("beta"), "{text}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_completed_stream_returns_its_lane_to_the_pool() {
+    let port = server().await;
+    let _guard = pool_guard().lock().await;
+    let before = automation::available_lanes();
+    assert!(before > 0, "lanes should be available before the request");
+    let (status, text) = http_get(port, "/api/pool/stream").await;
+    assert_eq!(status, 200);
+    assert!(text.contains("alpha"), "{text}");
+    // the lane is released when the stream completes; allow a brief settle
+    assert_eq!(
+        settle_to(before).await,
+        before,
+        "checkout/release must balance"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lane_checkout_is_lifo() {
+    let _port = server().await;
+    let _guard = pool_guard().lock().await;
+    // the pool is a stack ("ready" signal pattern): the most recently
+    // released lane is the first to be reused
+    let first = automation::checkout_lane().expect("a lane");
+    automation::release_lane(first.clone());
+    assert_eq!(
+        automation::checkout_lane().as_deref(),
+        Some(first.as_str()),
+        "most recently released lane is reused first"
+    );
+    automation::release_lane(first);
+}

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2626,3 +2626,31 @@ reaches a route that exists only as an event-over-http target, served by a stub
 guard first. The compiled-set parity pin grew 49 → 50 (it caught the new fixture
 immediately, as designed). Java lock-step: same guard relaxation plus a
 `PostOffice.getEventHttpTarget(route)` passthrough.
+
+## Increment 91 — HTTP response streaming: the multi-shot reply route reaches the HTTP edge (2026-08-28)
+
+The Java engine's HTTP response streaming feature (Java PR #299, ADR-0018), ported with
+engine-identical vocabulary and wire framing (this repo's ADR-0015). A callee streams an
+HTTP response by sending a sequence of events — marked with the reserved envelope header
+`x-event-stream: data | eof | exception` — to the caller's reply route until end of
+transmission; the edge renders SSE (`text/event-stream`) or chunked/JSON-Lines
+progressively. `stream: true` in rest.yaml checks out a dedicated ordered reply lane
+(`async.http.response.stream.{n}`, single instance) from a LIFO pool of 500 for the
+request's lifetime; an exhausted pool answers HTTP-503 "Streaming response pool
+exhausted". New `EventStreamWriter` producer API (`event_stream.rs`); the hyper edge
+gained a channel-backed streaming body (every handler path now shares one boxed body
+type). Port-idiomatic internals: the per-request tokio renderer task enforces the idle
+allowance directly (Java uses a housekeeper sweep) and emits the same in-band 408
+"Timeout for N seconds" error event — wire-identical by construction. The endpoint's
+response header transform applies to the streamed head with single-shot parity.
+`/info/routes` renders pool-style route families compactly ("async.http.response.stream.0
+- 499") and caches the rendered routing view for 10 minutes (Java parity round).
+
+Pins: 21 streaming tests (progressive-delivery timing, typed/multi-line SSE framing,
+NDJSON, in-band mid-stream error, pre-head error, eof-only, keep-alive pings, in-band
+idle timeout, touch-pacing, 8KB×50 FIFO burst, four concurrent bursts, transform parity,
+single-shot fallback on a stream endpoint, pool exhaustion → 503 → recovery, lane
+return, LIFO reuse, producer-contract set) + the actuator compression assertions.
+Demo proven live: examples/hello-world `GET /api/hello/sse` + `scripts/sse-client.mjs`
+rendered 10 messages exactly ~1s apart with the terminal done event — byte-identical
+demo behavior to the Java lambda-example twin.

--- a/docs/arch-decisions/ADR.md
+++ b/docs/arch-decisions/ADR.md
@@ -26,6 +26,46 @@ or *Deprecated* (no longer relevant), with its text left in place.
 
 ---
 
+## ADR-0015 — HTTP response streaming rides the multi-shot reply route; the wire stays standards-only {#adr-0015}
+**Status:** Proposed · **Date:** 2026-08-28 · **Serves:** vision-mercury · **Formalizes:** http-response-streaming-design
+<!-- id: adr-0015 | status: proposed -->
+
+**Abstract.** A function streams an HTTP response (LLM token segments, agent progress
+events, live updates) by exercising the platform's native streaming pattern: the callee
+sends a sequence of events to the caller-provided reply route until an
+end-of-transmission signal. Each event carries the reserved **envelope** header
+`x-event-stream: data | eof | exception`; the marker is internal protocol consumed by
+the REST automation edge — it never appears on the wire. The public HTTP surface is
+standards-only: Server-Sent Events framing when the content type is `text/event-stream`
+(typed events, a terminal `done` event carrying trailing metadata, in-band `error`
+events, keep-alive comments), chunked transfer with JSON Lines otherwise. A streaming
+endpoint is declared with `stream: true` in rest.yaml, which checks out a dedicated
+ordered reply lane for the request's lifetime — a single-instance route
+(`async.http.response.stream.{n}`) drawn LIFO from a pool of 500 (the
+`async.http.response` concurrency), returned when the request ends — the "ready" signal
+pattern of the reactive manager/worker design. One request's segments ride its own lane
+(strict FIFO) while different requests stream concurrently; an exhausted pool rejects
+further streaming requests immediately with HTTP-503 (deterministic back-pressure, no
+configuration knob). The first event commits the response head; each arrival extends
+the idle allowance; stalls fail in-band with status 408; client disconnects turn late
+segments into no-op drops; the response header transform applies to the streamed head
+with single-shot parity. Responses without the marker are single-shot, exactly as
+before.
+
+**Rationale.** The prerequisite for AI-era workloads is progressive delivery over plain
+HTTP — SSE is the de facto wire for chat token streams, agent progress protocols, and
+the live-watch window of long-running workflows. The multi-shot reply route adds no new
+substrate — anything that can send an envelope to a route can stream, which keeps the
+mechanism language-neutral by construction: flow tasks, graph nodes, and Event-over-HTTP
+peers join by sending the same envelopes. This is the Java engine's ADR-0018 twin
+(Java PR #299): the envelope vocabulary, the rest.yaml surface, the SSE framing, the
+503 message, and the `/info/routes` family compression are engine-identical; the
+internal execution differs idiomatically (a tokio renderer task enforces the idle
+allowance directly instead of Java's housekeeper sweep — the wire behavior is the same).
+The Java-side `x-stream-id` relay remains a documented deferral of this port.
+
+---
+
 ## ADR-0014 — Polyglot functions are Event-over-HTTP peers, not subprocesses or ports {#adr-0014}
 **Status:** Proposed · **Date:** 2026-08-22 · **Serves:** vision-mercury · **Formalizes:** polyglot-event-over-http-design
 <!-- id: adr-0014 | status: proposed -->

--- a/docs/guides/actuators-and-http-client.md
+++ b/docs/guides/actuators-and-http-client.md
@@ -23,7 +23,12 @@ GET /livenessprobe
     One Java default is not ported: **`/info/lib`** (Java lists JAR dependencies from the
     archive manifest — a Rust binary has no runtime dependency manifest). **`/info/routes`
     IS ported**: the app block plus the local routing table split by visibility
-    (`routing.public` / `routing.private`, route → instance count, sorted); Java's optional
+    (`routing.public` / `routing.private`, route → instance count, sorted). For
+    readability, pool-style route families render compactly: routes differing only by a
+    trailing numeric suffix, with the same instance count and contiguous numbering,
+    collapse into one display entry — e.g. the 500 streaming reply lanes appear as
+    `"async.http.response.stream.0 - 499": 1` (display-only; the routing table itself is
+    unchanged, and the rendered view is cached for 10 minutes). Java's optional
     `journal` / `route_substitution` / mesh `network` blocks are omitted when empty, and
     those subsystems do not exist here. XML actuator responses are not supported —
     actuators answer in JSON. **`POST /api/event` (Event over HTTP) IS ported**

--- a/docs/guides/http-streaming.md
+++ b/docs/guides/http-streaming.md
@@ -1,0 +1,188 @@
+# HTTP Response Streaming
+
+*How a function streams an HTTP response progressively - token by token, event by event.*
+
+> **At a glance**
+>
+> - **What** — a callee sends a *sequence* of events to the caller's reply route until an
+>   end-of-transmission signal; the HTTP edge renders each segment as it arrives.
+> - **For** — LLM token streams, agent progress events, and live updates of a running
+>   transaction. The wire is standard HTTP: Server-Sent Events (`text/event-stream`) or
+>   chunked transfer with JSON lines.
+
+Everything on this page describes this repository's engine
+(`crates/platform-core/src/automation/server.rs` and
+`crates/platform-core/src/event_stream.rs`); the envelope protocol, the rest.yaml
+surface, and the wire framing are engine-identical with the Java engine, so a flow or a
+client moves between the two engines without adaptation.
+
+## The model
+
+Streaming is native to the event system: a caller provides a `reply_to` address, and the
+callee may send it as many events as it likes. For a regular request the return route is
+single-shot - the first response event completes the HTTP exchange. A *streaming*
+response makes it multi-shot: each event carries one segment, and a final signal declares
+end of transmission.
+
+Each segment event carries the reserved envelope header:
+
+```text
+x-event-stream: data | eof | exception
+```
+
+This marker is internal protocol between the callee and the HTTP edge - it never appears
+on the wire. The HTTP client sees only standard HTTP: chunked transfer encoding, and
+Server-Sent Events framing when the content type is `text/event-stream`.
+
+## Declare a streaming endpoint
+
+Add `stream: true` to the endpoint definition in rest.yaml:
+
+```yaml
+  - service: "v1.token.producer"
+    methods: ['POST']
+    url: "/api/chat"
+    timeout: 60s
+    stream: true
+```
+
+The flag makes the request check out a *dedicated ordered reply lane* - a
+single-instance route drawn from a pool of 500 (matching the `async.http.response`
+concurrency). All segments of the request ride its own lane, so they render in the exact
+order the function sent them, while different requests stream concurrently through their
+own lanes. The lane returns to the pool when the request completes; when all 500 lanes
+are busy, further streaming requests are rejected immediately with HTTP-503
+(`Streaming response pool exhausted`) - deterministic back-pressure instead of silent
+queuing. An idle lane costs only a little memory and no CPU. The endpoint may still
+answer single-shot - a response without the `x-event-stream` marker behaves exactly as
+before.
+
+The endpoint's other declarations compose normally: `cors` headers and the optional
+`headers` response transform (add/keep/drop) apply to the streamed response head
+exactly as they do to a single-shot response.
+
+## Produce a stream
+
+A streaming producer is an interceptor function - it receives the raw event envelope
+(including `reply_to` and correlation id) and replies by sending events itself:
+
+```rust
+#[preload(route = "v1.token.producer", instances = 50, interceptor)]
+struct TokenProducer;
+
+#[async_trait]
+impl ComposableFunction for TokenProducer {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let mut out = EventStreamWriter::from_request(&Platform::get_instance(), &input)?;
+        out.first(200, "text/event-stream");
+        out.write("Hello").await?;                                    // one segment
+        out.write_named("tokens", serde_json::json!({"n": 2})).await?; // a named SSE event
+        out.close_with(serde_json::json!({"usage": 42})).await?;     // end of transmission
+        Ok(EventEnvelope::new())
+    }
+}
+```
+
+`EventStreamWriter` is thin sugar over plain event sends:
+
+| Method | Meaning |
+| ------ | ------- |
+| `first(status, content_type)` | optional head control, carried by the first outgoing event |
+| `first_with_ttl(status, content_type, ttl_seconds)` | as above, plus an idle-allowance override between segments |
+| `write(segment)` | one `data` segment - text, bytes or a map |
+| `write_named(event_name, segment)` | a named segment - the name maps to the SSE `event:` field |
+| `close()` / `close_with(metadata)` | end of transmission - metadata rides the terminal SSE `done` event |
+| `fail(&AppError)` | in-band failure - rendered as an SSE `error` event, or truncation in chunked mode |
+
+The first event commits the HTTP response head (status, content type, other headers).
+Later events cannot change it. Writes after `close` or `fail` are dropped, mirroring
+the edge dropping late segments after a timeout or client disconnect.
+
+## What the client sees
+
+**SSE mode** (`Content-Type: text/event-stream`) - the de facto wire for LLM token
+streams and agent progress events:
+
+```text
+data: Hello
+
+event: tokens
+data: {"n":2}
+
+event: done
+data: {"usage":42}
+```
+
+- A map segment renders as compact one-line JSON; multi-line text splits into
+  successive `data:` lines per the SSE specification.
+- End of transmission is the terminal `event: done`, carrying the `close_with(...)`
+  metadata.
+- An in-band failure is `event: error` with `{"status":n,"message":"...","type":"error"}` -
+  the HTTP status is already committed by then, which is why the failure travels in-band.
+- While the producer is quiet, the edge emits an SSE comment (`: ping`) every
+  `event.stream.keep.alive` interval (default `30s`, `0` disables) so idle proxies do not
+  drop the connection. Pings do not extend the idle timeout.
+
+**Chunked mode** (any other content type): text and byte segments append verbatim;
+map segments stream as JSON Lines (one compact JSON object per line). End of
+transmission simply ends the response.
+
+## Timeouts, disconnects and slow clients
+
+- The endpoint `timeout` acts as an *idle* allowance - each arriving segment extends it.
+  A producer may override the idle allowance with
+  `first_with_ttl(status, content_type, ttl_seconds)`.
+- A stalled stream fails in-band: the client receives an SSE `error` event with status
+  408 (chunked mode: the response truncates).
+- When the client disconnects, the context closes and late segments are dropped as
+  no-ops - producers do not need to handle cancellation.
+- A client that stops reading beyond the idle allowance is truncated - for SSE, the
+  missing terminal `done` event is the in-band truncation signal.
+
+## Failure before the first segment
+
+`fail(...)` before any `write(...)` renders a normal HTTP error response (the head is not
+yet committed), so early failures keep proper HTTP status codes.
+
+## Try it
+
+The hello-world example ships a runnable demo: the `hello.sse` function serves
+`GET /api/hello/sse` (declared with `stream: true`) and streams test messages slowly so
+you can watch the progressive rendering. Start the application and consume the endpoint
+with the companion Node.js script, which prints each event with its arrival time:
+
+```shell
+cargo run -p hello-world
+```
+
+```shell
+node examples/hello-world/scripts/sse-client.mjs
+```
+
+or with curl:
+
+```shell
+curl -N -H 'accept: text/event-stream' http://127.0.0.1:8085/api/hello/sse
+```
+
+The `-N` (`--no-buffer`) flag matters: curl receives the events progressively either
+way, but without `-N` it holds output in an internal buffer, so the messages would
+appear all at once when the stream ends.
+
+## Relation to `x-stream-id`
+
+The Java engine also carries a legacy `x-stream-id` relay (object streams, file
+downloads, `Flux` results), which is a documented deferral in this port. `x-event-stream`
+is the idiom for progressive text/JSON delivery - tokens and events - with SSE framing
+and in-band terminal signals, and it is fully supported here. If both headers appear on
+a response, `x-event-stream` wins and the stray `x-stream-id` is ignored with a warning.
+
+## See also
+
+- [Event over HTTP](event-over-http.md) - the same envelope protocol between applications
+- [Actuators & HTTP Client](actuators-and-http-client.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -71,6 +71,10 @@ Needed when a flow task or a graph's `graph.task` calls a custom function:
   accenture.github.io/mercury-nodejs) with the engines' preload/envelope/actuator/log contracts;
   flows call them via yaml.event.over.http; graph.task requires engine v4.11.11+; orchestration
   stays on the engine (no flows/graphs in wrappers).
+- [HTTP Response Streaming](guides/http-streaming.md) — stream an HTTP response progressively
+  (LLM tokens, progress events): `stream: true` in rest.yaml + EventStreamWriter; the reserved
+  `x-event-stream: data|eof|exception` envelope marker; SSE/chunked+NDJSON standards-only wire;
+  dedicated reply-lane pool of 500 with HTTP-503 back-pressure.
 
 ## Design & project docs (human-facing)
 - `docs/design/` — port design notes (platform-core, event-script, knowledge-graph, and

--- a/examples/hello-world/resources/rest.yaml
+++ b/examples/hello-world/resources/rest.yaml
@@ -9,6 +9,22 @@ rest:
     headers: header_1
     tracing: true
 
+  # Progressive result set rendering (HTTP response streaming) demo.
+  # "stream: true" gives the request a dedicated ordered reply lane so the
+  # "hello.sse" function can stream test messages slowly as Server-Sent
+  # Events. Optional query parameters: delay (ms between messages) and count.
+  #
+  # Try it with the companion script: node scripts/sse-client.mjs
+  #
+  - service: "hello.sse"
+    methods: ['GET']
+    url: "/api/hello/sse"
+    timeout: 30s
+    cors: cors_1
+    headers: header_1
+    tracing: true
+    stream: true
+
   # Override the default "/api/event" endpoint to attach the demo
   # authentication service (the EventApiAuth function). A calling party must
   # present the shared demo token in the "authorization" header - see

--- a/examples/hello-world/scripts/sse-client.mjs
+++ b/examples/hello-world/scripts/sse-client.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/*
+    Progressive rendering demo client for the hello-world SSE endpoint.
+
+    Start the application first:
+        cargo run -p hello-world
+
+    Then run this script:
+        node scripts/sse-client.mjs
+        node scripts/sse-client.mjs "http://127.0.0.1:8085/api/hello/sse?delay=500&count=5"
+
+    Each Server-Sent Event is printed the moment it arrives, prefixed with the
+    elapsed time, so you can see the progressive delivery - the messages render
+    one by one instead of appearing all at once. Requires Node.js 18 or higher.
+*/
+
+const url = process.argv[2] ?? 'http://127.0.0.1:8085/api/hello/sse';
+const started = Date.now();
+const elapsed = () => String(Date.now() - started).padStart(6, ' ');
+
+const response = await fetch(url, { headers: { accept: 'text/event-stream' } });
+console.log(`[${elapsed()} ms] HTTP ${response.status} (${response.headers.get('content-type')})`);
+if (!response.ok || !response.body) {
+    console.error(await response.text());
+    process.exit(1);
+}
+
+// Minimal SSE reader: frames are separated by a blank line; each frame carries
+// an optional "event:" name and one or more "data:" lines. A line starting
+// with ":" is a keep-alive comment.
+let buffer = '';
+const decoder = new TextDecoder();
+for await (const chunk of response.body) {
+    buffer += decoder.decode(chunk, { stream: true });
+    let boundary;
+    while ((boundary = buffer.indexOf('\n\n')) >= 0) {
+        renderFrame(buffer.slice(0, boundary));
+        buffer = buffer.slice(boundary + 2);
+    }
+}
+console.log(`[${elapsed()} ms] socket closed`);
+
+function renderFrame(frame) {
+    const lines = frame.split('\n');
+    const event = lines.find(line => line.startsWith('event:'))?.slice(6).trim();
+    const data = lines.filter(line => line.startsWith('data:'))
+        .map(line => line.slice(5).trim()).join('\n');
+    if (event) {
+        console.log(`[${elapsed()} ms] event: ${event} - ${data}`);
+    } else if (data) {
+        console.log(`[${elapsed()} ms] ${data}`);
+    } else if (lines.some(line => line.startsWith(':'))) {
+        console.log(`[${elapsed()} ms] (keep-alive)`);
+    }
+}

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -51,7 +51,8 @@ use async_trait::async_trait;
 use platform_core::automation::AsyncHttpRequest;
 use platform_core::{
     before_application, main_application, preload, trace, AppConfigReader, AppError,
-    ComposableFunction, EntryPoint, EventEnvelope, Platform, PostOffice, TypedFunction,
+    ComposableFunction, EntryPoint, EventEnvelope, EventStreamWriter, Platform, PostOffice,
+    TypedFunction,
 };
 use rmpv::Value;
 use serde::{Deserialize, Serialize};
@@ -354,6 +355,59 @@ impl ComposableFunction for HttpRequestFilter {
         EventEnvelope::new()
             .set_header("x-filter", "inspected")
             .set_body(serde_json::Value::Null)
+    }
+}
+
+// ---- progressive result set rendering (HTTP response streaming) ----
+
+/// This demo function serves an HTTP endpoint with progressive result set
+/// rendering (HTTP response streaming). The endpoint is declared with
+/// `stream: true` in rest.yaml, and the function streams a sequence of test
+/// messages slowly so that you can watch them render one by one as
+/// Server-Sent Events.
+///
+/// A streaming producer is an interceptor - it receives the raw event
+/// envelope (including the caller's reply_to address) and streams segments
+/// through the `EventStreamWriter` until it declares end of transmission.
+///
+/// Optional query parameters: "delay" in milliseconds between messages
+/// (default 1000, bounded 50 - 5000) and "count" for the number of messages
+/// (default 10, bounded 1 - 100).
+///
+/// Try it with the companion script: `node scripts/sse-client.mjs`
+/// or with `curl -N -H 'accept: text/event-stream'` against
+/// `http://127.0.0.1:8085/api/hello/sse`
+#[preload(route = "hello.sse", instances = 10, interceptor)]
+struct HelloSse;
+
+#[async_trait]
+impl ComposableFunction for HelloSse {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let request: serde_json::Value = input.body_as()?;
+        let query = &request["parameters"]["query"];
+        let delay = query["delay"]
+            .as_str()
+            .and_then(|v| v.parse::<u64>().ok())
+            .map_or(1000, |v| v.clamp(50, 5000));
+        let count = query["count"]
+            .as_str()
+            .and_then(|v| v.parse::<u32>().ok())
+            .map_or(10, |v| v.clamp(1, 100));
+        let mut out = EventStreamWriter::from_request(&Platform::get_instance(), &input)?;
+        out.first(200, "text/event-stream");
+        out.write("The following messages are rendered slowly to demonstrate the SSE feature:")
+            .await?;
+        for i in 1..=count {
+            tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+            out.write(format!("test message {i}")).await?;
+        }
+        out.close_with("end of SSE page.").await?;
+        Ok(EventEnvelope::new())
     }
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
   - "Operate & integrate":
       - Observability: guides/observability.md
       - Event over HTTP: guides/event-over-http.md
+      - HTTP Response Streaming: guides/http-streaming.md
       - Polyglot Functions (Python & Node.js): guides/polyglot-functions.md
   - Reference:
       - Configuration Keys: guides/configuration-reference.md

--- a/system/ai-contract-provider/resources/skill/files.list
+++ b/system/ai-contract-provider/resources/skill/files.list
@@ -11,6 +11,7 @@ references/guides/event-driven/index.md
 references/guides/event-driven/write-your-first-function.md
 references/guides/event-envelope-reference.md
 references/guides/event-over-http.md
+references/guides/http-streaming.md
 references/guides/event-script/ai-agent-guide.md
 references/guides/event-script/event-script-flow.json
 references/guides/event-script/flow-grammar.md


### PR DESCRIPTION
## What

The Java engine's HTTP response streaming feature
(Accenture/mercury-composable#299), ported with engine-identical vocabulary and wire
framing. A function streams an HTTP response progressively - LLM token segments, agent
progress events, or any result set rendered piece by piece - by sending a *sequence* of
events to the caller's reply route until an end-of-transmission signal.

- **Envelope protocol (internal, never on the wire):** each segment event carries the
  reserved header `x-event-stream: data | eof | exception`. The first event commits the
  HTTP head; `eof` ends the response (optional trailing metadata); `exception` fails the
  stream in-band. A response without the marker is single-shot, exactly as before.
- **Standards-only wire:** Server-Sent Events when the content type is
  `text/event-stream` (typed events via `x-event-name`, terminal `event: done`, in-band
  `event: error`, keep-alive comments via `event.stream.keep.alive`, default 30s);
  chunked transfer for other content types, with structured segments as JSON Lines.
- **Ordered delivery:** a streaming endpoint is declared with `stream: true` in
  rest.yaml. The request checks out a **dedicated ordered reply lane**
  (`async.http.response.stream.{n}`, single instance) from a LIFO pool of 500 (the
  `async.http.response` concurrency) for its lifetime, released exactly once at
  cleanup. Per-request strict FIFO, zero cross-request lane sharing. An exhausted pool
  rejects further streaming requests immediately with HTTP-503
  `Streaming response pool exhausted`.
- **Producer API:** new `EventStreamWriter` (`event_stream.rs`) - thin sugar over plain
  event sends (`first`/`first_with_ttl`, `write`/`write_named`, `close`/`close_with`,
  `fail`), so anything that can send an envelope can stream.
- **Edge mechanics:** the hyper boundary is now stream-capable - every handler path
  shares one boxed body type, and a channel-backed streaming body carries frames from a
  per-request renderer task. The renderer enforces the idle allowance directly (the
  port-idiomatic replacement for Java's housekeeper sweep) and emits the same in-band
  408 "Timeout for N seconds" error event - wire-identical by construction. Each
  arriving segment extends the idle allowance (`x-ttl` on the first event overrides it);
  client disconnects turn late segments into no-op drops; a client that stops reading
  beyond the idle allowance is truncated (the missing terminal event is the in-band
  truncation signal). Response header transforms (`headers.response` add/keep/drop)
  apply to the streamed head with single-shot parity.
- **Actuator (Java parity round):** `/info/routes` renders pool-style route families
  compactly - the 500 lanes appear as `"async.http.response.stream.0 - 499": 1` - and
  the rendered routing view is cached for 10 minutes.
- **Demo:** `examples/hello-world` gains `GET /api/hello/sse` (the `hello.sse`
  interceptor streams paced test messages) and `scripts/sse-client.mjs`, a
  zero-dependency Node 18+ consumer that prints each event with its arrival time.
- **Docs:** new "HTTP Response Streaming" guide, ADR-0015, Increment 91, CHANGELOG;
  the guide joined the ai-contract-provider files.list inventory.

## Why

Progressive delivery over plain HTTP is the prerequisite for AI-era workloads - chat
token streams, agent progress events, and live watch of long-running workflows - and
SSE is the industry's de facto wire for all three. The multi-shot reply route is the
event system's native streaming pattern (callee sends to the caller's `reply_to` until
done), so the feature adds no new substrate and stays language-neutral by construction.
Flows are engine-portable YAML and REST automation is engine surface, so the Java
feature and this port ship lock-step with engine-identical vocabulary, framing, and
messages - proven by a live demo run that is byte-identical to the Java twin
(intro immediately, ten messages exactly one second apart, `event: done`, socket close).

## Design notes

- Ordering uses the platform's own idiom - a single-instance route per active stream,
  drawn from a checkout pool (the "ready" signal pattern of the reactive manager/worker
  design). Lanes re-register on every server start (rebinding route workers to the
  current runtime, this port's documented idiom) while the pool fills exactly once per
  process - the pool tests caught and pinned a real registration race in the first cut.
- Known deferral unchanged: the Java `x-stream-id` relay remains out of scope for this
  port; `x-event-stream` wins over a stray `x-stream-id` with a warning, as in Java.

## Tests

- 21 new tests: progressive-delivery timing (incremental de-chunking reader with
  per-line arrival timestamps), typed and multi-line SSE framing, NDJSON, chunked text
  append, in-band mid-stream error, pre-head error as a normal HTTP error, eof-only
  stream, keep-alive pings, in-band idle timeout, touch-extends-life pacing, 8KB×50
  FIFO burst, four concurrent bursts, response-header-transform parity, single-shot
  fallback on a streaming endpoint, pool exhaustion → 503 → recovery, lane-return
  balance, LIFO reuse, and the producer-contract set - plus the `/info/routes`
  compression assertions.
- Full workspace: 65/65 test suites green; clippy 0; fmt clean; mkdocs strict clean;
  ai-contract-provider link validation green.

## Compatibility

Fully backward compatible. Responses without `x-event-stream` behave exactly as today;
HEAD requests never stream. One new config key (`event.stream.keep.alive`, default
30s). No new dependencies.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>