### PR TITLE
Streaming reply lanes rotate - FIFO round-robin checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ the design rationale in [`draft-design-specs/`](draft-design-specs/).
 - The public constant `ASYNC_HTTP_RESPONSE_STREAM_PREFIX` (dotted lane-name prefix) is
   replaced by `ASYNC_HTTP_RESPONSE_STREAM_POOL` (the un-dotted pool base) - lane route
   names on the wire and in telemetry are unchanged.
+- Streaming reply-lane checkout now rotates through the pool (FIFO round-robin)
+  instead of re-picking the most recently released lane (LIFO): the first stream
+  takes `async.http.response.stream.0`, the next `.1`, and so on, with a released
+  lane rejoining at the tail - predictable lane selection in telemetry and maximal
+  rest before a lane is reused (lock-step with the Java engine).
 
 ---
 ## Version 4.12.0, 8/30/2026

--- a/crates/platform-core/src/automation/server.rs
+++ b/crates/platform-core/src/automation/server.rs
@@ -36,7 +36,7 @@
 //! stripped, Java `copyResponseHeaders` parity). Errors use the Java JSON
 //! shape `{status, message, type: "error"}`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -97,24 +97,30 @@ fn full(bytes: Bytes) -> HttpBody {
     BoxBody::new(Full::new(bytes))
 }
 
-/// Available streaming reply lanes — a LIFO stack (the "ready" signal pattern
-/// of the reactive manager/worker design): checkout takes the most recently
-/// released lane; release returns it. Filled once at server start.
-fn lane_pool() -> &'static Mutex<Vec<String>> {
-    static POOL: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
-    POOL.get_or_init(|| Mutex::new(Vec::new()))
+/// Available streaming reply lanes — a rotating FIFO queue (a rotating variant
+/// of the "ready" signal pattern of the reactive manager/worker design):
+/// checkout takes from the head and a released lane rejoins at the tail, so
+/// selection round-robins through the pool (`.0`, `.1`, `.2` ...) and a
+/// just-released lane rests the full pool length before reuse. Filled once at
+/// server start in member order.
+fn lane_pool() -> &'static Mutex<VecDeque<String>> {
+    static POOL: OnceLock<Mutex<VecDeque<String>>> = OnceLock::new();
+    POOL.get_or_init(|| Mutex::new(VecDeque::new()))
 }
 
 /// Check out a dedicated ordered reply lane for one streaming request.
 /// Returns None when the pool is exhausted.
 pub fn checkout_lane() -> Option<String> {
-    lane_pool().lock().expect("lane pool poisoned").pop()
+    lane_pool().lock().expect("lane pool poisoned").pop_front()
 }
 
-/// Return a reply lane to the pool — called when the owning request ends,
-/// and at startup to fill the pool.
+/// Return a reply lane to the tail of the pool — called when the owning
+/// request ends, and at startup to fill the pool.
 pub fn release_lane(route: String) {
-    lane_pool().lock().expect("lane pool poisoned").push(route);
+    lane_pool()
+        .lock()
+        .expect("lane pool poisoned")
+        .push_back(route);
 }
 
 /// The number of reply lanes currently available for checkout.

--- a/crates/platform-core/tests/event_stream_pool.rs
+++ b/crates/platform-core/tests/event_stream_pool.rs
@@ -15,7 +15,7 @@
 //
 
 //! Reply-lane pool behavior for HTTP response streaming: checkout/release
-//! balance, LIFO reuse, and deterministic HTTP-503 back-pressure when the
+//! balance, rotation reuse, and deterministic HTTP-503 back-pressure when the
 //! pool is exhausted. These tests manipulate the process-wide pool, so they
 //! live in their own test binary and serialize among themselves through a
 //! shared guard.
@@ -179,17 +179,18 @@ async fn a_completed_stream_returns_its_lane_to_the_pool() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn lane_checkout_is_lifo() {
+async fn lane_checkout_rotates_through_the_pool() {
     let _port = server().await;
     let _guard = pool_guard().lock().await;
-    // the pool is a stack ("ready" signal pattern): the most recently
-    // released lane is the first to be reused
+    // the pool is a rotating FIFO queue: a released lane rejoins at the tail,
+    // so consecutive requests take successive lanes (round-robin) and a
+    // just-released lane gets the longest possible rest before reuse
     let first = automation::checkout_lane().expect("a lane");
     automation::release_lane(first.clone());
-    assert_eq!(
-        automation::checkout_lane().as_deref(),
-        Some(first.as_str()),
-        "most recently released lane is reused first"
+    let second = automation::checkout_lane().expect("another lane");
+    assert_ne!(
+        first, second,
+        "a released lane must go to the tail, not be reused immediately"
     );
-    automation::release_lane(first);
+    automation::release_lane(second);
 }

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2557,3 +2557,15 @@ same-day touch-up — lane route names unchanged). Tests: the `RoutePoolTest` tw
 (tests/route_pool.rs, six scenarios incl. a live RPC through a lane). Design
 record: the Java repo's draft-design-specs/register-route-pool.md (D1–D10
 ratified 2026-08-30).
+
+## Increment 95 — Streaming reply lanes rotate: FIFO round-robin checkout (2026-08-31)
+
+Lane checkout for HTTP response streaming now rotates through the pool instead of
+re-picking the most recently released lane: the pool became a `VecDeque` — checkout
+pops the front and a released lane rejoins at the back. The first stream takes
+`async.http.response.stream.0`, the next `.1`, and so on; a just-released lane rests
+the full pool length before reuse (maximal separation from any straggler cleanup on
+it), and lane selection is predictable in telemetry. Surfaced by the Java engine's
+live agent-orchestration regression run — every sequential stream re-picked `.499`
+off the LIFO stack top — and fixed lock-step on both engines the same day. The
+`lane_checkout_is_lifo` pin became `lane_checkout_rotates_through_the_pool`.


### PR DESCRIPTION
## What

Lane checkout for HTTP response streaming rotates through the pool instead of re-picking
the most recently released lane: the pool became a `VecDeque` - checkout pops the front, a
released lane rejoins at the back. Sequential streams walk
`async.http.response.stream.0`, `.1`, `.2` ...; the `lane_checkout_is_lifo` pin became
`lane_checkout_rotates_through_the_pool`. Increment 95; CHANGELOG Unreleased updated.

## Why

Lock-step with the Java engine's same-day change (mercury-composable
`feature/agent-orchestration-e0`), surfaced by its live agent-orchestration regression
run: every sequential stream re-picked `.499` off the LIFO stack top. Rotation makes lane
selection predictable in telemetry and gives a just-released lane the longest possible
rest before reuse - maximal separation from any straggler cleanup on it.

## Tests

platform-core suite green; clippy and fmt clean.

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)