### PR TITLE
Retire the async companion endpoint - lock-step with the Java engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`draft-design-specs/`](draft-design-specs/).
 
 ---
+## Unreleased
+
+### Breaking
+
+- The fire-and-forget AI companion endpoint `POST /api/companion/{id}` is RETIRED
+  (lock-step with the Java engine, its ADR-0021) - the bare URL now answers 404. Use the
+  synchronous `POST /api/companion/{id}/sync`, unchanged, which returns the command
+  outcome in-band and tees output to the session console. Driven by a field AI-agent
+  exercise: the async form hid errors and forced sleep-padded drivers.
+
+### Documentation
+
+- AI-grammar feedback round: the companion guides document /sync as the only endpoint;
+  "restart ends the session - export first" and "404 means the session is gone" warnings.
+  (graph.js needed no action here - this port never carried it and its guides already
+  say so; the Java engine formally deprecated it, ADR-0022.)
+
+---
 ## Version 4.12.1, 9/1/2026
 
 The first public-registry release: the seven library crates publish to crates.io

--- a/crates/knowledge-graph/src/lib.rs
+++ b/crates/knowledge-graph/src/lib.rs
@@ -430,26 +430,11 @@ impl ComposableFunction for GetWsHtml {
     }
 }
 
-/// Java `PostCompanionCommand` (`post.companion.command`) — the AI-companion hop.
-#[preload(route = "post.companion.command", instances = 10)]
-#[optional_service("app.env=dev")]
-pub struct PostCompanionCommand;
-
-#[async_trait]
-impl ComposableFunction for PostCompanionCommand {
-    async fn handle_event(
-        &self,
-        _headers: HashMap<String, String>,
-        input: EventEnvelope,
-        _instance: usize,
-    ) -> Result<EventEnvelope, AppError> {
-        rest::post_companion_command(&Platform::get_instance(), input).await
-    }
-}
-
-/// Synchronous AI-companion command (`post.companion.command.sync`) — returns the
-/// command outcome in-band (design: `draft-design-specs/ai-companion-sync.md`). Additive
-/// sibling of `post.companion.command`; the fire-and-forget hop is unchanged.
+/// Synchronous AI-companion command (`post.companion.command.sync`) — THE companion
+/// endpoint; returns the command outcome in-band (design:
+/// `draft-design-specs/ai-companion-sync.md`). Its fire-and-forget sibling
+/// (`post.companion.command`, which returned only `{status:"accepted"}`) was RETIRED
+/// 2026-09-02 in lock-step with the Java engine — it hid errors from the caller.
 #[preload(route = "post.companion.command.sync", instances = 10)]
 #[optional_service("app.env=dev")]
 pub struct PostCompanionCommandSync;

--- a/crates/knowledge-graph/src/rest.rs
+++ b/crates/knowledge-graph/src/rest.rs
@@ -111,64 +111,6 @@ pub async fn get_ws_html(event: EventEnvelope) -> Result<EventEnvelope, AppError
         .set_raw_body(Value::from(html.as_str())))
 }
 
-/// Java `PostCompanionCommand` (`post.companion.command`): the AI-companion
-/// hop — dispatches a text command to the singleton command handler.
-pub async fn post_companion_command(
-    platform: &Platform,
-    event: EventEnvelope,
-) -> Result<EventEnvelope, AppError> {
-    let (path_parameters, body, _) = request_view(&event);
-    let Some(id) = path_parameters.get("id") else {
-        return Err(invalid("Missing path parameter: id"));
-    };
-    let command = match &body {
-        Value::String(text) => text.as_str().unwrap_or_default().trim().to_string(),
-        _ => String::new(),
-    };
-    if command.is_empty() {
-        return Err(invalid("Body must be a non-empty text/plain command"));
-    }
-    if !commands::has_session(id) {
-        return Err(AppError::new(404, format!("No active session for id {id}")));
-    }
-    let route = id.replace('-', ".");
-    let in_route = format!("{route}.in");
-    let out_route = format!("{route}.out");
-    // Same restriction as the sync endpoint: only the read-only `session`
-    // status query is allowed from a companion (see `session_topology_subcommand`).
-    if let Some(sub) = session_topology_subcommand(&command) {
-        let error = refuse_session_topology(platform, &out_route, &command, sub).await;
-        return Err(AppError::new(400, error));
-    }
-    let po = PostOffice::new(platform);
-    let _ = po
-        .send(
-            EventEnvelope::new()
-                .set_to(commands::SINGLETON_COMMAND_HANDLER)
-                .set_raw_body(Value::Map(vec![
-                    (Value::from("type"), Value::from("command")),
-                    (Value::from("in"), Value::from(in_route.as_str())),
-                    (Value::from("out"), Value::from(out_route.as_str())),
-                    (Value::from("message"), Value::from(command.as_str())),
-                ])),
-        )
-        .await;
-    Ok(EventEnvelope::new()
-        .set_header("Content-Type", "application/json")
-        .set_raw_body(Value::Map(vec![
-            (Value::from("type"), Value::from("companion")),
-            (Value::from("status"), Value::from("accepted")),
-            (Value::from("id"), Value::from(id.as_str())),
-            (
-                Value::from("message"),
-                Value::from(
-                    "Command dispatched to graph.command.service. Output streams to the \
-                     WebSocket console for this session.",
-                ),
-            ),
-        ])))
-}
-
 /// Sentinel appended after a synchronous command so the capture route knows the
 /// command's (FIFO) output is fully drained. Not part of the returned output.
 const SYNC_SENTINEL: &str = "__companion_sync_done__";
@@ -311,8 +253,9 @@ fn is_traversal_terminal(line: &str) -> bool {
     line.starts_with("Graph traversal completed in") || line == "Graph traversal aborted"
 }
 
-/// **Synchronous** AI-companion command (design: `draft-design-specs/ai-companion-sync.md`).
-/// Additive sibling of [`post_companion_command`]: dispatches the same command but
+/// **Synchronous** AI-companion command (design: `draft-design-specs/ai-companion-sync.md`)
+/// — THE companion endpoint (its fire-and-forget sibling was retired 2026-09-02, both
+/// engines): dispatches the command and
 /// returns the command's **outcome in-band** — `ok`, the console `output` lines,
 /// the first `error` (if any), and any structured `result` (e.g. a run's
 /// `output.body`) — instead of a fire-and-forget `{status:"accepted"}`. The output

--- a/crates/knowledge-graph/tests/graph_runtime.rs
+++ b/crates/knowledge-graph/tests/graph_runtime.rs
@@ -1876,44 +1876,10 @@ async fn companion_sync_rejects_session_topology_commands(platform: &Platform) {
         "refusal must be visible on the live console: {teed:?}"
     );
 
-    // 4) the legacy fire-and-forget endpoint enforces the same restriction (400),
-    //    while the read-only `session` status query still dispatches (accepted)
-    async fn legacy_cmd(
-        platform: &Platform,
-        sid: &str,
-        command: &str,
-    ) -> Result<EventEnvelope, AppError> {
-        let event = EventEnvelope::new().set_raw_body(rmpv::Value::Map(vec![
-            (
-                rmpv::Value::from("parameters"),
-                rmpv::Value::Map(vec![(
-                    rmpv::Value::from("path"),
-                    rmpv::Value::Map(vec![(rmpv::Value::from("id"), rmpv::Value::from(sid))]),
-                )]),
-            ),
-            (rmpv::Value::from("body"), rmpv::Value::from(command)),
-            (rmpv::Value::from("method"), rmpv::Value::from("POST")),
-        ]));
-        knowledge_graph::rest::post_companion_command(platform, event).await
-    }
-    let refused = legacy_cmd(platform, sid, &format!("session subscribe {peer}")).await;
-    match refused {
-        Err(e) => {
-            assert_eq!(e.status(), 400, "legacy endpoint refuses with 400");
-            assert!(
-                e.message()
-                    .contains("not available on the companion endpoint"),
-                "legacy refusal carries the reason: {}",
-                e.message()
-            );
-        }
-        Ok(resp) => panic!("legacy endpoint must refuse session subscribe: {resp:?}"),
-    }
-    let status_ok = legacy_cmd(platform, sid, "session").await;
-    assert!(
-        status_ok.is_ok(),
-        "read-only 'session' stays allowed on the legacy endpoint: {status_ok:?}"
-    );
+    // 4) the fire-and-forget sibling is RETIRED (2026-09-02, lock-step with the
+    //    Java engine): the REST-layer 404 pin lives in tests/playground.rs; there is
+    //    no direct function to call anymore - /sync (tested above) is the only
+    //    companion endpoint.
 }
 
 /// The `/sync` `ok` flag is derived from the console output — and `import

--- a/crates/knowledge-graph/tests/playground.rs
+++ b/crates/knowledge-graph/tests/playground.rs
@@ -312,8 +312,8 @@ async fn playground_command_grammar_and_companion() {
     command(&po, in_route, out_route, "export graph as playtest").await;
     assert!(console_has(&lines, "Graph exported"), "export expected");
 
-    // --- the AI-companion REST hop: POST a command, output streams to the
-    // same session console (the field use case)
+    // --- the retired fire-and-forget companion URL answers 404 (retired
+    // 2026-09-02, lock-step with the Java engine): only /sync exists
     lines.lock().expect("console").clear();
     let public_id = "ws-100001-1";
     assert!(
@@ -335,12 +335,11 @@ async fn playground_command_grammar_and_companion() {
         )
         .await
         .expect("companion request");
-    let body = MultiLevelMap::from_value(reply.body().clone());
-    assert_eq!(Some(Value::from("accepted")), body.get_element("status"));
-    tokio::time::sleep(Duration::from_millis(120)).await;
-    assert!(
-        console_has(&lines, "mapper"),
-        "companion command output should reach the console"
+    assert_eq!(
+        404,
+        reply.status(),
+        "the retired async companion URL must answer 404: {:?}",
+        reply.body()
     );
 
     // --- the SYNCHRONOUS companion hop over REST: POST /api/companion/{id}/sync

--- a/crates/knowledge-graph/tests/resources/rest.yaml
+++ b/crates/knowledge-graph/tests/resources/rest.yaml
@@ -32,12 +32,7 @@ rest:
     timeout: 10s
     tracing: true
 
-  - service: 'post.companion.command'
-    methods: ['POST']
-    url: '/api/companion/{id}'
-    timeout: 10s
-    tracing: true
-
+  # THE companion endpoint (synchronous; the fire-and-forget sibling was retired 2026-09-02)
   - service: 'post.companion.command.sync'
     methods: ['POST']
     url: '/api/companion/{id}/sync'

--- a/crates/knowledge-graph/webapp/docs/COMPANION_ENDPOINT_README.md
+++ b/crates/knowledge-graph/webapp/docs/COMPANION_ENDPOINT_README.md
@@ -1,97 +1,69 @@
-# Companion Endpoint — Usage Guide
+# Driving the Playground from an HTTP client (the companion endpoint)
 
-A dev-only REST endpoint that lets an HTTP client (script, test harness, or AI
-agent) dispatch commands into an **already-open** MiniGraph Playground
-WebSocket session. Output continues to stream to the browser console.
-
-> Design and rationale: see [COMPANION_ENDPOINT_SPEC.md](COMPANION_ENDPOINT_SPEC.md).
-
----
-
-## When to use it
-
-- You have the Playground open in a browser and want an agent (or a curl
-  script) to drive graph-building commands while you watch the output.
-- You want to automate a reproducible graph setup without re-typing commands.
-- You're writing an integration test that needs to issue commands as if a
-  human were typing into the Playground CLI.
-
-This endpoint is **not** a headless way to run MiniGraph — it requires a live
-WebSocket session. It is also gated by `@OptionalService("app.env=dev")` and
-is not registered in production.
-
----
+The **companion endpoint** lets a script, test harness, or AI agent drive an
+already-open Playground session over plain HTTP. There is exactly **one**
+companion endpoint — the synchronous `/sync` (the fire-and-forget variant was
+retired 2026-09; its bare URL answers 404). The authoritative, always-current
+contract for AI drivers is the published **AI agent guide**
+(`docs/guides/knowledge-graph/ai-agent-guide.md`); this file is the short
+version for webapp developers.
 
 ## End-to-end flow
 
 ```
 1. Open  ws://<host>/ws/graph/playground
 2. Read  first inbound frame: { "type": "session", "id": "ws-123456-7" }
-3. POST  /api/companion/{id}  with Content-Type: text/plain  and the command in the body
-4. GET   /api/graph/session/{id}  when you want the current graph model as JSON
-5. Watch output appear on the WebSocket (HTTP response is just an ack)
+3. POST  /api/companion/{id}/sync  with Content-Type: text/plain, ONE command per request
+4. Read  the outcome from the HTTP response ({ok, output, error, result})
+5. GET   /api/graph/session/{id}  when you want the current graph model as JSON
 ```
 
-### Request
+Every output line is also teed to the session's WebSocket console, so a human
+watching the browser sees what the driver does, live.
+
+## Request / response
 
 ```
-POST /api/companion/{id}
+POST /api/companion/{id}/sync
 Content-Type: text/plain
 
 <any command the Playground CLI accepts>
 ```
 
-- `{id}` is the public session id from the WS welcome message (format
-  `ws-<6 digits>-<counter>`).
-- Body may be single-line or multi-line. Commands match the Playground CLI
-  grammar exactly.
-
-### Response (always 200 on dispatch success)
-
 ```json
 {
-  "type": "companion",
-  "status": "accepted",
+  "ok": true,
   "id": "ws-123456-7",
-  "message": "Command dispatched to graph.command.service. Output streams to the WebSocket console for this session."
+  "command": "create node root ...",
+  "output": ["> create node root ...", "node root created"],
+  "result": [ ... structured data, e.g. a run's output.body ... ]
 }
 ```
 
-- `400` — missing `id`, missing body, empty body, or non-text body.
-- `404` — no active session for `id` (WebSocket not open, or already closed).
-- **Command syntax errors still return 200.** The error text (`ERROR: ...`
-  or `Please try 'help' for details`) shows up on the WebSocket, not in the
-  HTTP response. Phase 2 will add opt-in synchronous capture.
-
----
+Null fields are omitted: `error` appears only on failure (with the first
+failing line), `result` only when the command yields data. Status codes:
+`200` executed (read `ok`), `400` missing/empty/non-text body, `404` no
+active session — **a 404 means the session is gone** (e.g. the app was
+restarted): obtain a fresh session id. And remember: **restarting the app
+ends every session — `export graph as {name}` first** or unexported work is
+lost.
 
 ## Minimal curl example
 
 ```bash
-# After reading the session id from the WS welcome frame:
 SESSION_ID="ws-384729-17"
 
-curl -sS -X POST "http://localhost:8300/api/companion/${SESSION_ID}" \
+curl -sS -X POST "http://localhost:8300/api/companion/${SESSION_ID}/sync" \
   -H 'Content-Type: text/plain' \
   --data-binary $'create node root\nwith type Root\nwith properties\nskill=graph.math'
 ```
 
-Output (the confirmation `"node root created"`) appears on the open
-WebSocket, not in the curl response.
-
-To check the current graph state for that same live session, use the
-live-session graph endpoint instead of sending `describe graph` just to fetch
-JSON:
+The outcome is in the curl response; the same lines appear on the WebSocket.
+Current graph state for the live session:
 
 ```bash
 curl -sS "http://localhost:8300/api/graph/session/${SESSION_ID}"
 ```
-
-This returns the active graph model for the open Playground session as JSON.
-Use it when a script, test harness, or agent needs to inspect the current
-graph state directly.
-
----
 
 ## Command grammar (cheat sheet)
 
@@ -103,59 +75,23 @@ Anything the Playground CLI accepts works. Common building blocks:
 | Connect nodes | `connect <a> to <b> with <label>` |
 | Instantiate graph | `instantiate graph` + optional `text(<v>) -> input.body.<field>` seed lines |
 | Run traversal | `run` |
-| Inspect state | `inspect <node>` / `inspect model` / `describe graph` |
+| Inspect state | `inspect <namespace.key>` / `describe graph` |
 | List | `list nodes` / `list connections` |
 | Persist | `export graph as <name>` / `import graph from <name>` |
 | Help | `help` / `help <topic>` / `describe skill <skill>` |
 
-Built-in skills: `graph.math`, `graph.data.mapper`, `graph.js`,
-`graph.api.fetcher`, `graph.extension`, `graph.island`, `graph.join`.
+Built-in skills: `graph.math`, `graph.data.mapper`, `graph.api.fetcher`, `graph.task`,
+`graph.extension`, `graph.island`, `graph.join`, `graph.suspend`, `graph.resume`
+(this Rust port never carried `graph.js`).
 
----
-
-## Example prompt — asking Claude to build a graph for you
-
-Paste something like this into Claude with the Playground open in your
-browser and the session id handy:
+## Example prompt — asking an AI agent to build a graph for you
 
 > I have the MiniGraph Playground open at `http://localhost:8300` with
-> session id `ws-384729-17`. Use the companion endpoint at
-> `POST /api/companion/{id}` (Content-Type: text/plain) to build the
-> following graph for me, one command per request, and wait for me to
-> confirm on the WebSocket console between steps:
+> session id `ws-384729-17`. Use the synchronous companion endpoint
+> `POST /api/companion/{id}/sync` (Content-Type: text/plain), exactly one
+> command per request. Read each response's `ok`/`error`/`output` and
+> self-correct before moving on — do not wait for me to relay the console.
+> Validate commands against the published command grammar first.
 >
 > **Goal:** given an `input.body.person_id`, fetch the person record,
 > extract their `name`, and return it as the graph output.
->
-> Nodes I want:
-> 1. `root` — type `Root`, skill `graph.math` (entry point only).
-> 2. `fetcher` — skill `graph.api.fetcher`, fetches a Person by
->    `person_id` using whatever data-dictionary stub is appropriate.
-> 3. `mapper` — skill `graph.data.mapper`, maps
->    `fetcher.response.name -> end.message`.
-> 4. `end` — type `End`.
->
-> Connect `root -> fetcher` with `fetch`, `fetcher -> mapper` with `map`,
-> `mapper -> end` with `done`. Then `instantiate graph` with
-> `int(42) -> input.body.person_id`, `run`, and then call
-> `GET /api/graph/session/{id}` to show me the current graph state. If any
-> command errors on the WebSocket, stop and ask
-> me before continuing.
-
-That prompt gives me enough to (a) build each node with the correct
-multi-line command, (b) issue the connects in order, (c) seed and run the
-graph, and (d) pause for your feedback so mistakes don't cascade.
-
----
-
-## Gotchas
-
-- **Session must exist first.** The endpoint does not create sessions; it
-  piggybacks on an open WebSocket. Close the tab → 404.
-- **HTTP response is just an ack.** Watch the WS for actual command output.
-- **One command per POST.** Multi-line is fine, but multiple independent
-  commands must be separate requests.
-- **No auth.** Dev-only by design. Do not expose beyond `localhost` /
-  trusted dev environments.
-- **Single operator.** No locking — don't have a human typing in the
-  browser at the same wall-clock instant an agent is POSTing.

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2585,3 +2585,16 @@ application and example members are fenced with `publish = false`, the workspace
 each crate ships the root README plus keywords/categories for the registry page.
 Publication itself is one `cargo publish --workspace` from the v4.12.1 tag (cargo ≥1.90
 orders the graph and waits for index propagation); the publish act is the maintainer's.
+
+## Increment 97 — The companion endpoint is synchronous only (2026-09-02)
+
+The fire-and-forget `POST /api/companion/{id}` hop is retired, lock-step with the Java
+engine (its ADR-0021): the handler and its rest.yaml mappings are removed, so the bare
+URL answers 404 through REST automation; `/sync` — which originated in this port — is
+unchanged and is now the only companion endpoint. Driven by a field AI-agent exercise
+against the Java engine: the guide that title-matched the task documented only the async
+form, and an agent following it was blind to errors, scraped the browser console for
+results, and sleep-padded every command (measured 12 s vs 0.1 s for a 25-command build).
+The playground test's async hop became the 404 retirement pin. Companion guides
+rewritten around the single endpoint, with the "restart ends the session — export first"
+and "404 means the session is gone" operational warnings from the same feedback.

--- a/docs/guides/knowledge-graph/ai-agent-guide.md
+++ b/docs/guides/knowledge-graph/ai-agent-guide.md
@@ -29,7 +29,6 @@ related:
 |---|---|---|
 | **Execute a deployed graph** | `POST /api/graph/{graph-id}` | Send the request body; get the response. No session. |
 | **Build/edit a graph — AI agents, preferred** | `POST /api/companion/{session-id}/sync` | **Synchronous** — returns the command outcome **in-band** `{ok, output, error, result}`; output is *also* teed to the human's WS console. |
-| **Build/edit a graph — fire-and-forget (legacy)** | `POST /api/companion/{session-id}` | Dispatches the command; outcome streams to the WS console only (HTTP returns just an ack). Kept for Java parity. |
 | **Read the live model** | `GET /api/graph/session/{session-id}` | Returns the current graph as JSON. |
 
 This guide is about the **companion** flow — co-authoring a graph with a human watching the
@@ -69,9 +68,10 @@ can self-correct without a human relaying the console:
 Status codes: `200` executed (read `ok`/`error` in the body); `400` missing/empty/non-text body;
 `404` no active session for that id.
 
-> **Legacy fire-and-forget** (`POST /api/companion/{session-id}`, no `/sync`): returns only
-> `{status:"accepted"}`; the outcome streams to the WS console, not the HTTP response, so the caller
-> is **blind to errors**. Prefer `/sync`.
+> **Retired:** the fire-and-forget `POST /api/companion/{session-id}` (no `/sync`) was removed in
+> 2026-09, lock-step with the Java engine — it returned only `{status:"accepted"}`, leaving the
+> caller **blind to errors**. The bare URL answers 404. There is exactly one companion endpoint:
+> `/sync`.
 
 **Rules of engagement:** one command per POST (multi-line commands are fine — see the grammar);
 the session must already be open (you do not create it); single operator — don't POST while a

--- a/docs/guides/knowledge-graph/build-your-first-graph.md
+++ b/docs/guides/knowledge-graph/build-your-first-graph.md
@@ -188,7 +188,12 @@ graph.model.automation: classpath:/graphs.yaml
 ```
 
 Copy the model into the deployed-graph folder **and list its ID in the manifest**
-(`graphs.yaml`), then restart the app:
+(`graphs.yaml`), then restart the app.
+
+> **Export before you restart.** Restarting ends every Playground session, and the working
+> graph lives in the session — anything not exported with `export graph as {name}` is lost.
+> The export in the previous step is what makes this restart safe.
+
 
 ```bash
 cp /tmp/graph/my-first-graph.json resources/graph/

--- a/docs/guides/knowledge-graph/playground-and-companion.md
+++ b/docs/guides/knowledge-graph/playground-and-companion.md
@@ -72,22 +72,29 @@ explicitly. The full rules are in the [command grammar](command-reference.md#ses
 
 The companion endpoints let an HTTP client — a script, a test harness, or an AI agent —
 dispatch a Playground command into an **already-open** session, as if it were typed into the
-console. Two variants:
+console:
 
 | Endpoint | Behavior |
 |---|---|
-| `POST /api/companion/{session-id}/sync` | **Synchronous** — returns the command's outcome in-band as a JSON envelope. The preferred endpoint for AI agents. |
-| `POST /api/companion/{session-id}` | **Fire-and-forget** — returns an immediate `{"status": "accepted", …}` acknowledgment; the outcome streams to the WebSocket console only, so the caller is blind to errors. Kept for compatibility. |
+| `POST /api/companion/{session-id}/sync` | **Synchronous** — returns the command's outcome in-band as a JSON envelope, and tees every output line to the session's WebSocket console. |
 
-Both take `Content-Type: text/plain` with exactly **one** command in the body (multi-line
+It takes `Content-Type: text/plain` with exactly **one** command in the body (multi-line
 commands are one command). Status codes: `200` executed (read the body), `400`
-missing/empty/non-text body, `404` no active session for that id. To read the current model
-of a live session: `GET /api/graph/session/{session-id}`.
+missing/empty/non-text body, `404` no active session for that id — **operationally, a 404
+means the session is gone** (for example, the app was restarted): obtain a fresh session id.
+To read the current model of a live session: `GET /api/graph/session/{session-id}`.
+
+> **Retired:** the fire-and-forget `POST /api/companion/{session-id}` variant (immediate
+> `{"status":"accepted"}`, outcome on the console only — the caller was blind to errors) was
+> **retired in 2026-09, lock-step in both engines**. The bare URL answers 404.
+
+> **Restarting the app ends every session — export first.** The working graph lives in the
+> session, not on disk: `export graph as {name}` before any restart, or unexported work is lost.
 
 !!! note "Rust port"
-    The synchronous `/sync` endpoint originated in this Rust port and has been merged into
-    the Java engine upstream — it is available in **both** engines with a byte-identical
-    REST contract, so companion clients are engine-neutral.
+    The synchronous `/sync` endpoint originated in this Rust port and was merged into the
+    Java engine upstream — available in **both** engines with a byte-identical REST
+    contract, so companion clients are engine-neutral.
 
 ### The `/sync` envelope
 

--- a/examples/minigraph-playground/resources/rest.yaml
+++ b/examples/minigraph-playground/resources/rest.yaml
@@ -58,14 +58,9 @@ rest:
     timeout: 30s
     tracing: true
 
-  - service: 'post.companion.command'
-    methods: ['POST']
-    url: '/api/companion/{id}'
-    timeout: 30s
-    tracing: true
-
-  # synchronous companion (design/ai-companion-sync.md) — returns the command
-  # outcome in-band {ok, output, error, result}; additive sibling of the above
+  # THE companion endpoint (design/ai-companion-sync.md, synchronous) — returns the
+  # command outcome in-band {ok, output, error, result} and tees every line to the
+  # session console. The fire-and-forget /api/companion/{id} was RETIRED 2026-09-02.
   - service: 'post.companion.command.sync'
     methods: ['POST']
     url: '/api/companion/{id}/sync'


### PR DESCRIPTION
## What

The fire-and-forget `POST /api/companion/{id}` hop is removed (handler + rest.yaml
mappings; the bare URL answers 404 through REST automation); `/sync` - which
originated in this port - is unchanged and is now the only companion endpoint. The
playground test's async hop became the 404 retirement pin. Companion guides rewritten
around the single endpoint with the "restart ends the session - export first" and
"404 means the session is gone" warnings; the webapp COMPANION_ENDPOINT_README
rewritten around /sync. Increment 97.

## Why

Lock-step with the Java engine's ADR-0021, driven by a field AI-agent exercise: the
async form left drivers blind to errors and sleep-padded (measured 12 s vs 0.1 s for a
25-command build). graph.js needed no action here - this port never carried it and its
guides already say so; the Java engine's new ADR-0022 deprecation converges with that.
(The array-mapping doc gap was Java-only: this repo's event-script syntax reference
already documents `[0]`/`[]`.)

## Verification

knowledge-graph crate tests, workspace clippy, and fmt all green.

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)