### PR TITLE
Doc: guide-first lookup rule + system/AGENTS.md consumer starting point

### DIFF
--- a/memory/sessions/2026-09-01-161203.md
+++ b/memory/sessions/2026-09-01-161203.md
@@ -6,6 +6,8 @@
 Added "Efficient lookup" section to `system/AGENTS.md` — guide-first rule for consumer AI
 agents, matching the convention added to mercury-composable's `system/AGENTS.md` in PR #306.
 
+PR: [#222](https://github.com/Accenture/mercury/pull/222) — awaiting merge.
+
 ## Memory References
 
 (none)

--- a/memory/sessions/2026-09-01-161203.md
+++ b/memory/sessions/2026-09-01-161203.md
@@ -1,0 +1,11 @@
+# Session (2026-09-01T16:12:03.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** doc-only change, no memory-relevant events.
+
+Added "Efficient lookup" section to `system/AGENTS.md` — guide-first rule for consumer AI
+agents, matching the convention added to mercury-composable's `system/AGENTS.md` in PR #306.
+
+## Memory References
+
+(none)

--- a/system/AGENTS.md
+++ b/system/AGENTS.md
@@ -46,3 +46,20 @@ functions they call use this port's Rust API.
 - REST automation: `docs/guides/rest-automation.md` — a flow binding needs BOTH
   `service: 'http.flow.adapter'` and `flow: '<flow-id>'`
 - Function authoring: `docs/guides/event-driven/ai-agent-guide.md` (the Rust contract)
+
+## Efficient lookup
+
+**For "how do I configure / use X" questions, start with the guide — not the source.**
+The guides served by `ai-contract-provider` (and exported into the `mercury-platform` skill)
+are the version-matched, token-efficient answer surface. A typical configuration question
+costs 3–5× more tokens when answered from source discovery instead of the guide.
+
+Lookup order:
+1. `docs/llms.txt` → find the matching guide page by keyword.
+2. Read the relevant guide section.
+3. Fall back to source only when the guide is genuinely silent on the specific behavior or you
+   need to verify a subtle invariant (exact constant name, safety contract, test-proven edge case).
+
+When source reveals something the guide missed, note the gap and consider raising an issue
+or PR against the upstream OSS project (github.com/Accenture/mercury) — that is how the
+guides improve.


### PR DESCRIPTION
## What

Standardizes the `system/AGENTS.md` consumer entry-point convention across all Mercury repos.

**mercury (Rust) — `system/AGENTS.md`**
Added an "Efficient lookup" section: guide-first rule, ordered lookup steps (llms.txt → guide
section → source as last resort), and upstream PR pointer for guide gaps.

**mercury-python / mercury-nodejs — new `system/AGENTS.md`**
Created the file (it did not exist yet — early-phase repos). Content mirrors the engine repos:
what this wrapper is, starting-point guide sequence, key reference table, and the efficient
lookup rule. Updated root `AGENTS.md` consumer path to point to `system/AGENTS.md` instead of
README.md directly.

## Why

`system/AGENTS.md` is the convention for the consumer AI agent entry point across the Mercury
family (established in mercury-composable). Tooling that discovers this path gets a consistent,
expanded guide surface in every repo. The guide-first rule (introduced in mercury-composable
PR #306) is now present at every entry point a consumer agent might land on.