### PR TITLE
Export graph: validate the root name only when declared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`draft-design-specs/`](draft-design-specs/).
 
 ---
+## Unreleased
+
+### Fixed
+
+- The Playground `export graph` overwrite guard no longer rejects a graph whose root
+  node has no `name` property (it compared "null" against the target filename). The
+  root name is validated only when declared - a declared, mismatching name still
+  rejects the overwrite; a missing or blank name is accepted and the export assigns
+  the target id as the root name, exactly like the no-root path. Lock-step with the
+  Java engine; found by the ai-enabled-repo-demo rehearsal loop.
+
+---
 ## Version 4.12.2, 9/2/2026
 
 ### Added

--- a/crates/knowledge-graph/src/commands.rs
+++ b/crates/knowledge-graph/src/commands.rs
@@ -1800,19 +1800,27 @@ async fn handle_export(
     let file = temp_dir().join(format!("{filename}.json"));
     let root = match graph.get_root_node() {
         Some(root) => {
-            let name = root.get_property("name").map(|v| display(&v));
-            if name.as_deref() != Some(filename) && file.exists() {
-                say(
-                    po,
-                    out_route,
-                    format!(
-                        "Expect root node name={filename}, Actual: {}\nUpdate root node to \
-                         overwrite existing graph model",
-                        name.unwrap_or_else(|| "null".to_string())
-                    ),
-                )
-                .await;
-                return Ok(());
+            // the guard fires only on a DECLARED, mismatching identity - a missing or
+            // blank root name has no identity evidence to contradict the export target
+            // and adopts the target id below, exactly like the no-root path
+            let declared = root
+                .get_property("name")
+                .filter(|v| !matches!(v, Value::Nil))
+                .map(|v| display(&v).trim().to_string())
+                .filter(|s| !s.is_empty());
+            if let Some(declared) = declared {
+                if declared != filename && file.exists() {
+                    say(
+                        po,
+                        out_route,
+                        format!(
+                            "Expect root node name={filename}, Actual: {declared}\nUpdate root \
+                             node to overwrite existing graph model"
+                        ),
+                    )
+                    .await;
+                    return Ok(());
+                }
             }
             root
         }

--- a/crates/knowledge-graph/tests/playground.rs
+++ b/crates/knowledge-graph/tests/playground.rs
@@ -795,3 +795,100 @@ async fn playground_command_grammar_and_companion() {
         "session cleared on close"
     );
 }
+
+/// Open a playground session and return its captured console (the .out route).
+async fn open_console(
+    platform: &Platform,
+    po: &PostOffice,
+    seq: &str,
+) -> (Arc<Mutex<Vec<String>>>, String, String) {
+    let lines: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let in_route = format!("ws.{seq}.1.in");
+    let out_route = format!("ws.{seq}.1.out");
+    platform
+        .register(
+            &out_route,
+            Arc::new(Console {
+                lines: lines.clone(),
+            }),
+            1,
+        )
+        .expect("console route");
+    let _ = po
+        .send(
+            EventEnvelope::new()
+                .set_to(knowledge_graph::commands::ROUTE)
+                .set_raw_body(Value::Map(vec![
+                    (Value::from("type"), Value::from("open")),
+                    (Value::from("in"), Value::from(in_route.as_str())),
+                ])),
+        )
+        .await;
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    (lines, in_route, out_route)
+}
+
+/// The export guard validates the root name only when one is DECLARED: a missing or
+/// blank root name has no identity evidence to contradict the export target, so the
+/// export adopts the target id as the name (exactly like the no-root path already
+/// does). A declared, mismatching name still rejects the overwrite. (Java twin:
+/// CompanionSyncTest.exportAcceptsMissingRootNameAndStillRejectsMismatch)
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn export_name_guard_accepts_missing_and_rejects_mismatch() {
+    let platform = boot().await;
+    let po = PostOffice::new(&platform);
+    let file = std::env::temp_dir()
+        .join(format!("mercury-playground-{}", std::process::id()))
+        .join("export-guard-test.json");
+    let _ = std::fs::remove_file(&file);
+
+    // an unnamed root exports fine when the file does not exist yet
+    let (lines1, in1, out1) = open_console(&platform, &po, "100031").await;
+    command(&po, &in1, &out1, "create node root\nwith type Root").await;
+    command(&po, &in1, &out1, "export graph as export-guard-test").await;
+    assert!(
+        console_has(&lines1, "Graph exported"),
+        "first export expected: {:?}",
+        lines1.lock().expect("console")
+    );
+    assert!(file.exists(), "first export created the file");
+
+    // the friction case: ANOTHER session's unnamed graph re-exports over the
+    // existing file - a missing name must be accepted, not compared as "null"
+    let (lines2, in2, out2) = open_console(&platform, &po, "100032").await;
+    command(&po, &in2, &out2, "create node root\nwith type Root").await;
+    command(&po, &in2, &out2, "export graph as export-guard-test").await;
+    assert!(
+        console_has(&lines2, "Graph exported"),
+        "an unnamed root must be accepted over an existing file: {:?}",
+        lines2.lock().expect("console")
+    );
+    assert!(
+        !console_has(&lines2, "Expect root node name="),
+        "no identity rejection without a declared name"
+    );
+
+    // a DECLARED mismatching name still rejects the overwrite
+    let (lines3, in3, out3) = open_console(&platform, &po, "100033").await;
+    command(
+        &po,
+        &in3,
+        &out3,
+        "create node root\nwith type Root\nwith properties\nname=some-other-graph",
+    )
+    .await;
+    command(&po, &in3, &out3, "export graph as export-guard-test").await;
+    assert!(
+        console_has(
+            &lines3,
+            "Expect root node name=export-guard-test, Actual: some-other-graph"
+        ),
+        "a declared mismatch must still reject the overwrite: {:?}",
+        lines3.lock().expect("console")
+    );
+    assert!(
+        !console_has(&lines3, "Graph exported"),
+        "the mismatching graph must not be exported"
+    );
+    let _ = std::fs::remove_file(&file);
+}

--- a/crates/knowledge-graph/tests/playground.rs
+++ b/crates/knowledge-graph/tests/playground.rs
@@ -794,6 +794,10 @@ async fn playground_command_grammar_and_companion() {
         !knowledge_graph::commands::has_session(public_id),
         "session cleared on close"
     );
+
+    // additional playground cases run sequentially on the same booted server
+    // (a second `#[tokio::test]` would drop this runtime and kill the server)
+    export_name_guard_accepts_missing_and_rejects_mismatch(&platform).await;
 }
 
 /// Open a playground session and return its captured console (the .out route).
@@ -833,17 +837,20 @@ async fn open_console(
 /// export adopts the target id as the name (exactly like the no-root path already
 /// does). A declared, mismatching name still rejects the overwrite. (Java twin:
 /// CompanionSyncTest.exportAcceptsMissingRootNameAndStillRejectsMismatch)
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn export_name_guard_accepts_missing_and_rejects_mismatch() {
-    let platform = boot().await;
-    let po = PostOffice::new(&platform);
+///
+/// A plain `async fn` (not a second `#[tokio::test]`): the harness gives each
+/// `#[tokio::test]` its own runtime, which drops and kills the shared HTTP server
+/// task when the first test finishes, so every playground case runs sequentially
+/// inside the single booted test.
+async fn export_name_guard_accepts_missing_and_rejects_mismatch(platform: &Platform) {
+    let po = PostOffice::new(platform);
     let file = std::env::temp_dir()
         .join(format!("mercury-playground-{}", std::process::id()))
         .join("export-guard-test.json");
     let _ = std::fs::remove_file(&file);
 
     // an unnamed root exports fine when the file does not exist yet
-    let (lines1, in1, out1) = open_console(&platform, &po, "100031").await;
+    let (lines1, in1, out1) = open_console(platform, &po, "100031").await;
     command(&po, &in1, &out1, "create node root\nwith type Root").await;
     command(&po, &in1, &out1, "export graph as export-guard-test").await;
     assert!(
@@ -855,7 +862,7 @@ async fn export_name_guard_accepts_missing_and_rejects_mismatch() {
 
     // the friction case: ANOTHER session's unnamed graph re-exports over the
     // existing file - a missing name must be accepted, not compared as "null"
-    let (lines2, in2, out2) = open_console(&platform, &po, "100032").await;
+    let (lines2, in2, out2) = open_console(platform, &po, "100032").await;
     command(&po, &in2, &out2, "create node root\nwith type Root").await;
     command(&po, &in2, &out2, "export graph as export-guard-test").await;
     assert!(
@@ -869,7 +876,7 @@ async fn export_name_guard_accepts_missing_and_rejects_mismatch() {
     );
 
     // a DECLARED mismatching name still rejects the overwrite
-    let (lines3, in3, out3) = open_console(&platform, &po, "100033").await;
+    let (lines3, in3, out3) = open_console(platform, &po, "100033").await;
     command(
         &po,
         &in3,

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2616,3 +2616,17 @@ keys, trailing commas) — portable flows use strict JSON. The plugin docs on bo
 engines also correct a stale claim: the argument tokenizer splits on top-level commas
 only (commas inside a nested constant are safe), and nested `f:` calls are deliberately
 ignored, not supported.
+
+## Increment 99 — Export guard: identity is validated only when declared (2026-09-02)
+
+The `export graph` overwrite guard compared a missing root `name` as the string "null"
+against the target filename, so an unnamed draft could be exported once but never
+re-exported — exactly the rehearsal loop the ai-enabled-repo-demo runs (its follow-up
+report surfaced the friction). The rule is now coherent across the identity lattice:
+no evidence (no root node, missing or blank name) → the export proceeds and assigns
+the target id as the root name, as the no-root path always did; contradictory evidence
+(a declared, different name) → the overwrite is rejected with the unchanged
+"Expect root node name=..." message. Lock-step with the Java engine (its
+CompanionSyncTest twin); pinned here by
+playground::export_name_guard_accepts_missing_and_rejects_mismatch. The command
+reference documents the rule on both engines.

--- a/docs/guides/knowledge-graph/command-reference.md
+++ b/docs/guides/knowledge-graph/command-reference.md
@@ -250,6 +250,11 @@ import graph from {name}
 import node {node} from {name}
 ```
 
+- **Overwriting an existing file** validates the root `name` only when one is declared: a
+  declared name that differs from the export target rejects the overwrite
+  (`Expect root node name=...`) — protecting `graph123.json` from another graph's content —
+  while a **missing or blank root name is accepted**, and the export assigns the target id
+  as the root name (the same self-naming a brand-new export performs).
 - `export` writes JSON to `location.graph.temp`; it adds `name={name}` to the root node and
   **fails if any node is an orphan** (every node must connect to ≥1 other).
 - The export reply includes `Described in /api/graph/model/{name}/{token}` — a read-only HTTP


### PR DESCRIPTION
## What

Increment 99, lock-step twin of the Java fix: the `export graph` overwrite guard
validates the root `name` only when declared (it compared a missing name as "null"
against the target filename). Declared mismatch still rejects; missing or blank name is
accepted and self-names to the target id. Pinned by
`playground::export_name_guard_accepts_missing_and_rejects_mismatch`, run as a sequential
`async fn` inside the single booted playground test (a second `#[tokio::test]` would drop
its runtime and kill the shared HTTP server — the repo's documented harness idiom).
Command reference updated.

## Why

Lock-step with mercury-composable `feature/export-name-optional`; found by the
ai-enabled-repo-demo rehearsal loop where an unnamed draft exported once but never again.

Gate: `cargo test -p mercury-knowledge-graph` ✅ · clippy `-D warnings` ✅ · `fmt --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>