### PR TITLE
Complete the v4.12.2 sweep: mercury-platform-core pin in minigraph-st…

### DIFF
--- a/extensions/minigraph-state-redis/Cargo.toml
+++ b/extensions/minigraph-state-redis/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["database", "asynchronous"]
 name = "minigraph_state_redis"
 
 [dependencies]
-mercury-platform-core = { version = "4.12.1", path = "../../crates/platform-core" }
+mercury-platform-core = { version = "4.12.2", path = "../../crates/platform-core" }
 async-trait = "0.1"
 log = "0.4"
 rmpv = { version = "1", features = ["with-serde"] }


### PR DESCRIPTION
## What

Complete the v4.12.2 version sweep: `mercury-platform-core` dependency pin in
`extensions/minigraph-state-redis` (4.12.1 → 4.12.2). One line; `cargo check` green.

## Why

The release sweep's glob missed the extensions directory — the crate itself inherits
4.12.2 from the workspace, but its registry pin still said 4.12.1. Semver would resolve
correctly, but the published metadata should carry the exact lock-step pin. Caught
before the crates.io publish; publish `mercury-minigraph-state-redis` only after this
merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>