### PR TITLE
Release v4.12.1 - first crates.io publication, mercury-prefixed package names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`draft-design-specs/`](draft-design-specs/).
 
 ---
-## Unreleased
+## Version 4.12.1, 9/1/2026
+
+The first public-registry release: the seven library crates publish to crates.io
+under mercury-prefixed package names, with lib (code-facing) names unchanged.
+Functionally a small follow-up to v4.12.0 (reply-lane rotation + the route pool
+registration API shipped after the tag).
 
 ### Added
 
@@ -32,6 +37,14 @@ the design rationale in [`draft-design-specs/`](draft-design-specs/).
   takes `async.http.response.stream.0`, the next `.1`, and so on, with a released
   lane rejoining at the tail - predictable lane selection in telemetry and maximal
   rest before a lane is reused (lock-step with the Java engine).
+- Library package names are mercury-prefixed for crates.io publication:
+  `mercury-platform-core`, `mercury-platform-macros`, `mercury-event-script`,
+  `mercury-event-script-macros`, `mercury-knowledge-graph`,
+  `mercury-knowledge-graph-macros`, `mercury-minigraph-state-redis`. The lib
+  (code-facing) names are unchanged, so source code and `use` paths are unaffected;
+  an application consuming these crates by path updates only its Cargo.toml
+  dependency keys. Application/example members are fenced with `publish = false`,
+  and the workspace `repository` metadata now points at this repository.
 
 ---
 ## Version 4.12.0, 8/30/2026

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,13 +13,13 @@ dependencies = [
 
 [[package]]
 name = "ai-contract-provider"
-version = "4.12.0"
+version = "4.12.1"
 dependencies = [
  "async-trait",
- "event-script",
- "knowledge-graph",
  "log",
- "platform-core",
+ "mercury-event-script",
+ "mercury-knowledge-graph",
+ "mercury-platform-core",
  "rmpv",
  "serde_json",
  "serde_yaml",
@@ -114,11 +114,11 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.12.0"
+version = "4.12.1"
 dependencies = [
  "async-trait",
  "log",
- "platform-core",
+ "mercury-platform-core",
  "rmpv",
  "tokio",
 ]
@@ -348,35 +348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-script"
-version = "4.12.0"
-dependencies = [
- "async-trait",
- "base64",
- "chrono",
- "chrono-tz",
- "event-script-macros",
- "iana-time-zone",
- "log",
- "platform-core",
- "rmpv",
- "serde_json",
- "serde_json_path",
- "tokio",
- "trybuild",
- "uuid",
-]
-
-[[package]]
-name = "event-script-macros"
-version = "4.12.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,12 +454,12 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.12.0"
+version = "4.12.1"
 dependencies = [
  "async-trait",
- "event-script",
  "log",
- "platform-core",
+ "mercury-event-script",
+ "mercury-platform-core",
  "rmpv",
  "serde_json",
  "tokio",
@@ -496,11 +467,11 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.12.0"
+version = "4.12.1"
 dependencies = [
  "async-trait",
  "log",
- "platform-core",
+ "mercury-platform-core",
  "rmpv",
  "serde",
  "serde_json",
@@ -751,35 +722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "knowledge-graph"
-version = "4.12.0"
-dependencies = [
- "async-trait",
- "chrono",
- "event-script",
- "getrandom 0.4.3",
- "knowledge-graph-macros",
- "log",
- "platform-core",
- "rmpv",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "trybuild",
- "uuid",
-]
-
-[[package]]
-name = "knowledge-graph-macros"
-version = "4.12.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,28 +755,126 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
-name = "minigraph-playground"
-version = "4.12.0"
+name = "mercury-event-script"
+version = "4.12.1"
 dependencies = [
  "async-trait",
- "event-script",
- "knowledge-graph",
+ "base64",
+ "chrono",
+ "chrono-tz",
+ "iana-time-zone",
  "log",
- "minigraph-state-redis",
- "platform-core",
+ "mercury-event-script-macros",
+ "mercury-platform-core",
+ "rmpv",
+ "serde_json",
+ "serde_json_path",
+ "tokio",
+ "trybuild",
+ "uuid",
+]
+
+[[package]]
+name = "mercury-event-script-macros"
+version = "4.12.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "mercury-knowledge-graph"
+version = "4.12.1"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "getrandom 0.4.3",
+ "log",
+ "mercury-event-script",
+ "mercury-knowledge-graph-macros",
+ "mercury-platform-core",
+ "rmpv",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "trybuild",
+ "uuid",
+]
+
+[[package]]
+name = "mercury-knowledge-graph-macros"
+version = "4.12.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "mercury-minigraph-state-redis"
+version = "4.12.1"
+dependencies = [
+ "async-trait",
+ "log",
+ "mercury-platform-core",
+ "redis",
  "rmpv",
  "tokio",
  "uuid",
 ]
 
 [[package]]
-name = "minigraph-state-redis"
-version = "4.12.0"
+name = "mercury-platform-core"
+version = "4.12.1"
+dependencies = [
+ "async-channel",
+ "async-trait",
+ "base64",
+ "futures-util",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "inventory",
+ "log",
+ "mercury-platform-macros",
+ "moka",
+ "rcgen",
+ "rmp-serde",
+ "rmpv",
+ "rustls-native-certs",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls",
+ "tokio-tungstenite",
+ "trybuild",
+ "uuid",
+]
+
+[[package]]
+name = "mercury-platform-macros"
+version = "4.12.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "minigraph-playground"
+version = "4.12.1"
 dependencies = [
  "async-trait",
  "log",
- "platform-core",
- "redis",
+ "mercury-event-script",
+ "mercury-knowledge-graph",
+ "mercury-minigraph-state-redis",
+ "mercury-platform-core",
  "rmpv",
  "tokio",
  "uuid",
@@ -998,46 +1038,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "platform-core"
-version = "4.12.0"
-dependencies = [
- "async-channel",
- "async-trait",
- "base64",
- "futures-util",
- "http-body-util",
- "hyper",
- "hyper-util",
- "inventory",
- "log",
- "moka",
- "platform-macros",
- "rcgen",
- "rmp-serde",
- "rmpv",
- "rustls-native-certs",
- "serde",
- "serde_json",
- "serde_yaml",
- "sha2",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rustls",
- "tokio-tungstenite",
- "trybuild",
- "uuid",
-]
-
-[[package]]
-name = "platform-macros"
-version = "4.12.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.12.0"
+version = "4.12.1"
 edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/Accenture/mercury-composable"
+repository = "https://github.com/Accenture/mercury"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # mercury
 
 A **Rust port of [mercury-composable](https://github.com/Accenture/mercury-composable)** —
-Accenture's event-driven, composable application platform (canonical Java implementation,
-v4.8.6), carrying the same vision: build applications from small, fully-decoupled functions
+Accenture's event-driven, composable application platform (the Java engine is the canonical
+reference; both engines release in lock-step at the same version), carrying the same vision: build applications from small, fully-decoupled functions
 wired by route name, orchestrated as configuration, and modeled as an executable knowledge
 graph.
 
-> **Status: all three layers ported and milestone-closed** across 49 verified increments;
-> 206 workspace tests green, `clippy` and `fmt` clean; benchmarked (RPC ~155K ops/s @ 6µs).
+> **Status: all three layers ported and milestone-closed** across 96 verified increments;
+> full workspace test suite, `clippy` and `fmt` clean; benchmarked (RPC ~155K ops/s @ 6µs).
 > The AI-agent documentation is battle-tested — twelve consecutive fresh-agent exercises
 > passed with zero documentation lookups, across both engines. See
 > [`CHANGELOG.md`](CHANGELOG.md) and [`docs/INCREMENTS.md`](docs/INCREMENTS.md).
@@ -26,6 +26,21 @@ Each layer builds on the one below (foundation → UI):
 3. **active knowledge graph** — the semantic layer: MiniGraph property graphs whose nodes
    carry executable **skills**, so traversing the graph *is* running the application — with
    the browser-based MiniGraph Playground for building, running and inspecting graphs.
+
+## Use from crates.io
+
+The seven library crates publish under mercury-prefixed package names, while the lib
+(code-facing) names stay short — Cargo.toml and code look like:
+
+```toml
+[dependencies]
+mercury-platform-core = "4.12"      # code: use platform_core::...
+mercury-event-script = "4.12"       # code: use event_script::...
+mercury-knowledge-graph = "4.12"    # code: use knowledge_graph::...
+```
+
+(The macro crates are pulled in automatically; add `mercury-minigraph-state-redis` for
+the Redis suspend/resume state store.)
 
 ## Quick start
 

--- a/benchmark/benchmark-reporter/Cargo.toml
+++ b/benchmark/benchmark-reporter/Cargo.toml
@@ -5,13 +5,15 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+# not a library release artifact - never publish to crates.io
+publish = false
 
 [[bin]]
 name = "benchmark-reporter"
 path = "src/main.rs"
 
 [dependencies]
-platform-core = { path = "../../crates/platform-core" }
+mercury-platform-core = { path = "../../crates/platform-core" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros"] }
 async-trait = "0.1"
 log = "0.4"

--- a/crates/event-script-macros/Cargo.toml
+++ b/crates/event-script-macros/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
-name = "event-script-macros"
+name = "mercury-event-script-macros"
 description = "Proc-macro annotations for the event-script layer (Java @SimplePlugin analog)"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "../../README.md"
+keywords = ["proc-macro", "orchestration", "mercury"]
+categories = ["development-tools::procedural-macro-helpers"]
 
 [lib]
+name = "event_script_macros"
 proc-macro = true
 
 [dependencies]

--- a/crates/event-script/Cargo.toml
+++ b/crates/event-script/Cargo.toml
@@ -1,13 +1,19 @@
 [package]
-name = "event-script"
+name = "mercury-event-script"
 description = "Rust port of mercury-composable event-script-engine — layer 2, composable orchestration"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "../../README.md"
+keywords = ["orchestration", "workflow", "event-driven", "yaml", "mercury"]
+categories = ["asynchronous"]
+
+[lib]
+name = "event_script"
 
 [dependencies]
-platform-core = { path = "../platform-core" }
+mercury-platform-core = { version = "4.12.1", path = "../platform-core" }
 async-trait = "0.1"
 log = "0.4"
 # --- increment E-2: data-mapping engine ---
@@ -25,7 +31,7 @@ chrono = "0.4"
 # (the ZoneId.systemDefault() analog, same crate chrono uses internally)
 chrono-tz = "0.10"
 iana-time-zone = "0.1"
-event-script-macros = { path = "../event-script-macros" }
+mercury-event-script-macros = { version = "4.12.1", path = "../event-script-macros" }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]

--- a/crates/knowledge-graph-macros/Cargo.toml
+++ b/crates/knowledge-graph-macros/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
-name = "knowledge-graph-macros"
+name = "mercury-knowledge-graph-macros"
 description = "Proc-macro annotations for the knowledge-graph layer (Java @FetchFeature analog)"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "../../README.md"
+keywords = ["proc-macro", "knowledge-graph", "mercury"]
+categories = ["development-tools::procedural-macro-helpers"]
 
 [lib]
+name = "knowledge_graph_macros"
 proc-macro = true
 
 [dependencies]

--- a/crates/knowledge-graph/Cargo.toml
+++ b/crates/knowledge-graph/Cargo.toml
@@ -1,17 +1,27 @@
 [package]
-name = "knowledge-graph"
+name = "mercury-knowledge-graph"
+description = "Rust port of mercury-composable's Active Knowledge Graph engine (MiniGraph) — layer 3, graphs that execute behavior via node skills"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "../../README.md"
+keywords = ["knowledge-graph", "workflow", "orchestration", "low-code", "mercury"]
+categories = ["asynchronous"]
+# the webapp/ React SOURCE is build-time only (its built bundle ships in
+# resources/public); keep the registry artifact lean
+exclude = ["webapp/"]
+
+[lib]
+name = "knowledge_graph"
 
 [dependencies]
-platform-core = { path = "../platform-core" }
+mercury-platform-core = { version = "4.12.1", path = "../platform-core" }
 # layer 3 rides layer 2: the data-mapping mini-language (converter, rmpv
 # MultiLevelMap) is shared with event-script, and deployed graphs are
 # exposed through event-script flows
-event-script = { path = "../event-script" }
-knowledge-graph-macros = { path = "../knowledge-graph-macros" }
+mercury-event-script = { version = "4.12.1", path = "../event-script" }
+mercury-knowledge-graph-macros = { version = "4.12.1", path = "../knowledge-graph-macros" }
 async-trait = "0.1"
 log = "0.4"
 rmpv = { version = "1", features = ["with-serde"] }

--- a/crates/platform-core/Cargo.toml
+++ b/crates/platform-core/Cargo.toml
@@ -1,10 +1,18 @@
 [package]
-name = "platform-core"
+name = "mercury-platform-core"
 description = "Rust port of mercury-composable platform-core — the event-driven foundation layer"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "../../README.md"
+keywords = ["event-driven", "composable", "microservices", "event-bus", "mercury"]
+categories = ["asynchronous", "network-programming"]
+
+# registry name is mercury-prefixed; the lib keeps its code-facing name so
+# every `use platform_core::...` (and macro-generated code) stays unchanged
+[lib]
+name = "platform_core"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -34,7 +42,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["ring",
 rustls-native-certs = "0.8"
 # --- increment 10: annotation macros (Java @PreLoad/@BeforeApplication/@MainApplication) ---
 inventory = "0.3"
-platform-macros = { path = "../platform-macros" }
+mercury-platform-macros = { version = "4.12.1", path = "../platform-macros" }
 # --- increment 71: ManagedCache (docs/design/managed-cache-port.md — the Caffeine-lineage
 # engine, wrapped; EvictionPolicy::lru per the maintainer's deterministic-eviction ruling) ---
 moka = { version = "0.12", features = ["sync"] }

--- a/crates/platform-macros/Cargo.toml
+++ b/crates/platform-macros/Cargo.toml
@@ -1,12 +1,17 @@
 [package]
-name = "platform-macros"
+name = "mercury-platform-macros"
 description = "Attribute macros emulating mercury-composable's Java annotations (@PreLoad, @BeforeApplication, @MainApplication, @ZeroTracing) for the Rust platform-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "../../README.md"
+keywords = ["proc-macro", "annotations", "composable", "mercury"]
+categories = ["development-tools::procedural-macro-helpers"]
 
 [lib]
+# code-facing name preserved (see platform-core)
+name = "platform_macros"
 proc-macro = true
 
 [dependencies]

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2569,3 +2569,19 @@ it), and lane selection is predictable in telemetry. Surfaced by the Java engine
 live agent-orchestration regression run — every sequential stream re-picked `.499`
 off the LIFO stack top — and fixed lock-step on both engines the same day. The
 `lane_checkout_is_lifo` pin became `lane_checkout_rotates_through_the_pool`.
+
+## Increment 96 — crates.io publication metadata: mercury-prefixed package names (2026-09-01)
+
+The seven library crates gained public-registry identities for the first crates.io
+release (v4.12.1): package names are mercury-prefixed (`mercury-platform-core`,
+`mercury-event-script`, `mercury-knowledge-graph`, the three macro crates, and
+`mercury-minigraph-state-redis`) because the registry namespace is global and the
+bare names say nothing about Mercury — all seven were verified free before claiming.
+Each crate pins `[lib] name` to its original snake_case name, so every `use` path and
+all macro-generated code stay byte-identical; only Cargo.toml dependency keys change.
+Internal dependencies carry `version` alongside `path` (a cargo publish requirement),
+application and example members are fenced with `publish = false`, the workspace
+`repository` URL now points at this repository (it pointed at the Java engine's), and
+each crate ships the root README plus keywords/categories for the registry page.
+Publication itself is one `cargo publish --workspace` from the v4.12.1 tag (cargo ≥1.90
+orders the graph and waits for index propagation); the publish act is the maintainer's.

--- a/examples/hello-flow/Cargo.toml
+++ b/examples/hello-flow/Cargo.toml
@@ -5,10 +5,12 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+# not a library release artifact - never publish to crates.io
+publish = false
 
 [dependencies]
-platform-core = { path = "../../crates/platform-core" }
-event-script = { path = "../../crates/event-script" }
+mercury-platform-core = { path = "../../crates/platform-core" }
+mercury-event-script = { path = "../../crates/event-script" }
 async-trait = "0.1"
 serde_json = "1"
 log = "0.4"

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -5,9 +5,11 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+# not a library release artifact - never publish to crates.io
+publish = false
 
 [dependencies]
-platform-core = { path = "../../crates/platform-core" }
+mercury-platform-core = { path = "../../crates/platform-core" }
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/examples/minigraph-playground/Cargo.toml
+++ b/examples/minigraph-playground/Cargo.toml
@@ -5,16 +5,18 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+# not a library release artifact - never publish to crates.io
+publish = false
 
 [dependencies]
-platform-core = { path = "../../crates/platform-core" }
-event-script = { path = "../../crates/event-script" }
-knowledge-graph = { path = "../../crates/knowledge-graph" }
+mercury-platform-core = { path = "../../crates/platform-core" }
+mercury-event-script = { path = "../../crates/event-script" }
+mercury-knowledge-graph = { path = "../../crates/knowledge-graph" }
 # Redis state store for graph suspend/resume: linking this crate registers
 # v1.redis.persist.model and v1.redis.retrieve.model automatically (preload
 # inventory) - the connection is lazy, so the app runs normally without
 # Redis until a graph actually suspends or resumes.
-minigraph-state-redis = { path = "../../extensions/minigraph-state-redis" }
+mercury-minigraph-state-redis = { path = "../../extensions/minigraph-state-redis" }
 async-trait = "0.1"
 log = "0.4"
 

--- a/extensions/minigraph-state-redis/Cargo.toml
+++ b/extensions/minigraph-state-redis/Cargo.toml
@@ -1,13 +1,19 @@
 [package]
-name = "minigraph-state-redis"
+name = "mercury-minigraph-state-redis"
 description = "Redis implementation of the graph suspend/resume state-store contract (import from the application, never the engine)"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "../../README.md"
+keywords = ["redis", "state-store", "suspend-resume", "workflow", "mercury"]
+categories = ["database", "asynchronous"]
+
+[lib]
+name = "minigraph_state_redis"
 
 [dependencies]
-platform-core = { path = "../../crates/platform-core" }
+mercury-platform-core = { version = "4.12.1", path = "../../crates/platform-core" }
 async-trait = "0.1"
 log = "0.4"
 rmpv = { version = "1", features = ["with-serde"] }

--- a/system/ai-contract-provider/Cargo.toml
+++ b/system/ai-contract-provider/Cargo.toml
@@ -5,10 +5,12 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+# not a library release artifact - never publish to crates.io
+publish = false
 
 [dependencies]
-platform-core = { path = "../../crates/platform-core" }
-event-script = { path = "../../crates/event-script" }
+mercury-platform-core = { path = "../../crates/platform-core" }
+mercury-event-script = { path = "../../crates/event-script" }
 async-trait = "0.1"
 serde_json = "1"
 serde_yaml = "0.9"
@@ -19,6 +21,6 @@ log = "0.4"
 # anchor verification only: contract behavior anchors are resolved at compile
 # time by tests (the Java Class.forName analog) - a runtime dependency on the
 # knowledge-graph crate would preload the playground into this app
-knowledge-graph = { path = "../../crates/knowledge-graph" }
+mercury-knowledge-graph = { path = "../../crates/knowledge-graph" }
 rmpv = { version = "1", features = ["with-serde"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util"] }


### PR DESCRIPTION
## What

The v4.12.1 release: crates.io publication metadata for the seven library crates, plus
the two items riding since v4.12.0 (streaming reply-lane FIFO rotation; the route pool
registration API).

- Package names are **mercury-prefixed** (`mercury-platform-core`, `mercury-platform-macros`,
  `mercury-event-script`, `mercury-event-script-macros`, `mercury-knowledge-graph`,
  `mercury-knowledge-graph-macros`, `mercury-minigraph-state-redis`) - all seven verified
  free on crates.io before claiming. Each crate pins `[lib] name` to its original
  snake_case form, so **source code, `use` paths and macro-generated code are unchanged**;
  only Cargo.toml dependency keys change. Consumers write
  `mercury-event-script = "4.12"` and `use event_script::...`.
- Internal dependencies carry `version` alongside `path` (a `cargo publish` requirement);
  application/example/benchmark members are fenced with `publish = false`; the workspace
  `repository` URL now points at this repository (it pointed at the Java engine's); each
  crate ships the root README plus keywords/categories for its registry page.
- `mercury-knowledge-graph` excludes the `webapp/` React source from its package (355 -> 183
  files, ~4MB -> ~2.5MB raw); the built UI bundle in `resources/public` still ships and the
  runtime resource-root mechanism is untouched.
- CHANGELOG flipped to 4.12.1; Increment 96; README gains a "Use from crates.io" section
  and drops stale version/increment counts.

## Why

Eric green-lit public-registry publication (P5 of the polyglot initiative, widened to
include this engine). Registry artifacts should correspond to a tag, and main had moved
past v4.12.0 (rotation, route pools) - hence a fresh lock-step v4.12.1 rather than
publishing 4.12.0-labeled crates that don't match the v4.12.0 tag. Generic bare names
(`platform-core`, `event-script`) would claim global namespace that says nothing about
Mercury; the prefix keeps registry identity clear at zero source-code cost.

## Verification

Full workspace tests, clippy (zero warnings), fmt clean, and
`cargo publish --workspace --dry-run`: all seven crates package, **compile from their
packaged form against the not-yet-published siblings**, and reach the upload step.

One known characteristic (pre-existing, not changed here): the engine's bundled
resources resolve via `CARGO_MANIFEST_DIR`, which for registry consumers points into the
cargo registry cache on the build machine - fine for build-and-run and containerized
builds; a future increment could embed via `include_dir!` if field demand appears.

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)