### PR TITLE
Release v4.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`draft-design-specs/`](draft-design-specs/).
 
 ---
-## Unreleased
+## Version 4.12.2, 9/2/2026
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ai-contract-provider"
-version = "4.12.1"
+version = "4.12.2"
 dependencies = [
  "async-trait",
  "log",
@@ -114,7 +114,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.12.1"
+version = "4.12.2"
 dependencies = [
  "async-trait",
  "log",
@@ -454,7 +454,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.12.1"
+version = "4.12.2"
 dependencies = [
  "async-trait",
  "log",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.12.1"
+version = "4.12.2"
 dependencies = [
  "async-trait",
  "log",
@@ -756,7 +756,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mercury-event-script"
-version = "4.12.1"
+version = "4.12.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-event-script-macros"
-version = "4.12.1"
+version = "4.12.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-knowledge-graph"
-version = "4.12.1"
+version = "4.12.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-knowledge-graph-macros"
-version = "4.12.1"
+version = "4.12.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-minigraph-state-redis"
-version = "4.12.1"
+version = "4.12.2"
 dependencies = [
  "async-trait",
  "log",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-platform-core"
-version = "4.12.1"
+version = "4.12.2"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-platform-macros"
-version = "4.12.1"
+version = "4.12.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "minigraph-playground"
-version = "4.12.1"
+version = "4.12.2"
 dependencies = [
  "async-trait",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.12.1"
+version = "4.12.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury"

--- a/crates/event-script/Cargo.toml
+++ b/crates/event-script/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous"]
 name = "event_script"
 
 [dependencies]
-mercury-platform-core = { version = "4.12.1", path = "../platform-core" }
+mercury-platform-core = { version = "4.12.2", path = "../platform-core" }
 async-trait = "0.1"
 log = "0.4"
 # --- increment E-2: data-mapping engine ---
@@ -31,7 +31,7 @@ chrono = "0.4"
 # (the ZoneId.systemDefault() analog, same crate chrono uses internally)
 chrono-tz = "0.10"
 iana-time-zone = "0.1"
-mercury-event-script-macros = { version = "4.12.1", path = "../event-script-macros" }
+mercury-event-script-macros = { version = "4.12.2", path = "../event-script-macros" }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]

--- a/crates/knowledge-graph/Cargo.toml
+++ b/crates/knowledge-graph/Cargo.toml
@@ -16,12 +16,12 @@ exclude = ["webapp/"]
 name = "knowledge_graph"
 
 [dependencies]
-mercury-platform-core = { version = "4.12.1", path = "../platform-core" }
+mercury-platform-core = { version = "4.12.2", path = "../platform-core" }
 # layer 3 rides layer 2: the data-mapping mini-language (converter, rmpv
 # MultiLevelMap) is shared with event-script, and deployed graphs are
 # exposed through event-script flows
-mercury-event-script = { version = "4.12.1", path = "../event-script" }
-mercury-knowledge-graph-macros = { version = "4.12.1", path = "../knowledge-graph-macros" }
+mercury-event-script = { version = "4.12.2", path = "../event-script" }
+mercury-knowledge-graph-macros = { version = "4.12.2", path = "../knowledge-graph-macros" }
 async-trait = "0.1"
 log = "0.4"
 rmpv = { version = "1", features = ["with-serde"] }

--- a/crates/platform-core/Cargo.toml
+++ b/crates/platform-core/Cargo.toml
@@ -42,7 +42,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["ring",
 rustls-native-certs = "0.8"
 # --- increment 10: annotation macros (Java @PreLoad/@BeforeApplication/@MainApplication) ---
 inventory = "0.3"
-mercury-platform-macros = { version = "4.12.1", path = "../platform-macros" }
+mercury-platform-macros = { version = "4.12.2", path = "../platform-macros" }
 # --- increment 71: ManagedCache (docs/design/managed-cache-port.md — the Caffeine-lineage
 # engine, wrapped; EvictionPolicy::lru per the maintainer's deterministic-eviction ruling) ---
 moka = { version = "0.12", features = ["sync"] }


### PR DESCRIPTION
## What

Release v4.12.2: workspace version and inter-crate pins 4.12.1 → 4.12.2 (Cargo.lock
updated), CHANGELOG flipped to `Version 4.12.2, 9/2/2026`. Full gate green
(`cargo test --workspace`, clippy `-D warnings`, `fmt --check`).

## Why

Lock-step field release with mercury-composable v4.12.2: the async companion endpoint
retirement (**breaking**) and the `json` simple plugin twin (Increment 98, #225).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>