### PR TITLE
Progressive rendering milestone v4.12.0 - demo relay, interop report, telemetry continuity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,14 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`draft-design-specs/`](draft-design-specs/).
 
 ---
-## Unreleased
+## Version 4.12.0, 8/30/2026
+
+The progressive-rendering milestone: token/event streaming end to end - HTTP edge,
+HTTP client, and Event-over-HTTP peers - with full OpenTelemetry lineage and
+business-correlation continuity across all four runtimes (Java and Rust engines,
+Python and Node.js language packs at the same version). Useful on its own, and
+the foundation for the AI SDLC (agent, MCP and tool adapters as wrapper-side
+functions with complete observability).
 
 ### Added
 
@@ -90,6 +97,19 @@ the design rationale in [`draft-design-specs/`](draft-design-specs/).
    cross-link. The navigation gains the Java site's "Operate & integrate" tab
    (Observability, Event over HTTP, Polyglot Functions) and an Orientation tab, so the
    tab row reads identically across the two engines' documentation sites.
+
+4. **Engine-to-wrapper streaming demo and interop test report.** The hello-world
+   example gains `GET /api/hello/remote` (`hello.remote.relay`): a streaming endpoint
+   whose function forwards its caller's reply lane into an event-over-http mapped
+   remote streaming function (the Python/Node.js demo apps' `hello.tokens`),
+   rendering a remote peer's tokens progressively out this application's HTTP edge
+   with zero imperative streaming code; a sample `resources/event-over-http.yaml`
+   ships with the example (auto-loaded). `hello.sse` is now public, so wrapper
+   clients can consume it over `/api/event`. A permanent interop test report
+   (`docs/test-reports/progressive-rendering-interop.md`, packaged with the AI
+   contract provider) records the live ten-combination cross-runtime matrix, the
+   OpenTelemetry span-lineage and business-correlation-id verification, and a
+   captured end-to-end telemetry + application-log-context example.
 
 ---
 ## Version 4.11.11, 8/23/2026

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ai-contract-provider"
-version = "4.11.11"
+version = "4.12.0"
 dependencies = [
  "async-trait",
  "event-script",
@@ -114,7 +114,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.11.11"
+version = "4.12.0"
 dependencies = [
  "async-trait",
  "log",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "event-script"
-version = "4.11.11"
+version = "4.12.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "event-script-macros"
-version = "4.11.11"
+version = "4.12.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -483,7 +483,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.11.11"
+version = "4.12.0"
 dependencies = [
  "async-trait",
  "event-script",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.11.11"
+version = "4.12.0"
 dependencies = [
  "async-trait",
  "log",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph"
-version = "4.11.11"
+version = "4.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge-graph-macros"
-version = "4.11.11"
+version = "4.12.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -814,7 +814,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minigraph-playground"
-version = "4.11.11"
+version = "4.12.0"
 dependencies = [
  "async-trait",
  "event-script",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "minigraph-state-redis"
-version = "4.11.11"
+version = "4.12.0"
 dependencies = [
  "async-trait",
  "log",
@@ -1001,7 +1001,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "platform-core"
-version = "4.11.11"
+version = "4.12.0"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macros"
-version = "4.11.11"
+version = "4.12.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.11.11"
+version = "4.12.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury-composable"

--- a/docs/guides/http-streaming.md
+++ b/docs/guides/http-streaming.md
@@ -306,4 +306,6 @@ a response, `x-event-stream` wins and the stray `x-stream-id` is ignored with a 
 ## See also
 
 - [Event over HTTP](event-over-http.md) - the same envelope protocol between applications
+- [Interop Test Report — Progressive Rendering](../test-reports/progressive-rendering-interop.md) -
+  the live four-runtime validation of this contract
 - [Actuators & HTTP Client](actuators-and-http-client.md)

--- a/docs/test-reports/progressive-rendering-interop.md
+++ b/docs/test-reports/progressive-rendering-interop.md
@@ -1,0 +1,371 @@
+---
+title: Interop Test Report — Progressive Rendering, all four runtimes
+summary: Permanent record of the live cross-runtime validation of the progressive
+  streaming contract - the multi-shot reply protocol and the Event-over-HTTP
+  envelope-mode SSE dialect - across the Java and Rust engines and the Python and
+  Node.js function hosts.
+layer: reference
+audience: [developer, architect]
+keywords: [interop, streaming, sse, event over http, envelope mode, test report]
+---
+
+# Interop Test Report — Progressive Rendering, all four runtimes
+
+*Live cross-runtime validation of the progressive streaming contract across the four
+Mercury Composable runtimes — the Java engine
+([mercury-composable](https://github.com/Accenture/mercury-composable)), the Rust engine
+([mercury](https://github.com/Accenture/mercury)), and the Python
+([mercury-python](https://github.com/Accenture/mercury-python)) and Node.js
+([mercury-nodejs](https://github.com/Accenture/mercury-nodejs)) function hosts — conducted
+2026-08-30 (UTC) at the close of the streaming program's wrapper round. This report is a
+permanent record in the tradition of the
+[Event over HTTP interop report](event-over-http-interop.md): what was tested, the
+evidence, and the defects the round surfaced with their fixes.*
+
+## The contract under test
+
+One paradigm on all four runtimes: **the caller provides a reply address; the callee
+streams events to it until a terminal signal.** Each segment is one event to the
+caller's `reply_to`, marked with the reserved envelope header
+`x-event-stream: data | eof | exception`. Across the Event-over-HTTP hop, the peer
+answers the one POST with a Server-Sent Events response in the **hybrid envelope-mode
+dialect**: envelope frames (the reserved SSE event name `envelope`, one base64-encoded
+serialized envelope per frame) wherever envelope semantics matter — the head, the
+terminals, and any segment that cannot round-trip as plain text — and raw SSE frames
+for text tokens. The consuming client decodes the dialect and forwards each event to
+the original reply address with the original correlation id, so a local stream and a
+remote stream are indistinguishable to the consumer.
+
+Delivered by: Java engine PRs
+[#299](https://github.com/Accenture/mercury-composable/pull/299) (edge streaming),
+[#300](https://github.com/Accenture/mercury-composable/pull/300) (SSE consumption),
+[#301](https://github.com/Accenture/mercury-composable/pull/301) (envelope mode) —
+ADR-0018/0019; Rust engine PRs
+[#216](https://github.com/Accenture/mercury/pull/216),
+[#217](https://github.com/Accenture/mercury/pull/217),
+[#218](https://github.com/Accenture/mercury/pull/218) — ADR-0015/0016; and the
+matching wrapper round in mercury-python and mercury-nodejs (interceptor functions,
+`EventStreamWriter`, streaming `/api/event` host, `stream()`/`stream_to()` client).
+
+## The live matrix
+
+Ten producer/consumer combinations were driven live with the SHIPPED demo applications
+— no test shims. Producers pace their segments (300 ms in these drives), so
+progressive delivery is directly observable in the arrival timestamps; buffered
+delivery would show all segments arriving together.
+
+| # | Consumer | Producer | Result |
+|---|----------|----------|--------|
+| 1 | Node.js client | Python `hello.tokens` | segments at ~11/312/612/916 ms, eof metadata `{count, language: python}` |
+| 2 | Python client | Node.js `hello.tokens` | segments at ~5/304/606/908 ms, eof metadata `{count, language: node.js}` |
+| 3 | Python client | **Java engine** `hello.sse` | segments at ~103/407/708/1012 ms, terminal `eof` |
+| 4 | Node.js client | **Java engine** `hello.sse` | segments at ~13/320/620/924 ms, terminal `eof` |
+| 5 | Python client | **Rust engine** `hello.sse` | segments at ~3/306/607 ms, terminal `eof` |
+| 6 | Node.js client | **Rust engine** `hello.sse` | segments at ~10/312/615 ms, terminal `eof` |
+| 7 | **Java engine** edge (`/api/hello/remote`) | Python `hello.tokens` | SSE out the engine edge at ~195/493/793/1094 ms, terminal `event: done` with the Python eof metadata |
+| 8 | **Java engine** edge | Node.js `hello.tokens` | ~217/516/817 ms, terminal metadata `{count, language: node.js}` |
+| 9 | **Rust engine** edge | Python `hello.tokens` | ~20/323/624 ms, same shape |
+| 10 | **Rust engine** edge | Node.js `hello.tokens` | ~19/320/622 ms, same shape |
+
+Common observations across all ten:
+
+- **Progressive on the wire** — arrival gaps match the producer's pacing; nothing
+  buffers end-to-end (rows 7–10 traverse the full chain: HTTP edge → engine relay
+  function → Event-over-HTTP → wrapper host → wrapper function and back).
+- **Correlation** — the caller's correlation id is restored on every delivered
+  envelope (D7), and the engines' demo authentication (`authorization: demo`) rides
+  the per-target security headers unchanged.
+- **Exact types** — eof trailing metadata arrives as a real map, not text, on every
+  path (the envelope-frame escape hatch).
+- **Explicit degradation, observed live** — a missing token produced the engine's
+  401 and a private target its 403, both delivered as clean envelopes through the
+  buffered fallback; a caller without the `accept: text/event-stream` opt-in receives
+  the pinned `406 Streaming function requires a caller that accepts
+  text/event-stream`.
+
+## Engine ⇄ engine and per-runtime coverage
+
+Because the protocol signatures are identical across the four runtimes, each
+repository's unit suite exercises the full protocol against its own application
+instance (client consuming its own `/api/event` host in one process): Java
+`EventOverHttpStreamTest` (14 cases), Rust `event_over_http_stream.rs` (14), Python
+`test_event_stream.py` (17), Node.js `event-stream.test.ts` (17). Each suite also
+carries **misbehaving-peer fixtures** — a raw first frame, a transport end without a
+decoded terminal, trailing frames after the terminal — because a self-loop alone
+cannot catch a deviation implemented identically in both halves of one runtime; the
+live matrix above is the cross-implementation conformance check, and it passed with
+zero shims.
+
+## Trace continuity (OpenTelemetry span / parent-span verification)
+
+The drives were repeated with telemetry capture to verify distributed-trace
+continuity across the streaming hop. Findings, with the observed evidence:
+
+- **One trace id end to end, both directions.** In the engine→wrapper drive, the
+  Java edge minted trace `f22af2e005f2445198563e2dc4f1ba54`; every engine span
+  carried it (the relay function, the HTTP client leg, each reply-lane segment
+  delivery), the Python function received it (trace id and path ride inside the
+  wire envelope), and the demo now echoes it in the eof trailing metadata - so
+  the terminal frame rendered out the engine's own edge carries the same trace
+  id the edge minted: continuity is self-documenting in the demo output. In the
+  wrapper→engine drive, a Python caller supplied W3C trace id
+  `4bf92f3577b34da6a3ce929d0e0e4736` with trace path `PY /stream-drive`; the
+  engine's `event.api.auth`, `event.api.service` and `hello.sse` spans all
+  carried that id, and the function's span carried the caller's trace path.
+- **Span parenting chains on the engines.** The streaming target's span parents
+  onto the Event API service span - observed live:
+  `event.api.service span_id=bfcddb32dd597ddb` →
+  `hello.sse parent_span_id=bfcddb32dd597ddb`. Outbound, the engines' relay leg
+  sends the W3C `traceparent` header carrying the sending function's span id
+  (the trace-aware PostOffice stamps the span onto the outbound event), so a
+  receiving ENGINE parents its spans onto the caller's - the same cross-engine
+  parenting validated in the Event over HTTP interop report.
+- **Wrapper executions are real spans** (closed at this round - the wrappers
+  originally propagated the trace id but minted no spans, which broke the
+  lineage into disconnected segments at every wrapper hop). The function hosts
+  now implement the engines' exact span model: every traced execution mints a
+  16-hex span with the caller's span (from the inbound envelope) as its
+  parent; outbound calls and stream segments carry the current span onward;
+  and non-RPC executions emit the engines' distributed-trace dataset record on
+  the `distributed.tracing` log stream - the same
+  `{"trace": {...}, "annotations": {...}}` shape the Java engine logs - so one
+  log aggregation (or a stdout log-ingest agent forwarding to an observability
+  dashboard) stitches the full span tree across all four runtimes. RPC
+  round-trips emit no dataset, exactly like the engines: their metrics fold
+  into the caller's view.
+- **The connected tree, live-proven in all three directions.** Engine→wrapper:
+  under one Java-edge trace, the relay function's span `8cbc0b4d4be75362`
+  became the Python `hello.tokens` span's parent (`span_id=7b90847f4b8b617a`,
+  `parent_span_id=8cbc0b4d4be75362` in the wrapper's own trace record), and
+  the Java reply-lane delivery spans then parented onto the Python span -
+  edge → engine function → wrapper function → engine deliveries, one unbroken
+  chain. Wrapper→engine: a Python caller carrying external span
+  `00f067aa0ba902b7` (the shape of a user-edge OpenTelemetry span) produced
+  `event.api.auth` and `event.api.service` spans parented on it, with
+  `hello.sse` parented on the service span. Wrapper⇄wrapper: a Node.js
+  execution's record showed the Python caller's span as its parent. This is
+  the lineage the AI SDLC requires - user → agent → MCP → tools in one tree.
+- **One deliberate exception**: plain-text token segments ride raw SSE frames,
+  which carry no envelope metadata (the zero-overhead token path), so their
+  engine-side delivery spans join the trace unparented; a stream's head and
+  terminal segments ride envelope frames and parent correctly. The engines'
+  HTTP client leg (`async.http.request`) remains a sibling span - classic
+  Event-over-HTTP parity.
+- **Correlation id**: the caller's cid rode every delivered envelope in every
+  drive (`cid-trace-drive` on all four segments of the supplied-trace drive).
+
+The check itself surfaced defect #5: the engine demo relay originally built its
+forward event with the raw EventEmitter, which stamps no trace - the hop
+continued cid but DROPPED the trace id. Fixed by using a trace-aware
+PostOffice (its `touch` fill-stamps from/trace/span), and the wrapper demos'
+`hello.tokens` now echo their received trace id in the eof metadata so the
+continuity is visible in every future drive.
+
+## Business correlation-id continuity
+
+The same verification was run for the business correlation-id (`my_cid`) - the
+engine-managed envelope tag captured at an engine's HTTP edge from the
+configured header (default `X-Correlation-Id`) and injected into every
+receiving function's input headers as the read-only `my_correlation_id` view.
+The wrapper demos' `hello.tokens` echo the view in the eof metadata alongside
+the trace id, so every future drive self-documents both continuity dimensions.
+Live results:
+
+- **Java engine edge → Python**: `X-Correlation-Id: biz-e2w-001` on the edge
+  request came back in the terminal metadata rendered out the same edge -
+  edge header → `my_cid` tag → relay function's injected header view →
+  trace-aware PostOffice re-stamp → packed envelope over the hop → wrapper
+  host injection → function echo.
+- **Rust engine edge → Python**: `biz-rust-005` echoed identically. The Rust
+  demo relay needed no change: the Rust engine has one PostOffice and
+  `apply_current_trace` always stamps trace and business correlation-id from
+  the ambient context.
+- **Python → Node.js and Node.js → Python** (wrapper ⇄ wrapper): a caller-side
+  context (`trace_context(..., my_correlation_id=...)` / `runWithTrace({...,
+  myCorrelationId})`) produced `biz-w2w-002` / `biz-w2w-003` echoes from the
+  opposite wrapper - the tag crossed the hop and the receiving host injected
+  the view.
+- **Wrapper → engine**: the wrappers stamp the identical tag bytes (the same
+  codec proven above), and the engines' pinned suites cover the receiving
+  half: an `/api/event` caller carrying the `my_cid` tag reaches the target
+  function as `po.getMyCorrelationId()` (Java
+  `EventHttpTest.eventOverHttpPropagatesTraceAndCorrelationId`; Rust twin).
+
+The check surfaced one parity gap in the (unreleased) wrapper round, fixed and
+test-pinned in both wrappers: the wrapper clients inherited trace id/path and
+the internal correlation id into outbound events but did not re-stamp the
+business correlation-id as the `my_cid` tag, and local bus deliveries skipped
+the header-view injection that the HTTP host performs. Both halves now mirror
+the engines (`PostOffice.touch` / WorkerHandler parity): outbound events carry
+the context's business correlation-id as the tag, local deliveries inject the
+read-only view, and the trace context (`get_trace()` / `getTrace()`) exposes
+it to handlers and relays.
+
+By design (confirmed at this verification round): an engine's `/api/event`
+ingress serves LOCAL routes only - it answers 404 for a route it does not
+host, even when its own `yaml.event.over.http` map points that route at a
+peer. The map is caller-side routing for the app's own outbound calls;
+forwarding inbound calls onward would make every application an
+Event-over-HTTP relay and open routing loops (the `x-event-api` wire marker
+exists precisely to prevent such re-forwarding). Callers address the owning
+peer directly; deliberate hop-through composition is an explicit relay
+function - the demo `hello.remote.relay` is exactly that pattern.
+
+## Defects surfaced by the round (fixed and re-verified)
+
+Honest engineering record — each was caught by the twin-building discipline before
+any release:
+
+1. **Rust engine**: the envelope-mode single-shot reply initially reached the caller
+   unwrapped (rendered as plain JSON instead of the classic packed-envelope wire);
+   fixed by wrapping at the one `SingleShot` outcome site — caught by the twin suite's
+   first run.
+2. **Node.js host**: a `Promise.race` against a queue waiter abandoned the losing
+   waiter, which would steal and drop the next envelope; fixed by reusing one pending
+   promise across keep-alive cycles (`raceMs` documents the rule) — caught in design
+   review before the first test run.
+3. **Error-body contract**: the in-band exception bodies converged on the standard
+   error key-values `type` / `status` / `message` across all four runtimes (three
+   Java sites and their twins were missing the `type` key or used a plain-text body).
+4. **Node.js**: object error bodies would have stringified as `[object Object]`;
+   fixed with JSON rendering (`errorText`).
+5. **Java demo relay**: the forward event was built with the raw (untraced)
+   EventEmitter, silently dropping the distributed trace across the hop; fixed
+   with a trace-aware PostOffice - found by the trace-continuity verification
+   above.
+
+## Reproduce
+
+Every row of the matrix uses shipped demo applications:
+
+- **Engine as producer**: run the Java `lambda-example` (port 8085) or Rust
+  `hello-world` (8085; any port with `-Drest.server.port=…`); their public
+  `hello.sse` streams paced test messages. Consume from a wrapper with
+  `PostOffice.stream("hello.sse", …, endpoint="http://host:port/api/event")` and the
+  demo `authorization: demo` header.
+- **Engine as consumer**: run a wrapper demo app (python `mercury-serve
+  examples/demo_app.py`, port 8086; node demo, 8087), then the engine demo with its
+  routing map (Java: `-Dyaml.event.over.http=classpath:/event-over-http.yaml`; Rust:
+  ships enabled) and `-Dpeer.demo.port` as needed, and watch
+  `curl -N -H 'accept: text/event-stream'
+  'http://127.0.0.1:8085/api/hello/remote?delay=300&count=3'` render the wrapper's
+  tokens progressively out the engine's edge.
+- **Wrapper ⇄ wrapper**: point either wrapper's `stream()` at the other demo's
+  `/api/event`.
+
+Baselines at the time of the drives: Java engine main after PR #301, Rust engine main
+after PR #218, mercury-python and mercury-nodejs at the streaming feature round -
+shipped together as the v4.12.0 milestone release across all four repositories.
+
+## Appendix - telemetry and app context example (live capture)
+
+One live request, captured end to end, showing how the telemetry stream and
+the application log context connect the engine to the wrapper. Setup: the Java
+`lambda-example` (port 8085) with its event-over-http map pointing
+`hello.tokens` at the Python demo app (port 8086, `-Dlog.format=compact`).
+The caller supplies a business correlation-id; the engine's HTTP edge mints
+the trace:
+
+```bash
+curl -N -H 'accept: text/event-stream' -H 'X-Correlation-Id: biz-e2e-777' \
+  'http://127.0.0.1:8085/api/hello/remote?delay=100&count=1'
+```
+
+**1. Java engine - the relay function's telemetry record** (the root span of
+trace `710dcb0b706e4b5b949be138d0992b0b`, minted at the edge):
+
+```json
+{
+  "level": "INFO",
+  "time": "2026-08-29 21:24:17.734",
+  "source": "org.platformlambda.core.services.Telemetry.handleEvent(Telemetry.java:81)",
+  "thread": 762,
+  "message": {
+    "trace": {
+      "path": "GET /api/hello/remote?delay=100&count=1",
+      "span_id": "afa2897918e3871b",
+      "service": "hello.remote.relay",
+      "success": true,
+      "origin": "20260830a0dcb550832b4683b4853c609778cd82",
+      "start": "2026-08-30T04:24:17.733Z",
+      "exec_time": 0.728,
+      "from": "http.request",
+      "id": "710dcb0b706e4b5b949be138d0992b0b",
+      "status": 200
+    }
+  }
+}
+```
+
+**2. The wire** - the relay's trace-aware PostOffice stamps the outbound event
+with the trace id and path, its own span id (`afa2897918e3871b`) and the
+`my_cid` tag (`biz-e2e-777`); the whole envelope crosses `POST /api/event`,
+with `X-Trace-Id` and the W3C `traceparent` on the HTTP headers.
+
+**3. Python wrapper - the function's own application log line.** The handler
+runs `log.info("Streaming %d messages", count)`; the app-log-context feature
+adds the `context` block. Note the join keys: the engine's trace id, the
+business `cid` from the edge header, and this execution's `spanId` with the
+relay's span as `parentSpanId`:
+
+```json
+{"time": "2026-08-29 21:24:17.847", "level": "INFO", "logger": "mercury_user_app:93", "message": "Streaming 1 messages", "context": {"cid": "biz-e2e-777", "traceId": "710dcb0b706e4b5b949be138d0992b0b", "tracePath": "GET /api/hello/remote?delay=100&count=1", "spanId": "55ebd6464ffdf9c2", "parentSpanId": "afa2897918e3871b", "service": "hello.tokens", "timestamp": "2026-08-30T04:24:17.847Z"}}
+```
+
+**4. Python wrapper - the telemetry record for the same execution** (same
+`span_id` as the app log line's `spanId` - the join key between the two
+streams; `from` names the calling engine function):
+
+```json
+{"time": "2026-08-29 21:24:17.949", "level": "INFO", "logger": "distributed.tracing:158", "message": {"trace": {"origin": "202608303cbae673831a4ab08cbb6f108fec0171", "id": "710dcb0b706e4b5b949be138d0992b0b", "path": "GET /api/hello/remote?delay=100&count=1", "service": "hello.tokens", "start": "2026-08-30T04:24:17.847Z", "success": true, "from": "hello.remote.relay", "exec_time": 101.673, "status": 200, "span_id": "55ebd6464ffdf9c2", "parent_span_id": "afa2897918e3871b"}}}
+```
+
+**5. Java engine - a reply-lane delivery record.** The wrapper's stream
+segments carry its span, so the engine-side delivery span parents onto the
+Python function (`parent_span_id = 55ebd6464ffdf9c2`):
+
+```json
+{
+  "level": "INFO",
+  "time": "2026-08-29 21:24:17.853",
+  "source": "org.platformlambda.core.services.Telemetry.handleEvent(Telemetry.java:81)",
+  "thread": 779,
+  "message": {
+    "trace": {
+      "path": "GET /api/hello/remote?delay=100&count=1",
+      "parent_span_id": "55ebd6464ffdf9c2",
+      "span_id": "a50c19b7415406df",
+      "service": "async.http.response.stream.499",
+      "success": true,
+      "origin": "20260830a0dcb550832b4683b4853c609778cd82",
+      "start": "2026-08-30T04:24:17.851Z",
+      "exec_time": 1.202,
+      "from": "hello.tokens",
+      "id": "710dcb0b706e4b5b949be138d0992b0b",
+      "status": 200
+    }
+  }
+}
+```
+
+**6. The caller's view** - the terminal SSE frame rendered back out the Java
+edge echoes both continuity dimensions:
+
+```text
+event: done
+data: {"trace_id":"710dcb0b706e4b5b949be138d0992b0b","count":1,"my_correlation_id":"biz-e2e-777","language":"python"}
+```
+
+**Connectivity, in one paragraph.** Every record above carries the one trace
+id the engine minted at its HTTP edge, and the span ids chain across the
+runtime boundary in both directions: the edge request → the relay function's
+span (`afa289...`) → the Python execution's span (`55ebd6...`, parented on the
+relay) → the engine's reply-lane delivery spans (parented on the Python span).
+The business correlation-id from the `X-Correlation-Id` edge header rides the
+`my_cid` envelope tag through every hop and surfaces as the `cid` in the
+wrapper's app-log context and in the demo's terminal metadata. The wrapper's
+application log line and its telemetry record share the same `span_id`, which
+is what lets a log aggregation (or a stdout log-ingest agent) attach a
+function's own log output to the exact span of the distributed trace - the
+complete telemetry and app-context story from user to engine to wrapper and
+back, assembled entirely from the four runtimes' stdout logs.

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -129,6 +129,31 @@ messages would appear all at once when the stream ends.
 Optional query parameters: `delay` in milliseconds between messages (default 1000)
 and `count` for the number of messages (default 10), e.g. `/api/hello/sse?delay=500&count=5`.
 
+### Streaming from a remote function
+
+The companion endpoint `GET /api/hello/remote` demonstrates the engine-to-wrapper
+composition: its function (`HelloRemoteRelay` in [src/main.rs](src/main.rs)) forwards
+its reply lane into a send to the event-over-http mapped `hello.tokens` function -
+the streaming demo of the python or node.js function host - and the remote segments
+re-render progressively out this application's HTTP edge, with no imperative
+streaming code in between. The routing map ships in
+[resources/event-over-http.yaml](resources/event-over-http.yaml); the python
+demo-app is the default peer (port 8086) and `-Dpeer.demo.port=8087` points at the
+node demo instead.
+
+Start a wrapper demo app (mercury-python's `mercury-serve examples/demo_app.py`,
+or the mercury-nodejs demo), run this application, and watch the remote function's
+tokens render one by one:
+
+```bash
+curl -N -H 'accept: text/event-stream' 'http://127.0.0.1:8085/api/hello/remote?delay=300&count=3'
+```
+
+The same `hello.sse` function is public, so the composition also runs the other
+way: a python or node.js function can consume this application's stream through
+`POST /api/event` (with the demo `authorization: demo` token) - see the wrapper
+documentation sites' Event Streaming chapters.
+
 ## Where things live
 
 | File | Role |

--- a/examples/hello-world/resources/event-over-http.yaml
+++ b/examples/hello-world/resources/event-over-http.yaml
@@ -1,0 +1,8 @@
+# Declarative Event-over-HTTP routing (yaml.event.over.http - this default
+# location auto-loads). The "hello.tokens" route is the wrapper demo apps'
+# streaming function: the python demo-app defaults to port 8086, the node
+# demo-app to 8087 - point at another peer with -Dpeer.demo.host /
+# -Dpeer.demo.port. Used by the /api/hello/remote streaming relay demo.
+event.http:
+  - route: 'hello.tokens'
+    target: 'http://${peer.demo.host:127.0.0.1}:${peer.demo.port:8086}/api/event'

--- a/examples/hello-world/resources/rest.yaml
+++ b/examples/hello-world/resources/rest.yaml
@@ -25,6 +25,21 @@ rest:
     tracing: true
     stream: true
 
+  # The engine-to-wrapper streaming composition: the endpoint's function
+  # forwards its reply lane into a send to the event-over-http mapped
+  # "hello.tokens" function (the python/node demo apps) - the remote segments
+  # re-render progressively out this application's HTTP edge. See
+  # HelloRemoteRelay in main.rs and the README's "Streaming from a remote
+  # function" section.
+  - service: "hello.remote.relay"
+    methods: ['GET']
+    url: "/api/hello/remote"
+    timeout: 30s
+    cors: cors_1
+    headers: header_1
+    tracing: true
+    stream: true
+
   # Override the default "/api/event" endpoint to attach the demo
   # authentication service (the EventApiAuth function). A calling party must
   # present the shared demo token in the "authorization" header - see

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -377,7 +377,10 @@ impl ComposableFunction for HttpRequestFilter {
 /// Try it with the companion script: `node scripts/sse-client.mjs`
 /// or with `curl -N -H 'accept: text/event-stream'` against
 /// `http://127.0.0.1:8085/api/hello/sse`
-#[preload(route = "hello.sse", instances = 10, interceptor)]
+// public so a peer application (an engine or a python/node function host) can
+// consume this stream through /api/event - the cross-runtime streaming demo,
+// the hello.declarative precedent
+#[preload(route = "hello.sse", instances = 10, interceptor, is_private = false)]
 struct HelloSse;
 
 #[async_trait]
@@ -458,6 +461,65 @@ impl EntryPoint for PreflightCheck {
         // the trace-independent context keys (environment, hello, timestamp)
         log::info!("[before-application] configuration validated");
         Ok(())
+    }
+}
+
+// ---- the engine-to-wrapper streaming relay (/api/hello/remote) ----
+
+/// The engine-to-wrapper streaming composition: this endpoint's function
+/// forwards its own reply lane and correlation id into a send to the
+/// event-over-http mapped "hello.tokens" function - the python/node demo apps'
+/// streaming function - and opts in with the "accept: text/event-stream" event
+/// header. The remote segments relay through the peer's /api/event in envelope
+/// mode and re-render progressively out this application's HTTP edge, with no
+/// imperative streaming code in between.
+///
+/// The routing map ships in resources/event-over-http.yaml (the python demo
+/// defaults to port 8086; point at another peer with -Dpeer.demo.host /
+/// -Dpeer.demo.port). Start a wrapper demo app, then:
+/// `curl -N -H 'accept: text/event-stream'` against
+/// `http://127.0.0.1:8085/api/hello/remote?delay=300&count=3`
+#[preload(route = "hello.remote.relay", instances = 10, interceptor)]
+struct HelloRemoteRelay;
+
+#[async_trait]
+impl ComposableFunction for HelloRemoteRelay {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        const REMOTE_ROUTE: &str = "hello.tokens";
+        let platform = Platform::get_instance();
+        if platform_core::automation::get_event_http_target(REMOTE_ROUTE).is_none() {
+            // teaching failure: the demo depends on the declarative routing map
+            let mut out = EventStreamWriter::from_request(&platform, &input)?;
+            out.fail(&AppError::new(
+                503,
+                "Remote streaming demo is not configured - check event-over-http.yaml and start a wrapper demo app (see README)",
+            ))
+            .await?;
+            return Ok(EventEnvelope::new());
+        }
+        let request: serde_json::Value = input.body_as()?;
+        let query = &request["parameters"]["query"];
+        let mut forward = EventEnvelope::new()
+            .set_to(REMOTE_ROUTE)
+            .set_reply_to(input.reply_to().unwrap_or_default())
+            .set_correlation_id(input.correlation_id().unwrap_or_default())
+            // the event-level opt-in for progressive streaming over Event-over-HTTP
+            .set_header("accept", "text/event-stream")
+            // idle allowance between stream events on both hops (ms)
+            .set_header("x-ttl", "30000");
+        if let Some(delay) = query["delay"].as_str() {
+            forward = forward.set_header("delay", delay);
+        }
+        if let Some(count) = query["count"].as_str() {
+            forward = forward.set_header("count", count);
+        }
+        PostOffice::new(&platform).send(forward).await?;
+        Ok(EventEnvelope::new())
     }
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
       - Reserved Names & Headers: guides/reserved-names-and-headers.md
       - Actuators & HTTP Client: guides/actuators-and-http-client.md
       - "Interop Test Report (Java ⇄ Rust)": test-reports/event-over-http-interop.md
+      - "Interop Test Report — Progressive Rendering": test-reports/progressive-rendering-interop.md
       - "Interop Test Report — Suspend/Resume": test-reports/suspend-resume-interop.md
       - "AI Companion Test Report": test-reports/AI-companion-test.md
       - Port Scope & Fidelity: background/port-scope.md

--- a/system/ai-contract-provider/resources/skill/files.list
+++ b/system/ai-contract-provider/resources/skill/files.list
@@ -39,5 +39,6 @@ references/index.md
 references/llms.txt
 references/test-reports/AI-companion-test.md
 references/test-reports/event-over-http-interop.md
+references/test-reports/progressive-rendering-interop.md
 references/test-reports/suspend-resume-interop.md
 security.json


### PR DESCRIPTION
## What

The v4.12.0 milestone release PR for the Rust engine (workspace version bump,
CHANGELOG section for 8/30/2026) plus the closing engine-side round of the
progressive-rendering program:

- **Engine-to-wrapper streaming demo**: hello-world gains
  `GET /api/hello/remote` (`hello.remote.relay`) - a `stream: true` endpoint
  whose interceptor forwards its caller's reply lane into the event-over-http
  mapped `hello.tokens` (the Python/Node.js demo apps' streaming function),
  with a sample auto-loaded `resources/event-over-http.yaml`. The Rust
  PostOffice is context-aware by construction (`apply_current_trace`), so
  trace and business correlation-id continue across the hop with no demo
  changes needed. `hello.sse` is now public for wrapper clients over
  `/api/event`.
- **Interop test report** (`docs/test-reports/progressive-rendering-interop.md`,
  packaged with the AI contract provider): the live ten-combination
  cross-runtime matrix, the OpenTelemetry span-lineage and
  business-correlation-id continuity verification (including the live
  Rust-edge drive `biz-rust-005`), the `/api/event` local-routes-only ruling,
  and the captured end-to-end telemetry + app-log-context appendix.

## Why

The same milestone as the Java engine's v4.12.0 PR: progressive rendering
end to end with full observability, shipped lock-step across the two engines
and the two language packs - useful on its own, and the foundation for the
AI SDLC (agent, MCP and tool adapters as wrapper-side functions with complete
span lineage and log-context correlation).

## Verification

- `cargo build --workspace` + `cargo test --workspace` green at v4.12.0
  (67 test suites), `cargo fmt --check` and `cargo clippy` clean.
- mkdocs strict build clean; the AI contract provider link validator passes
  with the new report in the inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>