### PR TITLE
Event-over-HTTP peer streaming - envelope mode on the SSE relay (Phase 2 twin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,27 @@ the design rationale in [`draft-design-specs/`](draft-design-specs/).
    the stream in-band. Engine-identical with the Java engine's feature
    (Java PR #300). See the HTTP Response Streaming guide (ADR-0016).
 
+3. **Event-over-HTTP peer streaming (envelope mode)** - a remote streaming function
+   reached through `/api/event` can stream its segments back to the caller's reply
+   route on the same HTTP call. The caller opts in per event: a send with a
+   `reply_to` and the `accept: text/event-stream` event header; the `x-ttl` event
+   header (ms, default 60s) is the idle allowance between stream events on both
+   hops. On the wire, the peer answers with SSE in a hybrid dialect - control
+   signals (the head, the eof/exception terminals, and any segment that cannot
+   round-trip as plain text) ride base64-encoded serialized envelopes under the
+   reserved SSE event name `envelope`, while text segments ride raw frames - so
+   segment types and terminal metadata survive the hop exactly, and token relays
+   stay near-zero overhead. Compatibility is explicit: a non-streaming target
+   answers byte-identical to the classic callback reply; a streaming function
+   invoked without the opt-in (RPC, or no accept header) receives
+   `406 Streaming function requires a caller that accepts text/event-stream`;
+   server-side lane exhaustion answers the same 503 back-pressure as a local
+   streaming endpoint (plain RPC traffic never consumes a lane). The consuming
+   client guards the dialect (a missing envelope head or a transport end without a
+   terminal fail in-band), and every in-band exception body now carries the
+   standard error key-values (type/status/message). Engine-identical with the Java
+   engine's feature (Java PR #301). See the HTTP Response Streaming guide (ADR-0016).
+
 ### Changed
 
 1. The `/info/routes` actuator endpoint renders pool-style route families compactly:

--- a/crates/platform-core/Cargo.toml
+++ b/crates/platform-core/Cargo.toml
@@ -38,11 +38,12 @@ platform-macros = { path = "../platform-macros" }
 # --- increment 71: ManagedCache (docs/design/managed-cache-port.md — the Caffeine-lineage
 # engine, wrapped; EvictionPolicy::lru per the maintainer's deterministic-eviction ruling) ---
 moka = { version = "0.12", features = ["sync"] }
+# envelope frames of the Event-over-HTTP streaming dialect (also decodes the
+# golden envelope wire-format vectors in tests)
+base64 = "0.22"
 
 [dev-dependencies]
 # compile-fail guards for the macro surfaces (tests/ui)
 trybuild = "1"
 # self-signed certificates for the HTTPS client integration test (increment 48)
 rcgen = "0.13"
-# decode the golden envelope wire-format vectors (increment 59)
-base64 = "0.22"

--- a/crates/platform-core/src/app_starter.rs
+++ b/crates/platform-core/src/app_starter.rs
@@ -184,12 +184,20 @@ impl AppStarter {
         // the event-over-http service (Java EssentialServiceLoader): reached
         // through REST automation's default /api/event route. Registered
         // PRIVATE — it is never itself a remote target. 250 workers (Java
-        // parity: the endpoint fans out concurrent RPC forwards).
+        // parity: the endpoint fans out concurrent RPC forwards). An event
+        // INTERCEPTOR (Java @EventInterceptor parity): replies are sent
+        // manually, so the streaming relay can withhold its auto-reply.
         if !platform.has_route(crate::automation::EVENT_API_SERVICE) {
-            if let Err(e) = platform.register_private(
+            let event_api_options = crate::platform::FunctionOptions {
+                zero_traced: false,
+                interceptor: true,
+                private: true,
+            };
+            if let Err(e) = platform.register_with_options(
                 crate::automation::EVENT_API_SERVICE,
                 Arc::new(crate::automation::EventApiService::new(&platform)),
                 250,
+                event_api_options,
             ) {
                 if !platform.has_route(crate::automation::EVENT_API_SERVICE) {
                     return Err(e);

--- a/crates/platform-core/src/automation/event_api.rs
+++ b/crates/platform-core/src/automation/event_api.rs
@@ -57,6 +57,9 @@ pub const EVENT_API_SERVICE: &str = "event.api.service";
 pub const X_EVENT_API: &str = "x-event-api";
 
 const OCTET_STREAM: &str = "application/octet-stream";
+const TEXT_EVENT_STREAM: &str = "text/event-stream";
+const STREAM_CALLER_REQUIRED: &str =
+    "Streaming function requires a caller that accepts text/event-stream";
 const X_TTL: &str = "x-ttl";
 const X_ASYNC: &str = "x-async";
 /// Java `EventEmitter.X_NO_STREAM`: instructs the receiving side to return a
@@ -94,6 +97,34 @@ impl ComposableFunction for EventApiService {
         input: EventEnvelope,
         _instance: usize,
     ) -> Result<EventEnvelope, AppError> {
+        // registered as an event interceptor (Java @EventInterceptor parity):
+        // replies are sent manually to the edge's reply route with the edge
+        // context id, so the streaming branch can withhold its auto-reply
+        let Some(reply_to) = input.reply_to().map(str::to_string) else {
+            return Ok(EventEnvelope::new());
+        };
+        let context_id = input.correlation_id().unwrap_or_default().to_string();
+        let po = PostOffice::new(&self.platform);
+        if let Some(response) = self.dispatch(&po, &reply_to, &context_id, input).await? {
+            let _ = po
+                .send(response.set_to(&reply_to).set_correlation_id(&context_id))
+                .await;
+        }
+        Ok(EventEnvelope::new())
+    }
+}
+
+impl EventApiService {
+    /// Decode, validate and dispatch one /api/event call. Returns the reply
+    /// envelope for the single-shot modes, or None when the streaming relay
+    /// rewired the inner request onto the edge's reply lane.
+    async fn dispatch(
+        &self,
+        po: &PostOffice,
+        reply_to: &str,
+        context_id: &str,
+        input: EventEnvelope,
+    ) -> Result<Option<EventEnvelope>, AppError> {
         let request = AsyncHttpRequest::from_value(input.body());
         let timeout_ms = request
             .header(X_TTL)
@@ -101,27 +132,45 @@ impl ComposableFunction for EventApiService {
             .unwrap_or(0)
             .max(1000);
         let is_async = request.header(X_ASYNC) == Some("true");
+        let accepts_sse = request
+            .header("accept")
+            .is_some_and(|accept| accept.contains(TEXT_EVENT_STREAM));
+        // on the streaming-capable path the edge dispatched through a reply
+        // lane (envelope mode) and wraps every single-shot lane reply into the
+        // classic wire itself - so errors ride RAW here, exactly once wrapped;
+        // the other paths pack the classic wire as before
+        let capable = accepts_sse && !is_async;
+        let answer = |status: i32, message: &str| -> EventEnvelope {
+            if capable {
+                EventEnvelope::new()
+                    .set_status(status)
+                    .set_raw_body(Value::from(message))
+            } else {
+                reply(status, error_envelope(status, message))
+            }
+        };
         // the HTTP body is the serialized envelope; octet-stream arrives as a
         // MsgPack-binary body on the request map (Java parity)
         let Value::Binary(bytes) = request.body() else {
-            return Ok(reply(500, b"Invalid event-over-http data format".to_vec()));
+            return Ok(Some(if capable {
+                answer(500, "Invalid event-over-http data format")
+            } else {
+                reply(500, b"Invalid event-over-http data format".to_vec())
+            }));
         };
         // v1 accepts the standard wire format only (phase-2 decision); a
         // compact (all single-char keys) envelope is rejected clearly
         if is_compact_envelope(bytes) {
-            return Ok(reply(
+            return Ok(Some(answer(
                 400,
-                error_envelope(
-                    400,
-                    "compact format not supported - set event.over.http.format=standard on the sender",
-                ),
-            ));
+                "compact format not supported - set event.over.http.format=standard on the sender",
+            )));
         }
         let inner = match EventEnvelope::from_bytes(bytes) {
             Ok(envelope) => envelope,
             // the format is unknown when decode fails (Java falls back to a
             // compact error reply; we answer 400 with a plain message)
-            Err(e) => return Ok(reply(400, error_envelope(400, e.message()))),
+            Err(e) => return Ok(Some(answer(400, e.message()))),
         };
         // an inbound '@origin' suffix from a legacy/mesh-era peer is parsed
         // away — this port never generates one (Eric's ruling)
@@ -129,7 +178,7 @@ impl ComposableFunction for EventApiService {
             .to()
             .map(|to| crate::platform::bare_route(to).to_string())
         else {
-            return Ok(reply(400, error_envelope(400, "Missing routing path")));
+            return Ok(Some(answer(400, "Missing routing path")));
         };
         // session info injected by an authentication service on this /api/event
         // entry rides to the target function as read-only headers (Java parity:
@@ -139,15 +188,11 @@ impl ComposableFunction for EventApiService {
             inner = inner.set_header(key, value);
         }
         if !self.platform.has_route(&to) {
-            return Ok(reply(
-                404,
-                error_envelope(404, &format!("Route {to} not found")),
-            ));
+            return Ok(Some(answer(404, &format!("Route {to} not found"))));
         }
         if self.platform.is_private(&to) == Some(true) {
-            return Ok(reply(403, error_envelope(403, &format!("{to} is private"))));
+            return Ok(Some(answer(403, &format!("{to} is private"))));
         }
-        let po = PostOffice::new(&self.platform);
         if is_async {
             // drop-n-forget: deliver and acknowledge (Java 202 ack shape)
             po.send(inner).await?;
@@ -158,15 +203,45 @@ impl ComposableFunction for EventApiService {
                     "delivered": true,
                     "time": crate::trace::iso8601_utc_now(),
                 }))?;
-            Ok(reply(200, ack.to_bytes()?))
+            Ok(Some(reply(200, ack.to_bytes()?)))
+        } else if accepts_sse {
+            // streaming-capable relay: the edge dispatched this call through a
+            // dedicated reply lane (stream_dispatch, envelope mode) - rewire
+            // the inner request onto that lane so the target streams straight
+            // to it, with the edge context id as the correlation id (exactly
+            // the rewrite the RPC inbox would make). A non-streaming target's
+            // single reply takes the same lane and renders byte-identical to
+            // the classic RPC response.
+            let inner = inner.set_reply_to(reply_to).set_correlation_id(context_id);
+            po.send(inner).await?;
+            Ok(None)
         } else {
-            // RPC: forward and mirror the target's envelope back (or 408)
+            // RPC: forward and mirror the target's envelope back (or 408).
+            // A streaming reply cannot ride a single-shot response: answer
+            // with an explicit refusal instead of a truncated first segment.
             match po.request(inner, Duration::from_millis(timeout_ms)).await {
-                Ok(result) => Ok(reply(200, result.to_bytes()?)),
-                Err(e) => Ok(reply(408, error_envelope(408, e.message()))),
+                Ok(result) => {
+                    if has_stream_marker(&result) {
+                        Ok(Some(reply(
+                            406,
+                            error_envelope(406, STREAM_CALLER_REQUIRED),
+                        )))
+                    } else {
+                        Ok(Some(reply(200, result.to_bytes()?)))
+                    }
+                }
+                Err(e) => Ok(Some(reply(408, error_envelope(408, e.message())))),
             }
         }
     }
+}
+
+/// True when the envelope carries the reserved x-event-stream marker.
+fn has_stream_marker(event: &EventEnvelope) -> bool {
+    event
+        .headers()
+        .iter()
+        .any(|(name, _)| name.eq_ignore_ascii_case(crate::event_stream::X_EVENT_STREAM))
 }
 
 /// Build the HTTP response envelope: the body is a serialized envelope carried
@@ -275,24 +350,7 @@ pub async fn event_over_http_with_headers(
     for (key, value) in security_headers {
         http = http.set_header(key, value);
     }
-    // trace propagation (Java sets both headers so the receiver chains onto
-    // this span as its parent). When a custom traceparent header name is
-    // configured (http.traceparent.header), the same value is stamped under
-    // that name too, so the trace context survives an intermediary that
-    // strips the standard header.
-    if let Some(trace_id) = &trace_id {
-        http = http.set_header("x-trace-id", trace_id);
-        if let Some(span_id) = &span_id {
-            if let Some(traceparent) = w3c_trace::format(trace_id, span_id) {
-                http = http.set_header(w3c_trace::TRACEPARENT, &traceparent);
-                let custom_traceparent = AppConfigReader::get_instance()
-                    .get_property_or("http.traceparent.header", w3c_trace::TRACEPARENT);
-                if !custom_traceparent.eq_ignore_ascii_case(w3c_trace::TRACEPARENT) {
-                    http = http.set_header(&custom_traceparent, &traceparent);
-                }
-            }
-        }
-    }
+    http = stamp_trace_headers(http, trace_id.as_deref(), span_id.as_deref());
     let http_event = EventEnvelope::new()
         .set_to(ASYNC_HTTP_REQUEST)
         .set_raw_body(http.to_value());
@@ -314,6 +372,32 @@ pub async fn event_over_http_with_headers(
         Value::Binary(bytes) => EventEnvelope::from_bytes(bytes),
         _ => Ok(response),
     }
+}
+
+/// Trace propagation of an Event-over-HTTP call (Java sets both headers so the
+/// receiver chains onto this span as its parent): `x-trace-id` plus the W3C
+/// `traceparent`. When a custom traceparent header name is configured
+/// (`http.traceparent.header`), the same value is stamped under that name too,
+/// so the trace context survives an intermediary that strips the standard header.
+fn stamp_trace_headers(
+    mut http: AsyncHttpRequest,
+    trace_id: Option<&str>,
+    span_id: Option<&str>,
+) -> AsyncHttpRequest {
+    if let Some(trace_id) = trace_id {
+        http = http.set_header("x-trace-id", trace_id);
+        if let Some(span_id) = span_id {
+            if let Some(traceparent) = w3c_trace::format(trace_id, span_id) {
+                http = http.set_header(w3c_trace::TRACEPARENT, &traceparent);
+                let custom_traceparent = AppConfigReader::get_instance()
+                    .get_property_or("http.traceparent.header", w3c_trace::TRACEPARENT);
+                if !custom_traceparent.eq_ignore_ascii_case(w3c_trace::TRACEPARENT) {
+                    http = http.set_header(&custom_traceparent, &traceparent);
+                }
+            }
+        }
+    }
+    http
 }
 
 /// Split `http://host:port/api/event` into (`http://host:port`, `/api/event`).
@@ -448,6 +532,13 @@ pub(crate) fn send_with_event_http(
     entry: &'static EventHttpTarget,
 ) -> Result<(), AppError> {
     let callback = event.reply_to().map(str::to_string);
+    if let Some(callback) = &callback {
+        if accepts_event_stream_header(&event) {
+            // the event-level opt-in for progressive streaming over
+            // Event-over-HTTP: "accept: text/event-stream"
+            return relay_event_stream(platform, event, to, entry, callback.clone());
+        }
+    }
     let event_api_type = if callback.is_some() {
         "callback"
     } else {
@@ -509,6 +600,112 @@ pub(crate) fn send_with_event_http(
                     e.message()
                 );
             }
+        }
+    });
+    Ok(())
+}
+
+/// The event-level opt-in for progressive streaming over Event-over-HTTP:
+/// the outbound event declares the header `accept: text/event-stream`.
+fn accepts_event_stream_header(event: &EventEnvelope) -> bool {
+    event.headers().iter().any(|(name, value)| {
+        name.eq_ignore_ascii_case("accept") && value.contains(TEXT_EVENT_STREAM)
+    })
+}
+
+/// Streaming-capable Event-over-HTTP relay (callback mode with the accept
+/// opt-in, Java `EventEmitter.relayEventStream`): the POST advertises
+/// `Accept: text/event-stream` and the caller's reply route and correlation id
+/// pass through to the HTTP client, which consumes the peer's SSE response
+/// progressively (the envelope-mode wire dialect) and forwards each decoded
+/// event to the callback. A peer that answers single-shot - a non-streaming
+/// target, or an older engine - falls back to the classic callback delivery.
+/// The event's `x-ttl` header (milliseconds, default 60 seconds) is the idle
+/// allowance between stream events on both hops.
+fn relay_event_stream(
+    platform: &Platform,
+    event: EventEnvelope,
+    to: &str,
+    entry: &'static EventHttpTarget,
+    callback: String,
+) -> Result<(), AppError> {
+    let ttl_ms = event
+        .headers()
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(X_TTL))
+        .and_then(|(_, value)| value.trim().parse::<u64>().ok())
+        .map_or(ASYNC_EVENT_HTTP_TIMEOUT.as_millis() as u64, |v| v.max(1000));
+    // the wire envelope carries the caller's trace lineage (fill-if-absent id
+    // and path, the caller's span) so the remote function parents onto it
+    let forward = crate::post_office::apply_current_trace(
+        event
+            .clear_reply_to()
+            .set_header(X_EVENT_API, crate::automation::http_client::STREAM_RELAY),
+    );
+    let cid = forward.correlation_id().map(str::to_string);
+    let trace_id = forward.trace_id().map(str::to_string);
+    let trace_path = forward.trace_path().map(str::to_string);
+    let span_id = forward.span_id().map(str::to_string);
+    let platform = platform.clone();
+    let to = to.to_string();
+    tokio::spawn(async move {
+        let (host, path) = match split_endpoint(&entry.target) {
+            Ok(parts) => parts,
+            Err(e) => {
+                log::error!(
+                    "Unable to relay event stream {to} to {} - {}",
+                    entry.target,
+                    e.message()
+                );
+                return;
+            }
+        };
+        let payload = match forward.to_bytes() {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                log::error!(
+                    "Unable to relay event stream {to} to {} - {}",
+                    entry.target,
+                    e.message()
+                );
+                return;
+            }
+        };
+        let mut http = AsyncHttpRequest::new()
+            .set_method("POST")
+            .set_url(&path)
+            .set_target_host(&host)
+            .set_header("content-type", OCTET_STREAM)
+            .set_header(X_NO_STREAM, "true")
+            .set_header("accept", TEXT_EVENT_STREAM)
+            .set_header(X_TTL, &ttl_ms.to_string())
+            // the engine's own transport leg: the client must not stamp the
+            // business correlation-id header on it (event_over_http parity)
+            .set_header(X_EVENT_API, "true")
+            .set_body(Value::Binary(payload));
+        for (key, value) in &entry.headers {
+            http = http.set_header(key, value);
+        }
+        http = stamp_trace_headers(http, trace_id.as_deref(), span_id.as_deref());
+        let mut http_event = EventEnvelope::new()
+            .set_to(ASYNC_HTTP_REQUEST)
+            .set_raw_body(http.to_value())
+            .set_reply_to(&callback)
+            .set_from(&to)
+            .set_header(X_EVENT_API, crate::automation::http_client::STREAM_RELAY);
+        if let Some(cid) = &cid {
+            http_event = http_event.set_correlation_id(cid);
+        }
+        if let (Some(id), Some(path)) = (&trace_id, &trace_path) {
+            http_event = http_event.set_trace(id, path);
+        }
+        let po = PostOffice::new(&platform);
+        if let Err(e) = po.send(http_event).await {
+            log::error!(
+                "Unable to relay event stream {to} to {} - {}",
+                entry.target,
+                e.message()
+            );
         }
     });
     Ok(())

--- a/crates/platform-core/src/automation/http_client.rs
+++ b/crates/platform-core/src/automation/http_client.rs
@@ -53,6 +53,10 @@ use crate::util::app_config_reader::AppConfigReader;
 use crate::util::w3c_trace;
 
 pub const ASYNC_HTTP_REQUEST: &str = "async.http.request";
+/// The `x-event-api` marker value of the streaming-capable Event-over-HTTP
+/// relay: the request event carrying it opts the SSE consumption into the
+/// envelope-mode wire dialect (Java `EventEmitter.STREAM_RELAY`).
+pub const STREAM_RELAY: &str = "stream";
 const USER_AGENT_NAME: &str = "async-http-client";
 const DEFAULT_TTL_SECONDS: u64 = 30;
 /// Headers that may interfere with the underlying HTTP client (Java parity).
@@ -640,6 +644,17 @@ fn display_text(value: &Value) -> String {
 
 /// The interceptor body: process the request and reply manually with the
 /// decoded HTTP response (or an error envelope).
+/// The reply routing of one client call, when the caller supplied a reply_to.
+/// `envelope_mode` marks the Event-over-HTTP streaming relay leg (the request
+/// event carries `x-event-api: stream`): an SSE response decodes as the
+/// envelope-mode wire dialect and a buffered reply decodes as a serialized
+/// envelope, preserving the classic callback semantics.
+struct StreamTarget {
+    reply_to: String,
+    cid: String,
+    envelope_mode: bool,
+}
+
 pub(crate) async fn handle(
     platform: &Platform,
     _headers: HashMap<String, String>,
@@ -654,7 +669,14 @@ pub(crate) async fn handle(
         return EventEnvelope::new().set_body("ignored");
     };
     let cid = event.correlation_id().unwrap_or_default().to_string();
-    let stream_target = Some((reply_to.clone(), cid.clone()));
+    let envelope_mode = event.headers().iter().any(|(name, value)| {
+        name.eq_ignore_ascii_case(super::event_api::X_EVENT_API) && value == STREAM_RELAY
+    });
+    let stream_target = Some(StreamTarget {
+        reply_to: reply_to.clone(),
+        cid: cid.clone(),
+        envelope_mode,
+    });
     let response = match process_request(platform, &po, &_headers, &event, stream_target).await {
         // a progressive SSE relay was spawned - it owns the reply route now
         Ok(None) => return EventEnvelope::new().set_body("ignored"),
@@ -683,7 +705,7 @@ async fn process_request(
     po: &PostOffice,
     invocation_headers: &HashMap<String, String>,
     event: &EventEnvelope,
-    stream_target: Option<(String, String)>,
+    stream_target: Option<StreamTarget>,
 ) -> Result<Option<EventEnvelope>, AppError> {
     let request = AsyncHttpRequest::from_value(event.body());
     let (secure, host, port) = validate_url(&request)?;
@@ -784,22 +806,36 @@ async fn process_request(
     // x-event-stream data envelope to the caller's reply route (the producer
     // contract the HTTP edge consumes), then eof. The relay runs in its own task
     // so this worker is freed - a long stream never holds a client instance.
-    if let Some((reply_to, cid)) = stream_target {
+    let envelope_mode = stream_target.as_ref().is_some_and(|t| t.envelope_mode);
+    if let Some(target) = stream_target {
         let sse = content_type
             .as_deref()
             .is_some_and(|ct| ct.starts_with("text/event-stream"));
         if sse && accepts_event_stream(&request) {
-            let idle = Duration::from_secs(request.timeout_seconds().max(1));
             let status = http_response.status().as_u16() as i32;
             let relay_platform = platform.clone();
-            tokio::spawn(relay_sse(
-                relay_platform,
-                http_response.into_body(),
-                status,
-                reply_to,
-                cid,
-                idle,
-            ));
+            if target.envelope_mode {
+                // one extra second so the peer's in-band 408, sent AT the
+                // deadline, wins the race against the local idle timer
+                let idle = Duration::from_secs(request.timeout_seconds().max(1) + 1);
+                tokio::spawn(relay_envelope_sse(
+                    relay_platform,
+                    http_response.into_body(),
+                    target.reply_to,
+                    target.cid,
+                    idle,
+                ));
+            } else {
+                let idle = Duration::from_secs(request.timeout_seconds().max(1));
+                tokio::spawn(relay_sse(
+                    relay_platform,
+                    http_response.into_body(),
+                    status,
+                    target.reply_to,
+                    target.cid,
+                    idle,
+                ));
+            }
             return Ok(None);
         }
     }
@@ -809,6 +845,11 @@ async fn process_request(
         .await
         .map_err(|e| AppError::new(500, format!("Unable to read HTTP response - {e}")))?
         .to_bytes();
+    if envelope_mode {
+        // the peer answered single-shot (a non-streaming target, or an edge
+        // error) - decode and deliver with the classic callback semantics
+        return Ok(Some(decode_relay_reply(&bytes, response.status())));
+    }
     if !has_content_length {
         response = response.set_header("x-content-length", &bytes.len().to_string());
     }
@@ -816,6 +857,45 @@ async fn process_request(
         &bytes,
         content_type.as_deref(),
     ))))
+}
+
+/// Decode a single-shot Event-over-HTTP reply: a serialized envelope normally,
+/// with the classic tolerant handling of an edge-level REST error body
+/// (`'{"type": "error", "status": n, "message": text}'` JSON) and of a payload
+/// that is not a serialized envelope at all.
+fn decode_relay_reply(bytes: &[u8], http_status: i32) -> EventEnvelope {
+    if bytes.is_empty() {
+        return EventEnvelope::new().set_status(http_status);
+    }
+    match EventEnvelope::from_bytes(bytes) {
+        Ok(envelope) => envelope.clear_reply_to(),
+        Err(e) => rest_error_reply(bytes, http_status).unwrap_or_else(|| {
+            EventEnvelope::new()
+                .set_status(400)
+                .set_raw_body(Value::from(format!(
+                    "Did you configure rest.yaml correctly? Invalid result set - {}",
+                    e.message()
+                )))
+        }),
+    }
+}
+
+/// An edge-level REST error arrives as JSON, not as a serialized envelope -
+/// unwrap it exactly as the classic relay does.
+fn rest_error_reply(bytes: &[u8], http_status: i32) -> Option<EventEnvelope> {
+    if http_status < 400 {
+        return None;
+    }
+    let data = serde_json::from_slice::<serde_json::Value>(bytes).ok()?;
+    if data.get("type").and_then(|v| v.as_str()) != Some("error") {
+        return None;
+    }
+    let message = data.get("message").and_then(|v| v.as_str())?;
+    Some(
+        EventEnvelope::new()
+            .set_status(http_status)
+            .set_raw_body(Value::from(message)),
+    )
 }
 
 /// Incremental SSE frame parser (raw mode): byte-level line split (a newline
@@ -943,6 +1023,138 @@ async fn relay_sse(
     }
 }
 
+/// The spawned relay of an Event-over-HTTP streaming response (envelope mode):
+/// an "envelope" frame carries one base64-encoded serialized EventEnvelope -
+/// the head, the terminals and non-text segments; any other frame is a raw
+/// text segment. Decoded events forward to the original caller's reply route
+/// with the original correlation id; a decoded terminal (eof or exception)
+/// ends the logical stream and trailing frames are discarded. Dialect guards:
+/// the first frame must be an envelope frame, and a transport end without a
+/// decoded terminal is a truncation - both fail in-band.
+async fn relay_envelope_sse(
+    platform: Platform,
+    mut body: hyper::body::Incoming,
+    reply_to: String,
+    cid: String,
+    idle: Duration,
+) {
+    let po = PostOffice::new(&platform);
+    let mut parser = SseParser::default();
+    let mut head_seen = false;
+    loop {
+        match tokio::time::timeout(idle, body.frame()).await {
+            Ok(Some(Ok(frame))) => {
+                if let Some(data) = frame.data_ref() {
+                    for (name, text) in parser.feed(data) {
+                        match relay_envelope_event(&po, name, text, &reply_to, &cid, &mut head_seen)
+                            .await
+                        {
+                            RelayFlow::Next => {}
+                            // a decoded terminal ends the logical stream -
+                            // frames after it (and the transport end) are
+                            // discarded by returning here
+                            RelayFlow::End => return,
+                        }
+                    }
+                }
+            }
+            Ok(None) => {
+                // the dialect ends with a decoded terminal - a bare transport
+                // end is a truncation
+                fail_in_band(
+                    &po,
+                    &reply_to,
+                    &cid,
+                    500,
+                    "Event stream ended without eof",
+                    head_seen,
+                )
+                .await;
+                return;
+            }
+            Ok(Some(Err(e))) => {
+                fail_in_band(&po, &reply_to, &cid, 500, &e.to_string(), head_seen).await;
+                return;
+            }
+            Err(_) => {
+                let message = format!("Timeout for {} seconds", idle.as_secs());
+                fail_in_band(&po, &reply_to, &cid, 408, &message, head_seen).await;
+                return;
+            }
+        }
+    }
+}
+
+/// What one envelope-mode frame did to the relay.
+enum RelayFlow {
+    Next,
+    End,
+}
+
+async fn relay_envelope_event(
+    po: &PostOffice,
+    name: Option<String>,
+    text: String,
+    reply_to: &str,
+    cid: &str,
+    head_seen: &mut bool,
+) -> RelayFlow {
+    use base64::Engine as _;
+    if name.as_deref() == Some(event_stream::ENVELOPE) {
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&text)
+            .ok()
+            .and_then(|bytes| EventEnvelope::from_bytes(&bytes).ok());
+        let Some(decoded) = decoded else {
+            fail_in_band(
+                po,
+                reply_to,
+                cid,
+                500,
+                "Invalid event stream - malformed envelope frame",
+                *head_seen,
+            )
+            .await;
+            return RelayFlow::End;
+        };
+        *head_seen = true;
+        let terminal = decoded.headers().iter().any(|(key, value)| {
+            key.eq_ignore_ascii_case(event_stream::X_EVENT_STREAM)
+                && (value.eq_ignore_ascii_case(event_stream::EOF)
+                    || value.eq_ignore_ascii_case(event_stream::EXCEPTION))
+        });
+        let _ = send_segment(po, decoded.clear_reply_to(), reply_to, cid).await;
+        if terminal {
+            RelayFlow::End
+        } else {
+            RelayFlow::Next
+        }
+    } else if !*head_seen {
+        // the dialect guarantees an envelope frame first (conformance guard)
+        fail_in_band(
+            po,
+            reply_to,
+            cid,
+            500,
+            "Invalid event stream - missing envelope head",
+            false,
+        )
+        .await;
+        RelayFlow::End
+    } else {
+        // a raw frame is one plain text segment
+        let mut segment =
+            EventEnvelope::new().set_header(event_stream::X_EVENT_STREAM, event_stream::DATA);
+        if let Some(name) = name.filter(|n| !n.is_empty()) {
+            segment = segment.set_header(event_stream::X_EVENT_NAME, &name);
+        }
+        if let Ok(segment) = segment.set_body(text) {
+            let _ = send_segment(po, segment, reply_to, cid).await;
+        }
+        RelayFlow::Next
+    }
+}
+
 async fn fail_in_band(
     po: &PostOffice,
     reply_to: &str,
@@ -951,7 +1163,8 @@ async fn fail_in_band(
     message: &str,
     head_sent: bool,
 ) {
-    let body = serde_json::json!({"status": status, "message": message});
+    // the standard error key-values: '{"type": "error", "status": n, "message": text}'
+    let body = serde_json::json!({"type": "error", "status": status, "message": message});
     let Ok(mut error) = EventEnvelope::new()
         .set_header(event_stream::X_EVENT_STREAM, event_stream::EXCEPTION)
         .set_status(status)

--- a/crates/platform-core/src/automation/server.rs
+++ b/crates/platform-core/src/automation/server.rs
@@ -704,9 +704,14 @@ async fn process(
         }
     }
     let is_head = method == "HEAD";
+    // a streaming-capable /api/event call (Accept: text/event-stream, not
+    // drop-n-forget) dispatches through a dedicated reply lane rendering the
+    // envelope-mode wire dialect - so a remote peer's streaming function can
+    // answer the one POST progressively; plain RPC calls never consume a lane
+    let envelope_stream = !is_head && is_event_api_stream(info, &http_request);
     // a streaming endpoint (rest.yaml `stream: true`) uses the multi-shot
     // reply route; HEAD requests never stream (Java parity)
-    let result = if info.stream_response && !is_head {
+    let result = if (info.stream_response && !is_head) || envelope_stream {
         match stream_dispatch(
             state,
             info,
@@ -717,6 +722,7 @@ async fn process(
             &trace_path,
             &parent_span,
             accept.clone(),
+            envelope_stream,
         )
         .await?
         {
@@ -964,11 +970,39 @@ fn stream_event_name(event: &EventEnvelope) -> Option<&str> {
         .map(|(_, value)| value.as_str())
 }
 
+/// True when this request is a streaming-capable Event-over-HTTP call: the
+/// /api/event service, invoked with `Accept: text/event-stream` and not
+/// drop-n-forget. Such a call dispatches through a reply lane in envelope
+/// mode - the EventApiService rewires the inner request onto the lane so a
+/// streaming target's segments relay straight to the wire.
+fn is_event_api_stream(info: &RouteInfo, request: &crate::automation::AsyncHttpRequest) -> bool {
+    info.service == super::event_api::EVENT_API_SERVICE
+        && request.header("x-async") != Some("true")
+        && request
+            .header("accept")
+            .is_some_and(|accept| accept.contains("text/event-stream"))
+}
+
+/// The idle allowance of a streaming-capable Event-over-HTTP call: the POST's
+/// x-ttl header in milliseconds (the caller's declaration), floor one second -
+/// the same reading the EventApiService applies (Java parity).
+fn event_api_idle(request: &crate::automation::AsyncHttpRequest) -> Duration {
+    let ttl_ms = request
+        .header("x-ttl")
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(0)
+        .max(1000);
+    Duration::from_millis(ttl_ms)
+}
+
 /// Dispatch to a streaming endpoint: check out a dedicated ordered reply
 /// lane, send the request with `reply_to` = that lane, and turn the event
 /// sequence into a progressive HTTP response. The first event decides the
 /// shape: unmarked = ordinary single-shot; `exception` before the head = a
 /// normal HTTP error; `data`/`eof` commit the head and start the renderer.
+/// In envelope mode (the Event-over-HTTP streaming relay) the wire is the
+/// hybrid dialect and a pre-head exception still rides the stream, so the
+/// caller always receives the exact envelope.
 #[allow(clippy::too_many_arguments)]
 async fn stream_dispatch(
     state: &RouterState,
@@ -980,6 +1014,7 @@ async fn stream_dispatch(
     trace_path: &str,
     parent_span: &Option<String>,
     accept: Option<String>,
+    envelope_mode: bool,
 ) -> Result<StreamOutcome, AppError> {
     // a streaming endpoint borrows a dedicated ordered reply lane for the
     // lifetime of the request - an empty pool means full streaming capacity
@@ -1007,9 +1042,16 @@ async fn stream_dispatch(
         cleanup_stream(&context_id, &lane);
         return Err(e);
     }
-    // await the first event; the endpoint timeout is the idle allowance
+    // the idle allowance: the endpoint timeout, or the caller-declared x-ttl
+    // for a streaming-capable Event-over-HTTP call
+    let base_idle = if envelope_mode {
+        event_api_idle(http_request)
+    } else {
+        info.timeout
+    };
+    // await the first event within the idle allowance
     let (first, marker) = loop {
-        match tokio::time::timeout(info.timeout, rx.recv()).await {
+        match tokio::time::timeout(base_idle, rx.recv()).await {
             Ok(Some(envelope)) => match stream_marker(&envelope) {
                 Ok(Some(marker)) => break (envelope, Some(marker)),
                 Ok(None) => break (envelope, None),
@@ -1029,18 +1071,28 @@ async fn stream_dispatch(
                 cleanup_stream(&context_id, &lane);
                 return Err(AppError::new(
                     408,
-                    format!("Timeout for {} ms", info.timeout.as_millis()),
+                    format!("Timeout for {} ms", base_idle.as_millis()),
                 ));
             }
         }
     };
     let Some(marker) = marker else {
-        // the endpoint answered single-shot - render exactly as before
+        // the endpoint answered single-shot - render exactly as before; in
+        // envelope mode the reply is wrapped into the classic Event-over-HTTP
+        // wire (the whole envelope as a serialized octet-stream body), so a
+        // non-streaming target stays byte-identical to the RPC path
         cleanup_stream(&context_id, &lane);
-        return Ok(StreamOutcome::SingleShot(first));
+        let reply = if envelope_mode {
+            wire_single_shot(first)?
+        } else {
+            first
+        };
+        return Ok(StreamOutcome::SingleShot(reply));
     };
-    if marker == event_stream::EXCEPTION {
+    if marker == event_stream::EXCEPTION && !envelope_mode {
         // failure before the head is committed - render a normal HTTP error
+        // (in envelope mode a pre-head failure still rides the stream, so the
+        // caller receives the exact error envelope)
         cleanup_stream(&context_id, &lane);
         let status = if first.status() >= 400 {
             first.status()
@@ -1075,6 +1127,9 @@ async fn stream_dispatch(
                     }
                 }
             }
+            // in envelope mode the target's own headers stay inside the
+            // envelope frames; only endpoint-level headers reach the wire
+            _ if envelope_mode => {}
             "content-type" => content_type = Some(value.to_lowercase()),
             "set-cookie" => {
                 set_cookies.extend(value.split('|').map(|c| c.trim().to_string()));
@@ -1098,7 +1153,12 @@ async fn stream_dispatch(
             response_headers.insert(name.to_lowercase(), value.clone());
         }
     }
-    let content_type = content_type.unwrap_or_else(|| negotiate_stream_type(accept.as_deref()));
+    // envelope mode is always SSE on the wire; raw mode negotiates
+    let content_type = if envelope_mode {
+        "text/event-stream".to_string()
+    } else {
+        content_type.unwrap_or_else(|| negotiate_stream_type(accept.as_deref()))
+    };
     let sse = content_type.starts_with("text/event-stream");
     if sse {
         // default for SSE - an explicit event header or transform add wins
@@ -1106,7 +1166,7 @@ async fn stream_dispatch(
             .entry("cache-control".to_string())
             .or_insert_with(|| "no-cache".to_string());
     }
-    let idle = idle_override.unwrap_or(info.timeout);
+    let idle = idle_override.unwrap_or(base_idle);
     let mut builder = Response::builder().status(status_of(first.status()));
     for (name, value) in &response_headers {
         builder = builder.header(name, value);
@@ -1122,7 +1182,15 @@ async fn stream_dispatch(
         .body(BoxBody::new(ChannelBody { rx: body_rx }))
         .map_err(|e| AppError::new(500, e.to_string()))?;
     tokio::spawn(render_stream(
-        rx, body_tx, sse, idle, context_id, lane, first, marker,
+        rx,
+        body_tx,
+        sse,
+        idle,
+        context_id,
+        lane,
+        first,
+        marker,
+        envelope_mode,
     ));
     Ok(StreamOutcome::Streaming(response))
 }
@@ -1209,6 +1277,10 @@ async fn push_frame(
 /// writes SSE or chunked frames until end of transmission, an in-band error,
 /// an idle timeout, or a gone/too-slow client. Always returns the lane to
 /// the pool at the end (Java: closeContext, the termination funnel).
+/// In envelope mode the wire is the hybrid dialect: envelope frames wherever
+/// envelope semantics matter (the first event, the terminals, non-text
+/// segments), raw SSE frames for plain text - and no cosmetic done/error
+/// frames, because the decoded terminal envelope is the signal.
 #[allow(clippy::too_many_arguments)]
 async fn render_stream(
     mut rx: mpsc::Receiver<EventEnvelope>,
@@ -1219,8 +1291,10 @@ async fn render_stream(
     lane: String,
     first: EventEnvelope,
     first_marker: &'static str,
+    envelope_mode: bool,
 ) {
     let mut pending = Some((first, first_marker));
+    let mut first_frame = true;
     loop {
         let (event, marker) = match pending.take() {
             Some(next) => next,
@@ -1237,7 +1311,10 @@ async fn render_stream(
                 },
                 Waited::Idle => {
                     // fail the stream in-band (Java housekeeper parity)
-                    if sse {
+                    if envelope_mode {
+                        let frame = idle_timeout_envelope_frame(idle);
+                        let _ = push_frame(&body_tx, idle, &context_id, frame).await;
+                    } else if sse {
                         let error = serde_json::json!({
                             "status": 408,
                             "message": format!("Timeout for {} seconds", idle.as_secs()),
@@ -1253,7 +1330,9 @@ async fn render_stream(
         };
         match marker {
             event_stream::DATA => {
-                let bytes = if sse {
+                let bytes = if envelope_mode {
+                    envelope_mode_data_frame(&event, first_frame)
+                } else if sse {
                     if matches!(event.body(), rmpv::Value::Nil) {
                         Bytes::new()
                     } else {
@@ -1262,12 +1341,16 @@ async fn render_stream(
                 } else {
                     chunk_bytes(event.body())
                 };
+                first_frame = false;
                 if !push_frame(&body_tx, idle, &context_id, bytes).await {
                     break;
                 }
             }
             event_stream::EOF => {
-                if sse {
+                if envelope_mode {
+                    let frame = envelope_wire_frame(&event);
+                    let _ = push_frame(&body_tx, idle, &context_id, frame).await;
+                } else if sse {
                     let text = if matches!(event.body(), rmpv::Value::Nil) {
                         "{}".to_string()
                     } else {
@@ -1279,9 +1362,13 @@ async fn render_stream(
                 break;
             }
             _ => {
-                // in-band failure after the head is committed: SSE renders an
-                // error event; chunked mode truncates (Java parity)
-                if sse {
+                // in-band failure after the head is committed: envelope mode
+                // frames the exact envelope; SSE renders an error event;
+                // chunked mode truncates (Java parity)
+                if envelope_mode {
+                    let frame = envelope_wire_frame(&event);
+                    let _ = push_frame(&body_tx, idle, &context_id, frame).await;
+                } else if sse {
                     let status = if event.status() >= 400 {
                         event.status()
                     } else {
@@ -1300,6 +1387,87 @@ async fn render_stream(
         }
     }
     cleanup_stream(&context_id, &lane);
+}
+
+/// One envelope-mode data frame: the first event always rides an envelope
+/// frame (it carries the head control), a losslessly raw-able text segment
+/// rides a raw SSE frame, a bare no-op segment carries nothing, and anything
+/// else takes the envelope-frame escape hatch.
+fn envelope_mode_data_frame(event: &EventEnvelope, first_frame: bool) -> Bytes {
+    if first_frame || !raw_streamable(event) {
+        envelope_wire_frame(event)
+    } else if matches!(event.body(), rmpv::Value::Nil) {
+        Bytes::new()
+    } else {
+        sse_frame(stream_event_name(event), &stream_text(event.body()))
+    }
+}
+
+/// A data segment may ride a raw SSE frame only when the frame carries it
+/// losslessly: a 200 status, no custom envelope headers, a user event name
+/// clear of the reserved word, and a Nil-or-text body without a carriage
+/// return (SSE normalizes line endings). Everything else takes the
+/// envelope-frame escape hatch.
+fn raw_streamable(event: &EventEnvelope) -> bool {
+    if event.status() != 200 {
+        return false;
+    }
+    for (name, value) in event.headers() {
+        let key = name.to_lowercase();
+        let reserved = key == event_stream::X_EVENT_STREAM
+            || key == event_stream::X_EVENT_NAME
+            || key == "x-ttl";
+        if !reserved || (key == event_stream::X_EVENT_NAME && value == event_stream::ENVELOPE) {
+            return false;
+        }
+    }
+    match event.body() {
+        rmpv::Value::Nil => true,
+        rmpv::Value::String(text) => !text.as_str().unwrap_or_default().contains('\r'),
+        _ => false,
+    }
+}
+
+/// The classic Event-over-HTTP single-shot wire: the whole reply envelope as
+/// a serialized byte body with an octet-stream content type and outer status
+/// 200 (the real status rides inside - Java sendResponse parity).
+fn wire_single_shot(result: EventEnvelope) -> Result<EventEnvelope, AppError> {
+    let bytes = result.clear_to().clear_reply_to().to_bytes()?;
+    Ok(EventEnvelope::new()
+        .set_status(200)
+        .set_header("content-type", "application/octet-stream")
+        .set_raw_body(rmpv::Value::Binary(bytes)))
+}
+
+/// One envelope-mode wire frame: the envelope serialized verbatim - with the
+/// server-internal addressing cleared, because the consuming relay rewrites
+/// addressing to the original caller - as base64 under the reserved SSE event
+/// name "envelope".
+fn envelope_wire_frame(event: &EventEnvelope) -> Bytes {
+    use base64::Engine as _;
+    let wire = event.clone().clear_to().clear_reply_to();
+    match wire.to_bytes() {
+        Ok(bytes) => sse_frame(
+            Some(event_stream::ENVELOPE),
+            &base64::engine::general_purpose::STANDARD.encode(bytes),
+        ),
+        Err(_) => Bytes::new(),
+    }
+}
+
+/// The in-band idle-timeout terminal of an envelope-mode stream: an exception
+/// envelope with the standard error key-values, framed for the wire
+/// (Java housekeeper-abort parity).
+fn idle_timeout_envelope_frame(idle: Duration) -> Bytes {
+    let message = format!("Timeout for {} seconds", idle.as_secs());
+    let error = EventEnvelope::new()
+        .set_header(event_stream::X_EVENT_STREAM, event_stream::EXCEPTION)
+        .set_status(408)
+        .set_body(serde_json::json!({"type": "error", "status": 408, "message": message}));
+    match error {
+        Ok(envelope) => envelope_wire_frame(&envelope),
+        Err(_) => Bytes::new(),
+    }
 }
 
 fn build_event(

--- a/crates/platform-core/src/envelope.rs
+++ b/crates/platform-core/src/envelope.rs
@@ -153,6 +153,15 @@ impl EventEnvelope {
         self
     }
 
+    /// Remove the routing address (Java `setTo(null)`) — used when an envelope
+    /// is serialized for a wire that rewrites addressing on the consuming side,
+    /// e.g. the envelope-mode streaming frames, so a server-internal route name
+    /// never leaks.
+    pub fn clear_to(mut self) -> Self {
+        self.to = None;
+        self
+    }
+
     pub fn set_correlation_id(mut self, cid: &str) -> Self {
         self.cid = Some(cid.to_string());
         self

--- a/crates/platform-core/src/event_stream.rs
+++ b/crates/platform-core/src/event_stream.rs
@@ -44,8 +44,13 @@ pub const X_EVENT_NAME: &str = "x-event-name";
 pub const DATA: &str = "data";
 /// End of transmission (optional body = trailing metadata).
 pub const EOF: &str = "eof";
-/// In-band failure (body = `{status, message}`).
+/// In-band failure (body = the standard error key-values
+/// `'{"type": "error", "status": n, "message": text}'`).
 pub const EXCEPTION: &str = "exception";
+/// Reserved SSE event name of the Event-over-HTTP envelope-mode wire dialect:
+/// a frame with this name carries one base64-encoded serialized EventEnvelope
+/// (Java `EventStreamWriter.ENVELOPE`).
+pub const ENVELOPE: &str = "envelope";
 
 /// Producer helper for a streaming HTTP response — thin sugar over plain
 /// event sends to the caller's reply route (Java `EventStreamWriter`).
@@ -159,7 +164,9 @@ impl EventStreamWriter {
         } else {
             500
         };
-        let body = serde_json::json!({"status": status, "message": error.message()});
+        // the standard error key-values: '{"type": "error", "status": n, "message": text}'
+        let body =
+            serde_json::json!({"type": "error", "status": status, "message": error.message()});
         let event = self.envelope(EXCEPTION, body, None)?.set_status(status);
         self.po.send(event).await
     }

--- a/crates/platform-core/tests/event_http_declarative.rs
+++ b/crates/platform-core/tests/event_http_declarative.rs
@@ -103,10 +103,17 @@ async fn declarative_event_over_http() {
     let _ = AppConfigReader::get_instance();
     let platform = Platform::new();
     platform
-        .register_private(
+        .register_with_options(
             automation::EVENT_API_SERVICE,
             Arc::new(EventApiService::new(&platform)),
             10,
+            // an event interceptor since the streaming relay (Phase 2): it
+            // replies manually, matching the app_starter registration
+            FunctionOptions {
+                zero_traced: false,
+                interceptor: true,
+                private: true,
+            },
         )
         .unwrap();
     // the PUBLIC remote target of the declarative routes

--- a/crates/platform-core/tests/event_over_http.rs
+++ b/crates/platform-core/tests/event_over_http.rs
@@ -88,10 +88,17 @@ async fn server() -> (u16, Platform) {
     let platform = Platform::new();
     // the event service + a PUBLIC target and a PRIVATE one
     platform
-        .register_private(
+        .register_with_options(
             automation::EVENT_API_SERVICE,
             Arc::new(EventApiService::new(&platform)),
             10,
+            // an event interceptor since the streaming relay (Phase 2): it
+            // replies manually, matching the app_starter registration
+            FunctionOptions {
+                zero_traced: false,
+                interceptor: true,
+                private: true,
+            },
         )
         .unwrap();
     platform

--- a/crates/platform-core/tests/event_over_http_stream.rs
+++ b/crates/platform-core/tests/event_over_http_stream.rs
@@ -1,0 +1,929 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Event-over-HTTP peer streaming (envelope mode): a send with reply_to that
+//! declares the "accept: text/event-stream" event header relays a remote
+//! streaming function's segments progressively to the caller's reply route.
+//! The wire is the hybrid dialect - envelope frames (base64 MsgPack) for the
+//! head, the terminals and non-text segments; raw SSE frames for text tokens.
+//! A non-streaming target and every existing calling mode stay byte-identical.
+//! (Java `EventOverHttpStreamTest` twin.)
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use platform_core::automation::http_client::AsyncHttpClientService;
+use platform_core::automation::{self, EventApiService};
+use platform_core::platform::FunctionOptions;
+use platform_core::{
+    event_stream, overrides, resources, AppConfigReader, AppError, ComposableFunction,
+    EventEnvelope, EventStreamWriter, Platform, PostOffice,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+const STREAMING_TARGET: &str = "hello.stream.remote";
+const SINGLE_SHOT_TARGET: &str = "hello.single.remote";
+const TEXT_EVENT_STREAM: &str = "text/event-stream";
+
+/// A PUBLIC streaming target reached through /api/event - modes are selected
+/// by the "mode" event header (a plain function, not an edge endpoint).
+struct RemoteStreamProducer {
+    platform: Platform,
+}
+
+#[async_trait]
+impl ComposableFunction for RemoteStreamProducer {
+    async fn handle_event(
+        &self,
+        headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let mode = headers.get("mode").map(String::as_str).unwrap_or("tokens");
+        let mut out = EventStreamWriter::from_request(&self.platform, &input)?;
+        match mode {
+            "tokens" => {
+                out.first(200, TEXT_EVENT_STREAM);
+                out.write("alpha").await?;
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                out.write("beta").await?;
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                out.close_with(serde_json::json!({"segments": 2})).await?;
+            }
+            "typed" => {
+                // every escape-hatch trigger: a map body, text with a carriage
+                // return, a user event name colliding with the reserved word,
+                // a binary body - plus one plain token that rides a raw frame
+                out.first(200, TEXT_EVENT_STREAM);
+                out.write(serde_json::json!({"n": 1})).await?;
+                out.write_named("crlf", "line1\r\nline2").await?;
+                out.write_named("envelope", "reserved-name").await?;
+                let po = PostOffice::new(&self.platform);
+                po.send(
+                    EventEnvelope::new()
+                        .set_to(input.reply_to().unwrap_or_default())
+                        .set_correlation_id(input.correlation_id().unwrap_or_default())
+                        .set_header(event_stream::X_EVENT_STREAM, event_stream::DATA)
+                        .set_raw_body(rmpv::Value::Binary(vec![1, 2, 3, 4])),
+                )
+                .await?;
+                out.write("plain token").await?;
+                out.close_with(serde_json::json!({"done": true})).await?;
+            }
+            "error-mid" => {
+                out.first(200, TEXT_EVENT_STREAM);
+                out.write("partial").await?;
+                out.fail(&AppError::new(503, "backend on fire")).await?;
+            }
+            "error-first" => {
+                out.fail(&AppError::new(503, "no backend")).await?;
+            }
+            "stall" => {
+                // one-second declared idle allowance, then silence - the edge
+                // renderer or the consuming client must fail the stream in-band
+                out.first_with_ttl(200, TEXT_EVENT_STREAM, 1);
+                out.write("one").await?;
+            }
+            other => {
+                out.fail(&AppError::new(400, format!("unknown mode {other}")))
+                    .await?;
+            }
+        }
+        Ok(EventEnvelope::new())
+    }
+}
+
+/// A PUBLIC single-shot echo (the byte-identical fallback pins).
+struct SingleShotEcho;
+
+#[async_trait]
+impl ComposableFunction for SingleShotEcho {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        EventEnvelope::new().set_body(serde_json::json!({
+            "echo": format!("{}", input.body()),
+        }))
+    }
+}
+
+/// The engine-to-engine composition: a streaming edge endpoint whose function
+/// forwards its own reply lane and correlation id into a send to the
+/// event-over-http MAPPED streaming function, opting in with the accept
+/// event header - the remote segments re-render progressively out this edge.
+struct RemoteRelayFixture {
+    platform: Platform,
+}
+
+#[async_trait]
+impl ComposableFunction for RemoteRelayFixture {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let request = input.body_as::<serde_json::Value>().unwrap_or_default();
+        let mode = request["parameters"]["query"]["mode"]
+            .as_str()
+            .unwrap_or("tokens")
+            .to_string();
+        let po = PostOffice::new(&self.platform);
+        po.send(
+            EventEnvelope::new()
+                .set_to(STREAMING_TARGET)
+                .set_reply_to(input.reply_to().unwrap_or_default())
+                .set_correlation_id(input.correlation_id().unwrap_or_default())
+                .set_header("accept", TEXT_EVENT_STREAM)
+                .set_header("x-ttl", "10000")
+                .set_header("mode", &mode),
+        )
+        .await?;
+        Ok(EventEnvelope::new())
+    }
+}
+
+/// Captures every envelope delivered to its route.
+struct CaptureRoute {
+    received: Arc<Mutex<Vec<EventEnvelope>>>,
+}
+
+#[async_trait]
+impl ComposableFunction for CaptureRoute {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        self.received.lock().expect("capture mutex").push(input);
+        Ok(EventEnvelope::new())
+    }
+}
+
+/// The rest.yaml of the shared fixture: the /api/event entry plus the
+/// streaming edge endpoint of the engine-to-engine composition.
+const REST_YAML: &str = r#"
+rest:
+  - service: "event.api.service"
+    methods: ['POST']
+    url: "/api/event"
+    timeout: 60s
+
+  - service: "hello.remote.relay"
+    methods: ['GET']
+    url: "/api/hello/remote"
+    timeout: 15s
+    stream: true
+"#;
+
+/// The shared fixture: ONE platform + edge server + misbehaving-peer mock on a
+/// dedicated thread with its own runtime, because the declarative
+/// event-over-http registry is a process-wide one-shot (route workers would
+/// otherwise die with the first test's runtime - the per-test-runtime lesson).
+/// The event-over-http map is written at runtime with the REAL ports.
+fn shared() -> (u16, Platform) {
+    static SHARED: OnceLock<(u16, Platform)> = OnceLock::new();
+    SHARED
+        .get_or_init(|| {
+            let (tx, rx) = std::sync::mpsc::channel::<(u16, Platform)>();
+            std::thread::spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("fixture runtime");
+                runtime.block_on(async move {
+                    resources::prepend_resource_root("tests/resources");
+                    let pid = std::process::id();
+                    let rest_file =
+                        std::env::temp_dir().join(format!("rest-eoh-stream-{pid}.yaml"));
+                    std::fs::write(&rest_file, REST_YAML).expect("write rest.yaml");
+                    overrides::set(
+                        "yaml.rest.automation",
+                        &format!("file:{}", rest_file.display()),
+                    );
+                    overrides::set("rest.server.port", "0");
+                    let _ = AppConfigReader::get_instance();
+                    let platform = Platform::new();
+                    let interceptor = FunctionOptions {
+                        zero_traced: false,
+                        interceptor: true,
+                        private: true,
+                    };
+                    let public_interceptor = FunctionOptions {
+                        zero_traced: false,
+                        interceptor: true,
+                        private: false,
+                    };
+                    platform
+                        .register_with_options(
+                            automation::EVENT_API_SERVICE,
+                            Arc::new(EventApiService::new(&platform)),
+                            10,
+                            interceptor,
+                        )
+                        .expect("register event api");
+                    platform
+                        .register_with_options(
+                            automation::ASYNC_HTTP_REQUEST,
+                            Arc::new(AsyncHttpClientService::new(&platform)),
+                            10,
+                            interceptor,
+                        )
+                        .expect("register http client");
+                    platform
+                        .register_with_options(
+                            STREAMING_TARGET,
+                            Arc::new(RemoteStreamProducer {
+                                platform: platform.clone(),
+                            }),
+                            10,
+                            public_interceptor,
+                        )
+                        .expect("register streaming target");
+                    platform
+                        .register(SINGLE_SHOT_TARGET, Arc::new(SingleShotEcho), 5)
+                        .expect("register single-shot echo");
+                    platform
+                        .register_with_options(
+                            "hello.remote.relay",
+                            Arc::new(RemoteRelayFixture {
+                                platform: platform.clone(),
+                            }),
+                            10,
+                            interceptor,
+                        )
+                        .expect("register remote relay");
+                    let addr = automation::start_http_server(&platform)
+                        .await
+                        .expect("http server");
+                    let edge_port = addr.port();
+                    let mock_port = start_misbehaving_peer().await;
+                    let map_file = std::env::temp_dir().join(format!("eoh-map-{pid}.yaml"));
+                    let map = format!(
+                        r#"
+event.http:
+  - route: '{STREAMING_TARGET}'
+    target: 'http://127.0.0.1:{edge_port}/api/event'
+  - route: '{SINGLE_SHOT_TARGET}'
+    target: 'http://127.0.0.1:{edge_port}/api/event'
+  # an edge-level REST error on the relay path (POST to a GET-only endpoint)
+  - route: 'mock.rest.error'
+    target: 'http://127.0.0.1:{edge_port}/api/hello/remote'
+  # conformance guards against a misbehaving peer
+  - route: 'mock.sse.raw.first'
+    target: 'http://127.0.0.1:{mock_port}/mock/raw-first'
+  - route: 'mock.sse.no.terminal'
+    target: 'http://127.0.0.1:{mock_port}/mock/no-terminal'
+  - route: 'mock.sse.foreign'
+    target: 'http://127.0.0.1:{mock_port}/mock/foreign-dialect'
+"#
+                    );
+                    std::fs::write(&map_file, map).expect("write event-over-http map");
+                    overrides::set(
+                        "yaml.event.over.http",
+                        &format!("file:{}", map_file.display()),
+                    );
+                    tx.send((edge_port, platform.clone())).expect("announce");
+                    std::future::pending::<()>().await;
+                });
+            });
+            rx.recv().expect("shared fixture")
+        })
+        .clone()
+}
+
+/// A misbehaving-peer mock: it violates the envelope dialect in the exact ways
+/// the consuming client must catch. It lives on the fixture runtime, which
+/// never ends.
+async fn start_misbehaving_peer() -> u16 {
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("mock peer bind");
+    let port = listener.local_addr().expect("mock addr").port();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 8192];
+                let mut head = Vec::new();
+                loop {
+                    let Ok(n) = socket.read(&mut buf).await else {
+                        return;
+                    };
+                    if n == 0 {
+                        return;
+                    }
+                    head.extend_from_slice(&buf[..n]);
+                    if head.windows(4).any(|w| w == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                let request = String::from_utf8_lossy(&head);
+                let path = request.split_whitespace().nth(1).unwrap_or("/").to_string();
+                // the peer may still be sending the POST body - it is ignored
+                let head = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ntransfer-encoding: chunked\r\n\r\n";
+                if socket.write_all(head.as_bytes()).await.is_err() {
+                    return;
+                }
+                let chunk = |text: &str| format!("{:x}\r\n{}\r\n", text.len(), text);
+                match path.as_str() {
+                    "/mock/raw-first" => {
+                        // the dialect guarantees an envelope frame first
+                        let _ = socket.write_all(chunk("data: hello\n\n").as_bytes()).await;
+                        let _ = socket.write_all(b"0\r\n\r\n").await;
+                    }
+                    "/mock/no-terminal" => {
+                        // a clean end without a decoded terminal is a truncation
+                        let _ = socket.write_all(chunk(&mock_head_frame()).as_bytes()).await;
+                        let _ = socket.write_all(b"0\r\n\r\n").await;
+                    }
+                    "/mock/foreign-dialect" => {
+                        // a conforming foreign peer: envelope head, raw token,
+                        // envelope eof - plus a trailing frame that must be
+                        // discarded after the terminal
+                        let frames = format!(
+                            "{}data: mock-token\n\n{}data: trailing-noise\n\n",
+                            mock_head_frame(),
+                            mock_eof_frame()
+                        );
+                        let _ = socket.write_all(chunk(&frames).as_bytes()).await;
+                        let _ = socket.write_all(b"0\r\n\r\n").await;
+                    }
+                    _ => {
+                        let _ = socket.write_all(b"0\r\n\r\n").await;
+                    }
+                }
+            });
+        }
+    });
+    port
+}
+
+fn envelope_frame(event: EventEnvelope) -> String {
+    let bytes = event.to_bytes().expect("serialize mock envelope");
+    format!(
+        "event: envelope\ndata: {}\n\n",
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    )
+}
+
+fn mock_head_frame() -> String {
+    envelope_frame(
+        EventEnvelope::new()
+            .set_header(event_stream::X_EVENT_STREAM, event_stream::DATA)
+            .set_header("content-type", TEXT_EVENT_STREAM)
+            .set_status(200)
+            .set_body("mock-head")
+            .expect("mock head"),
+    )
+}
+
+fn mock_eof_frame() -> String {
+    envelope_frame(
+        EventEnvelope::new()
+            .set_header(event_stream::X_EVENT_STREAM, event_stream::EOF)
+            .set_body(serde_json::json!({"done": true}))
+            .expect("mock eof"),
+    )
+}
+
+/// One global test guard: the pool-drain test must not race sibling tests.
+async fn suite_guard() -> tokio::sync::MutexGuard<'static, ()> {
+    static GUARD: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await
+}
+
+fn next_seq() -> usize {
+    static SEQ: AtomicUsize = AtomicUsize::new(0);
+    SEQ.fetch_add(1, Ordering::Relaxed) + 1
+}
+
+fn marker(event: &EventEnvelope) -> Option<String> {
+    event
+        .headers()
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(event_stream::X_EVENT_STREAM))
+        .map(|(_, value)| value.to_lowercase())
+}
+
+fn header<'a>(event: &'a EventEnvelope, name: &str) -> Option<&'a str> {
+    event
+        .headers()
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str())
+}
+
+fn is_terminal(event: &EventEnvelope) -> bool {
+    matches!(
+        marker(event).as_deref(),
+        Some(event_stream::EOF) | Some(event_stream::EXCEPTION)
+    )
+}
+
+/// Send to an event-over-http mapped route with the streaming opt-in and a
+/// capture route as reply_to; return the captured envelopes up to and
+/// including the first terminal marker - or the first envelope for
+/// single-shot pins.
+async fn send_streaming(
+    platform: &Platform,
+    route: &str,
+    mode: Option<&str>,
+    ttl_ms: Option<&str>,
+    expected: usize,
+) -> Vec<EventEnvelope> {
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let seq = next_seq();
+    let capture = format!("capture.eoh.stream.{seq}");
+    platform
+        .register_with_options(
+            &capture,
+            Arc::new(CaptureRoute {
+                received: received.clone(),
+            }),
+            1,
+            FunctionOptions {
+                zero_traced: false,
+                interceptor: true,
+                private: true,
+            },
+        )
+        .expect("register capture");
+    let mut event = EventEnvelope::new()
+        .set_to(route)
+        .set_reply_to(&capture)
+        .set_correlation_id(&format!("cid-eoh-{seq}"))
+        .set_header("accept", TEXT_EVENT_STREAM);
+    if let Some(mode) = mode {
+        event = event.set_header("mode", mode);
+    }
+    if let Some(ttl) = ttl_ms {
+        event = event.set_header("x-ttl", ttl);
+    }
+    let po = PostOffice::new(platform);
+    po.send(event).await.expect("send");
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        {
+            let events = received.lock().expect("capture mutex");
+            let complete = events.len() >= expected || events.iter().any(is_terminal);
+            if complete {
+                let mut trimmed = Vec::new();
+                for event in events.iter() {
+                    trimmed.push(event.clone());
+                    if is_terminal(event) {
+                        break;
+                    }
+                }
+                return trimmed;
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "expected {expected} events from {route}"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[tokio::test]
+async fn streaming_target_relays_progressively_to_callback() {
+    let _guard = suite_guard().await;
+    let (_, platform) = shared();
+    let events = send_streaming(&platform, STREAMING_TARGET, Some("tokens"), None, 3).await;
+    assert_eq!(3, events.len(), "2 data envelopes + eof");
+    // the decoded head is the target's first envelope, verbatim
+    let head = &events[0];
+    assert_eq!(Some(event_stream::DATA.to_string()), marker(head));
+    assert_eq!(200, head.status());
+    assert_eq!(Some(TEXT_EVENT_STREAM), header(head, "content-type"));
+    assert_eq!("alpha", head.body_as::<String>().expect("text body"));
+    assert!(
+        head.correlation_id()
+            .unwrap_or_default()
+            .starts_with("cid-eoh-"),
+        "original correlation id restored"
+    );
+    // the second token rode a raw frame and was synthesized back
+    let token = &events[1];
+    assert_eq!(Some(event_stream::DATA.to_string()), marker(token));
+    assert_eq!("beta", token.body_as::<String>().expect("text body"));
+    // eof carries the trailing metadata with its exact map type
+    let eof = &events[2];
+    assert_eq!(Some(event_stream::EOF.to_string()), marker(eof));
+    let metadata = eof.body_as::<serde_json::Value>().expect("eof metadata");
+    assert_eq!(2, metadata["segments"].as_i64().unwrap_or_default());
+}
+
+#[tokio::test]
+async fn typed_segments_round_trip_exactly() {
+    let _guard = suite_guard().await;
+    let (_, platform) = shared();
+    let events = send_streaming(&platform, STREAMING_TARGET, Some("typed"), None, 6).await;
+    assert_eq!(6, events.len(), "5 data envelopes + eof");
+    let map_segment = events[0].body_as::<serde_json::Value>().expect("map body");
+    assert_eq!(1, map_segment["n"].as_i64().unwrap_or_default());
+    let crlf = &events[1];
+    assert_eq!(Some("crlf"), header(crlf, event_stream::X_EVENT_NAME));
+    assert_eq!(
+        "line1\r\nline2",
+        crlf.body_as::<String>().expect("text body"),
+        "carriage return preserved"
+    );
+    let reserved = &events[2];
+    assert_eq!(
+        Some("envelope"),
+        header(reserved, event_stream::X_EVENT_NAME),
+        "a user event name colliding with the reserved word survives"
+    );
+    assert_eq!(
+        "reserved-name",
+        reserved.body_as::<String>().expect("text body")
+    );
+    let bytes = &events[3];
+    assert_eq!(
+        &rmpv::Value::Binary(vec![1, 2, 3, 4]),
+        bytes.body(),
+        "binary body preserved"
+    );
+    assert_eq!(
+        "plain token",
+        events[4].body_as::<String>().expect("text body")
+    );
+    let eof = &events[5];
+    assert_eq!(Some(event_stream::EOF.to_string()), marker(eof));
+    let metadata = eof.body_as::<serde_json::Value>().expect("eof metadata");
+    assert_eq!(Some(true), metadata["done"].as_bool());
+}
+
+#[tokio::test]
+async fn single_shot_target_over_capable_path_is_classic() {
+    let _guard = suite_guard().await;
+    let (_, platform) = shared();
+    // classic callback (no accept header) as the baseline
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let capture = format!("capture.eoh.single.{}", next_seq());
+    platform
+        .register_with_options(
+            &capture,
+            Arc::new(CaptureRoute {
+                received: received.clone(),
+            }),
+            1,
+            FunctionOptions {
+                zero_traced: false,
+                interceptor: true,
+                private: true,
+            },
+        )
+        .expect("register capture");
+    let po = PostOffice::new(&platform);
+    po.send(
+        EventEnvelope::new()
+            .set_to(SINGLE_SHOT_TARGET)
+            .set_reply_to(&capture)
+            .set_correlation_id("cid-classic")
+            .set_body("ping-1")
+            .expect("body"),
+    )
+    .await
+    .expect("classic send");
+    let classic = wait_for_one(&received, 0).await;
+    // streaming-capable call to the same target
+    po.send(
+        EventEnvelope::new()
+            .set_to(SINGLE_SHOT_TARGET)
+            .set_reply_to(&capture)
+            .set_correlation_id("cid-capable")
+            .set_header("accept", TEXT_EVENT_STREAM)
+            .set_body("ping-1")
+            .expect("body"),
+    )
+    .await
+    .expect("capable send");
+    let capable = wait_for_one(&received, 1).await;
+    assert!(
+        marker(&capable).is_none(),
+        "a single-shot reply carries no stream marker"
+    );
+    assert_eq!(classic.status(), capable.status());
+    assert_eq!(classic.body(), capable.body());
+    assert_eq!(Some("cid-capable"), capable.correlation_id());
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        2,
+        received.lock().expect("capture mutex").len(),
+        "single-shot means one reply per call"
+    );
+}
+
+async fn wait_for_one(received: &Arc<Mutex<Vec<EventEnvelope>>>, index: usize) -> EventEnvelope {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        {
+            let events = received.lock().expect("capture mutex");
+            if events.len() > index {
+                return events[index].clone();
+            }
+        }
+        assert!(Instant::now() < deadline, "expected reply {index}");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[tokio::test]
+async fn streaming_target_without_accept_is_refused_406() {
+    let _guard = suite_guard().await;
+    let (_, platform) = shared();
+    // classic callback mode (no accept opt-in) against a streaming function:
+    // the peer answers with an explicit refusal instead of a truncated reply
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let capture = format!("capture.eoh.refuse.{}", next_seq());
+    platform
+        .register_with_options(
+            &capture,
+            Arc::new(CaptureRoute {
+                received: received.clone(),
+            }),
+            1,
+            FunctionOptions {
+                zero_traced: false,
+                interceptor: true,
+                private: true,
+            },
+        )
+        .expect("register capture");
+    let po = PostOffice::new(&platform);
+    po.send(
+        EventEnvelope::new()
+            .set_to(STREAMING_TARGET)
+            .set_reply_to(&capture)
+            .set_correlation_id("cid-refuse")
+            .set_header("mode", "tokens"),
+    )
+    .await
+    .expect("send");
+    let reply = wait_for_one(&received, 0).await;
+    assert_eq!(406, reply.status());
+    assert_eq!(
+        "Streaming function requires a caller that accepts text/event-stream",
+        reply.body_as::<String>().expect("text body")
+    );
+}
+
+#[tokio::test]
+async fn streaming_target_via_rpc_is_refused_406() {
+    let _guard = suite_guard().await;
+    let (edge_port, platform) = shared();
+    // the RPC path never streams (a request completes once)
+    let po = PostOffice::new(&platform);
+    let endpoint = format!("http://127.0.0.1:{edge_port}/api/event");
+    let response = automation::event_over_http(
+        &po,
+        &endpoint,
+        EventEnvelope::new()
+            .set_to(STREAMING_TARGET)
+            .set_header("mode", "tokens"),
+        Duration::from_secs(15),
+        true,
+    )
+    .await
+    .expect("rpc");
+    assert_eq!(406, response.status());
+    assert_eq!(
+        "Streaming function requires a caller that accepts text/event-stream",
+        response.body_as::<String>().expect("text body")
+    );
+}
+
+#[tokio::test]
+async fn mid_stream_failure_propagates_exact_status() {
+    let _guard = suite_guard().await;
+    let (_, platform) = shared();
+    let events = send_streaming(&platform, STREAMING_TARGET, Some("error-mid"), None, 2).await;
+    assert_eq!("partial", events[0].body_as::<String>().expect("text body"));
+    let error = &events[1];
+    assert_eq!(Some(event_stream::EXCEPTION.to_string()), marker(error));
+    assert_eq!(503, error.status());
+    // the standard error key-values: '{"type": "error", "status": n, "message": text}'
+    let body = error.body_as::<serde_json::Value>().expect("error body");
+    assert_eq!(Some("error"), body["type"].as_str());
+    assert_eq!(503, body["status"].as_i64().unwrap_or_default());
+    assert_eq!(Some("backend on fire"), body["message"].as_str());
+}
+
+#[tokio::test]
+async fn failure_before_first_segment_arrives_as_exception() {
+    let _guard = suite_guard().await;
+    let (_, platform) = shared();
+    // a pre-head failure still rides the stream (SSE-uniform) - the caller
+    // receives the exact error envelope
+    let events = send_streaming(&platform, STREAMING_TARGET, Some("error-first"), None, 1).await;
+    let error = &events[0];
+    assert_eq!(Some(event_stream::EXCEPTION.to_string()), marker(error));
+    assert_eq!(503, error.status());
+    let body = error.body_as::<serde_json::Value>().expect("error body");
+    assert_eq!(Some("no backend"), body["message"].as_str());
+}
+
+#[tokio::test]
+async fn idle_stall_fails_in_band_408() {
+    let _guard = suite_guard().await;
+    let (_, platform) = shared();
+    // the target declares a one-second idle allowance and goes silent - the
+    // edge renderer or the client's own idle timer must fail it in-band;
+    // both produce the pinned 408 wording
+    let started = Instant::now();
+    let events = send_streaming(&platform, STREAMING_TARGET, Some("stall"), Some("5000"), 2).await;
+    let elapsed = started.elapsed();
+    assert_eq!("one", events[0].body_as::<String>().expect("text body"));
+    let error = &events[1];
+    assert_eq!(Some(event_stream::EXCEPTION.to_string()), marker(error));
+    assert_eq!(408, error.status());
+    let body = error.body_as::<serde_json::Value>().expect("error body");
+    assert_eq!(Some("error"), body["type"].as_str());
+    let message = body["message"].as_str().unwrap_or_default();
+    assert!(message.starts_with("Timeout for "), "{message}");
+    assert!(
+        elapsed < Duration::from_secs(15),
+        "in-band timeout expected, took {elapsed:?}"
+    );
+}
+
+#[tokio::test]
+async fn server_pool_exhaustion_answers_503() {
+    let _guard = suite_guard().await;
+    let (_, platform) = shared();
+    // with no reply lane available, a streaming-capable call is refused
+    // single-shot with the pinned message - and recovers after release
+    let mut drained = Vec::new();
+    while let Some(lane) = automation::checkout_lane() {
+        drained.push(lane);
+    }
+    assert!(!drained.is_empty(), "the pool should have lanes to drain");
+    let events = send_streaming(&platform, STREAMING_TARGET, Some("tokens"), None, 1).await;
+    let reply = &events[0];
+    assert_eq!(503, reply.status());
+    assert_eq!(
+        "Streaming response pool exhausted",
+        reply.body_as::<String>().expect("text body")
+    );
+    for lane in drained {
+        automation::release_lane(lane);
+    }
+    // capacity restored - the same call streams normally again
+    let events = send_streaming(&platform, STREAMING_TARGET, Some("tokens"), None, 3).await;
+    assert_eq!(Some(event_stream::EOF.to_string()), marker(&events[2]));
+}
+
+#[tokio::test]
+async fn rest_level_error_unwraps_to_callback() {
+    let _guard = suite_guard().await;
+    let (_, platform) = shared();
+    // the relay POSTs to a GET-only endpoint: the edge answers a REST error
+    // (JSON, not a serialized envelope) - the client unwraps it classically
+    let events = send_streaming(&platform, "mock.rest.error", None, None, 1).await;
+    let reply = &events[0];
+    assert!(
+        marker(reply).is_none(),
+        "an edge error is a single-shot reply"
+    );
+    assert_eq!(405, reply.status());
+}
+
+#[tokio::test]
+async fn raw_first_frame_from_foreign_server_is_rejected() {
+    let _guard = suite_guard().await;
+    let (_, platform) = shared();
+    let events = send_streaming(&platform, "mock.sse.raw.first", None, None, 1).await;
+    let error = &events[0];
+    assert_eq!(Some(event_stream::EXCEPTION.to_string()), marker(error));
+    assert_eq!(500, error.status());
+    let body = error.body_as::<serde_json::Value>().expect("error body");
+    assert_eq!(
+        Some("Invalid event stream - missing envelope head"),
+        body["message"].as_str()
+    );
+}
+
+#[tokio::test]
+async fn transport_end_without_terminal_is_truncation() {
+    let _guard = suite_guard().await;
+    let (_, platform) = shared();
+    let events = send_streaming(&platform, "mock.sse.no.terminal", None, None, 2).await;
+    assert_eq!(
+        "mock-head",
+        events[0].body_as::<String>().expect("text body")
+    );
+    let error = &events[1];
+    assert_eq!(Some(event_stream::EXCEPTION.to_string()), marker(error));
+    assert_eq!(500, error.status());
+    let body = error.body_as::<serde_json::Value>().expect("error body");
+    assert_eq!(
+        Some("Event stream ended without eof"),
+        body["message"].as_str()
+    );
+}
+
+#[tokio::test]
+async fn foreign_dialect_peer_works_and_trailing_frames_drop() {
+    let _guard = suite_guard().await;
+    let (_, platform) = shared();
+    let events = send_streaming(&platform, "mock.sse.foreign", None, None, 3).await;
+    assert_eq!(3, events.len(), "head + raw token + eof");
+    assert_eq!(
+        "mock-head",
+        events[0].body_as::<String>().expect("text body")
+    );
+    assert_eq!(Some(event_stream::DATA.to_string()), marker(&events[1]));
+    assert_eq!(
+        "mock-token",
+        events[1].body_as::<String>().expect("text body")
+    );
+    assert_eq!(Some(event_stream::EOF.to_string()), marker(&events[2]));
+    // frames after the decoded terminal are discarded
+    tokio::time::sleep(Duration::from_millis(300)).await;
+}
+
+#[tokio::test]
+async fn remote_stream_renders_progressively_out_the_edge() {
+    let _guard = suite_guard().await;
+    let (edge_port, _) = shared();
+    // the engine-to-engine composition: a streaming edge endpoint forwards its
+    // reply lane into a send to the event-over-http mapped streaming function -
+    // segments relay through /api/event and re-render progressively here
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", edge_port))
+        .await
+        .expect("connect edge");
+    let request = format!(
+        "GET /api/hello/remote HTTP/1.1\r\nHost: 127.0.0.1:{edge_port}\r\nAccept: text/event-stream\r\nConnection: close\r\n\r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("send request");
+    let started = Instant::now();
+    let mut received = Vec::new();
+    let mut arrivals: Vec<(usize, Duration)> = Vec::new();
+    let mut buf = vec![0u8; 4096];
+    loop {
+        match tokio::time::timeout(Duration::from_secs(15), stream.read(&mut buf)).await {
+            Ok(Ok(0)) | Err(_) => break,
+            Ok(Ok(n)) => {
+                arrivals.push((received.len(), started.elapsed()));
+                received.extend_from_slice(&buf[..n]);
+            }
+            Ok(Err(_)) => break,
+        }
+    }
+    let text = String::from_utf8_lossy(&received).to_string();
+    assert!(text.contains("200 OK"), "{text}");
+    assert!(text.contains("text/event-stream"), "{text}");
+    let alpha = text.find("data: alpha").expect("alpha frame");
+    let beta = text.find("data: beta").expect("beta frame");
+    let done = text.find("event: done").expect("terminal frame");
+    assert!(alpha < beta && beta < done, "ordered relay: {text}");
+    // the remote eof's trailing metadata is the terminal frame's data
+    assert!(text.contains("data: {\"segments\":2}"), "{text}");
+    // progressive end to end: the remote target paces segments 250 ms apart -
+    // the read that carried beta must be measurably later than alpha's
+    let offset_of = |needle: usize| {
+        arrivals
+            .iter()
+            .rev()
+            .find(|(start, _)| *start <= needle)
+            .map(|(_, at)| *at)
+            .unwrap_or_default()
+    };
+    let gap = offset_of(beta).saturating_sub(offset_of(alpha));
+    assert!(
+        gap >= Duration::from_millis(150),
+        "progressive relay expected, gap {gap:?}: {text}"
+    );
+}

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2686,3 +2686,55 @@ moved into it (git mv, 23 referencing files updated; the folder was already excl
 from the built site, so the move is site-neutral), and the Java site's
 `docs/css/extra.css` (reference-table token wrapping) adopted with `extra_css` wiring —
 it was live in the Java repo and missing here, not outdated.
+
+## Increment 93 — Event-over-HTTP peer streaming: envelope mode on the SSE relay (2026-08-29)
+
+The Java engine's Phase 2 (Java PR #301, ADR-0019 Accepted), ported wire-identical
+(this repo's ADR-0016, flipped Accepted with ADR-0015). A remote streaming function
+reached through `/api/event` streams its segments back to the caller's reply route
+on the same HTTP call - the engine⇄engine leg of the ratified hybrid dialect
+(envelope frames under the reserved SSE name `envelope` for the head, the terminals
+and non-text segments; raw frames for text tokens).
+
+Caller side: `send_with_event_http` gains a streaming branch - a send with
+`reply_to` plus the `accept: text/event-stream` event header relays through
+`async.http.request` with the caller's reply route and correlation id passed
+through and an internal `x-event-api: stream` marker; the `x-ttl` event header
+(ms, default 60s) is the idle allowance on both hops (the client side pads +1s so
+the peer's in-band 408 wins the race). Consuming side: `relay_envelope_sse` decodes
+the dialect, restores addressing, and guards conformance (raw-first frame → 500
+"Invalid event stream - missing envelope head"; transport end without a decoded
+terminal → 500 "Event stream ended without eof"; trailing frames after a terminal
+discarded); the buffered fallback decodes a single-shot serialized-envelope reply
+with the classic tolerant REST-error unwrap.
+
+Server side (two port idioms vs Java, same wire): (1) the EDGE decides the mode -
+`stream_dispatch` runs for a streaming-capable /api/event call (Accept + not
+x-async) with `envelope_mode`, so the lane/channel/renderer lifecycle is inherited
+whole (Java binds the lane dynamically from EventApiService instead); the
+`EventApiService` became an event INTERCEPTOR (true Java parity) and simply rewires
+the inner request onto its own reply lane with the edge context id as the
+correlation id - the exact rewrite the RPC inbox makes. (2) single-shot wrapping
+happens at ONE site: capable-path service errors ride raw envelopes and the edge
+wraps every unmarked lane reply into the classic octet-stream wire - so the outer
+HTTP status of capable-path validation errors is 200 with the real status inside
+(Java mirrors it on the outer response; the decoded caller-visible envelope is
+identical). The RPC path answers a streaming target with the pinned
+`406 Streaming function requires a caller that accepts text/event-stream`; a
+pre-head failure rides the stream SSE-uniform; pool exhaustion keeps the pinned
+503. Contract alignment inherited from the Java review: every in-band exception
+body carries the standard error key-values
+`'{"type": "error", "status": n, "message": text}'` (writer `fail()`, the client's
+in-band failures, the renderer's idle terminal).
+
+Tests: `tests/event_over_http_stream.rs` (14, the Java `EventOverHttpStreamTest`
+twin) on a shared fixture thread with its own runtime (the declarative registry is
+a process-wide one-shot; the per-test-runtime lesson applied in advance this time)
+and runtime-written rest.yaml + event-over-http.yaml carrying real ephemeral ports.
+Coverage: progressive relay mapping, every escape-hatch round-trip with exact types
+(map, binary, `\r`, reserved-name collision, eof trailing metadata),
+byte-identical single-shot fallback vs the classic callback baseline, both 406
+paths, 503 pool exhaustion with recovery, REST-error unwrap, misbehaving-peer
+conformance guards, and the engine⇄engine e2e out the edge with pacing asserted -
+5/5 consecutive green runs. The hello-world README also gained the SSE demo section
+(the Java lambda-example README twin).

--- a/docs/arch-decisions/ADR.md
+++ b/docs/arch-decisions/ADR.md
@@ -27,8 +27,8 @@ or *Deprecated* (no longer relevant), with its text left in place.
 ---
 
 ## ADR-0016 — The HTTP client consumes SSE progressively; Event-over-HTTP streams on the same call {#adr-0016}
-**Status:** Proposed · **Date:** 2026-08-29 · **Serves:** vision-mercury · **Formalizes:** async-http-client-sse-streaming-design
-<!-- id: adr-0016 | status: proposed -->
+**Status:** Accepted · **Date:** 2026-08-29 · **Serves:** vision-mercury · **Formalizes:** async-http-client-sse-streaming-design
+<!-- id: adr-0016 | status: accepted -->
 
 **Abstract.** `async.http.request` consumes a `text/event-stream` response progressively
 and relays it as the platform's own streaming protocol: one `x-event-stream: data`
@@ -70,8 +70,8 @@ free, and rides the wire shape gateways already accommodate for LLM traffic.
 ---
 
 ## ADR-0015 — HTTP response streaming rides the multi-shot reply route; the wire stays standards-only {#adr-0015}
-**Status:** Proposed · **Date:** 2026-08-28 · **Serves:** vision-mercury · **Formalizes:** http-response-streaming-design
-<!-- id: adr-0015 | status: proposed -->
+**Status:** Accepted · **Date:** 2026-08-28 · **Serves:** vision-mercury · **Formalizes:** http-response-streaming-design
+<!-- id: adr-0015 | status: accepted -->
 
 **Abstract.** A function streams an HTTP response (LLM token segments, agent progress
 events, live updates) by exercising the platform's native streaming pattern: the callee

--- a/docs/guides/event-over-http.md
+++ b/docs/guides/event-over-http.md
@@ -396,6 +396,21 @@ between the two engines; the permanent record is the
 [Interop Test Report](../test-reports/event-over-http-interop.md) (mirrored on the
 [Java docs site](https://accenture.github.io/mercury-composable/test-reports/event-over-http-interop/)).
 
+## Streaming across the hop
+
+A remote streaming function - one that produces a multi-shot reply with
+`EventStreamWriter` - can stream its segments back to your reply route through the
+same `/api/event` call: supply a `reply_to` on the send and opt in with the
+`accept: text/event-stream` event header. The peer answers the one POST with a
+Server-Sent Events response carrying the envelope-mode wire dialect, and the
+consuming client forwards each decoded event to your reply route with your
+correlation id - a local stream and a remote stream look identical to the consumer.
+A non-streaming target called this way answers byte-identical to the classic
+callback reply, and a streaming function invoked without the opt-in receives an
+explicit 406 refusal instead of a truncated reply. The full contract - the wire
+dialect, compatibility matrix and idle-timeout semantics - lives in
+[HTTP Response Streaming](http-streaming.md#stream-across-applications-event-over-http).
+
 ## See also
 
 - [Interop Test Report (Java ⇄ Rust)](../test-reports/event-over-http-interop.md) — the live

--- a/docs/guides/http-streaming.md
+++ b/docs/guides/http-streaming.md
@@ -241,6 +241,60 @@ impl ComposableFunction for SseRelay {
 }
 ```
 
+## Stream across applications (Event-over-HTTP)
+
+The same client capability carries the platform's own streaming protocol between
+applications: a function in another application (or a polyglot function host) can
+stream its segments back to your reply route through `/api/event` - engine to engine,
+on the one HTTP call the relay already makes.
+
+The caller side is one send. Address the remote function through your
+`yaml.event.over.http` mapping as usual, supply a `reply_to`, and opt in with the
+`accept` event header:
+
+```rust
+// the remote function's segments arrive at my.reply.handler as
+// x-event-stream data envelopes, then eof - exactly like a local stream
+po.send(EventEnvelope::new().set_to("remote.token.stream")
+        .set_reply_to("my.reply.handler")
+        .set_correlation_id(&my_correlation_id)
+        .set_header("accept", "text/event-stream")
+        .set_header("x-ttl", "30000"))
+    .await?;
+```
+
+The remote function is a normal streaming producer - it writes with
+`EventStreamWriter` and never knows the caller is remote. On the wire, the peer
+answers the same POST with an SSE response in a hybrid dialect: control signals -
+the first envelope (head), the `eof`/`exception` terminals, and any segment that
+cannot round-trip as plain text (a map or byte body, text containing a carriage
+return, an event name colliding with the reserved word) - ride base64-encoded
+serialized envelopes under the reserved SSE event name `envelope`, while plain text
+segments ride raw SSE frames with near-zero overhead. The consuming client decodes
+the dialect and forwards each event to your reply route with your correlation id, so
+segment types (a map stays a map, bytes stay bytes) and terminal metadata survive the
+hop exactly.
+
+Everything degrades explicitly, never silently:
+
+- a **non-streaming target** called this way answers byte-identical to the classic
+  callback reply - opting in is always safe;
+- a **streaming function invoked without the opt-in** (an RPC call, or a caller
+  without the `accept` header) receives an explicit error -
+  `406 Streaming function requires a caller that accepts text/event-stream` -
+  instead of a truncated first segment;
+- an **older peer** that cannot stream answers single-shot as today;
+- when the server has **no reply lane available** the call is refused with the same
+  `503 Streaming response pool exhausted` back-pressure as a local streaming endpoint.
+
+The `x-ttl` event header (milliseconds, default 60 seconds) is the idle allowance
+between stream events on both hops; the producer can extend it for the whole stream
+with `first_with_ttl(status, content_type, ttl_seconds)`. Idle expiry, disconnects and
+truncated streams fail in-band with an `exception` envelope, exactly like a local
+stream. Combined with a `stream: true` endpoint that forwards its reply lane into the
+send, the composition streams a remote function's tokens progressively out your HTTP
+edge with no imperative streaming code.
+
 ## Relation to `x-stream-id`
 
 The Java engine also carries a legacy `x-stream-id` relay (object streams, file

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -95,6 +95,40 @@ hello-flow README and the docs site's *Event over HTTP* guide.
 
 Stop with Ctrl-C (graceful shutdown cleans the elastic store).
 
+## Progressive result set rendering (SSE demo)
+
+The `hello.sse` function (in [src/main.rs](src/main.rs)) serves an HTTP endpoint
+with progressive result set rendering - it streams test messages slowly as
+Server-Sent Events so you can watch them render one by one. The endpoint is
+declared with `stream: true` in rest.yaml, which gives each request a dedicated
+ordered reply lane for the multi-shot response.
+
+Start the application:
+
+```bash
+cargo run -p hello-world
+```
+
+Then consume the endpoint with the companion script (Node.js 18+) that prints
+each event with its arrival time:
+
+```bash
+node scripts/sse-client.mjs
+```
+
+or with curl:
+
+```bash
+curl -N -H 'accept: text/event-stream' http://127.0.0.1:8085/api/hello/sse
+```
+
+The `-N` (`--no-buffer`) flag matters: curl receives the events progressively
+either way, but without `-N` it holds output in an internal buffer, so the
+messages would appear all at once when the stream ends.
+
+Optional query parameters: `delay` in milliseconds between messages (default 1000)
+and `count` for the number of messages (default 10), e.g. `/api/hello/sse?delay=500&count=5`.
+
 ## Where things live
 
 | File | Role |
@@ -104,3 +138,4 @@ Stop with Ctrl-C (graceful shutdown cleans the elastic store).
 | `resources/rest.yaml` | declarative endpoints — the YAML *is* the router |
 | `resources/app-log-context.yaml` | which keys join every structured log line |
 | `resources/public/` | static content (etag/304, filter) |
+| `scripts/sse-client.mjs` | progressive-rendering demo client for the SSE endpoint (Node.js 18+) |


### PR DESCRIPTION
## What

**Event-over-HTTP peer streaming (envelope mode) — the Rust twin of Java PR #301,
completing Phase 2 on both engines.** A remote streaming function reached through
`/api/event` now streams its segments back to the caller's reply route on the same HTTP
call, engine to engine — wire-identical with the Java engine, with pinned vocabulary and
engine-identical messages.

- **Caller contract** — one send: address the remote function through the
  `yaml.event.over.http` mapping with a `reply_to` and opt in with the
  `accept: text/event-stream` event header. The `x-ttl` event header (ms, default 60s) is
  the idle allowance between stream events on both hops (the consuming side pads +1s so
  the peer's in-band 408 wins the race). The RPC and drop-n-forget paths never stream and
  are unchanged.
- **Wire dialect (ratified hybrid)** — control signals ride envelope frames (reserved SSE
  event name `envelope`, one base64-encoded serialized EventEnvelope per frame, addressing
  cleared so server-internal route names never leak): the head, the `eof`/`exception`
  terminals, and any segment that cannot round-trip as plain text (map/byte bodies, text
  with a carriage return, an event name colliding with the reserved word). Plain text
  segments ride raw SSE frames. Segment types and terminal metadata survive the hop
  exactly.
- **Server side** — the edge dispatches a streaming-capable `/api/event` call (Accept +
  not x-async) through the existing `stream_dispatch` with `envelope_mode`, so the lane,
  channel, renderer, idle and cleanup lifecycle is inherited whole; plain RPC traffic
  never consumes a lane, and a dry pool answers the pinned
  `503 Streaming response pool exhausted`. `EventApiService` became a true **event
  interceptor** (Java `@EventInterceptor` parity — previously the one non-interceptor
  divergence) and rewires the inner request onto its own reply lane with the edge context
  id as the correlation id — exactly the rewrite the RPC inbox makes. Single-shot
  wrapping happens at ONE site: capable-path service errors ride raw envelopes and the
  edge wraps every unmarked lane reply into the classic octet-stream wire, so a
  non-streaming target stays byte-identical to the RPC path.
- **Client side** — `relay_envelope_sse` decodes the dialect, restores addressing to the
  original caller, and guards conformance: a raw first frame fails in-band with
  `500 Invalid event stream - missing envelope head`, a transport end without a decoded
  terminal with `500 Event stream ended without eof`; frames after a decoded terminal are
  discarded. The buffered (non-SSE) fallback decodes a single-shot serialized-envelope
  reply with the classic tolerant REST-error unwrap.
- **Explicit degradation** — a streaming function invoked without the opt-in receives
  `406 Streaming function requires a caller that accepts text/event-stream` instead of a
  truncated first segment; older peers answer single-shot as today.
- **Error-body contract alignment** (from the Java review) — every in-band exception body
  carries the standard error key-values `{"type": "error", "status": n, "message": text}`:
  the writer's `fail()`, the client's in-band failures, and the renderer's idle terminal.
- **Docs** — "Stream across applications (Event-over-HTTP)" section in the HTTP Response
  Streaming guide, a cross-reference section in the Event over HTTP guide, CHANGELOG,
  **ADR-0015/ADR-0016 flip to Accepted** (their features merged in #216/#217),
  Increment 93, and the hello-world README gains the SSE demo section (the Java
  lambda-example README twin).

**Port idioms vs Java (same wire, recorded in Increment 93):** the edge decides the mode
at dispatch instead of a dynamic lane bind from inside the service; and the outer HTTP
status of capable-path validation errors is 200 with the real status packed inside
(Java mirrors it on the outer response) — the decoded caller-visible envelope is
identical.

**Tests (14 new, `tests/event_over_http_stream.rs` — the Java `EventOverHttpStreamTest`
twin):** progressive relay with exact head/segment/eof mapping; every escape-hatch
round-trip with exact types; byte-identical single-shot fallback vs the classic callback
baseline; both 406 paths; mid-stream and pre-head failure propagation; in-band 408 idle
stall; 503 pool exhaustion with recovery; REST-error unwrap; misbehaving-peer conformance
guards; and the engine⇄engine e2e — a `stream: true` edge endpoint relaying a remote
streaming function progressively out the edge, pacing asserted. The suite runs on a
shared fixture thread with its own runtime (the declarative registry is process-wide;
the per-test-runtime lesson applied in advance this time) with runtime-written config
carrying real ephemeral ports — no fixed-port collisions.

**Gates:** new suite 14/14 (5/5 consecutive runs) · workspace 67/67 suites (361 tests) ·
clippy 0 · fmt clean · mkdocs strict clean.

## Why

Phase 2's point is peer streaming over the transport that polyglot wrappers and remote
engines already use — and the two engines must speak one dialect for flows and graphs to
stay engine-portable (the telemetry/presentation-parity rule). With this twin, Phase 2 is
lock-step on both engines: an `llm.chat`-style function on any peer can token-stream to
either engine's edge. Next is Phase 3 — the same dialect in the mercury-python and
mercury-nodejs wrapper hosts, conformance-tested against both engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>