### PR TITLE
Unpin mkdocs-material in the docs toolchain to match the Java engine

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,13 +10,11 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
-      - "docs-requirements.txt"
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
       - "docs/**"
       - "mkdocs.yml"
-      - "docs-requirements.txt"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -36,11 +34,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          cache: pip
-          cache-dependency-path: docs-requirements.txt
 
       - name: Install MkDocs toolchain
-        run: pip install -r docs-requirements.txt
+        run: pip install mkdocs-material
 
       - name: Build the site (strict)
         run: mkdocs build --strict
@@ -59,11 +55,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          cache: pip
-          cache-dependency-path: docs-requirements.txt
 
       - name: Install MkDocs toolchain
-        run: pip install -r docs-requirements.txt
+        run: pip install mkdocs-material
 
       - name: Publish to GitHub Pages
         run: |

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,6 +1,0 @@
-# Documentation site toolchain (MkDocs + Material theme).
-# Used by .github/workflows/docs.yml and for local builds:
-#   uv venv /tmp/mkdocs-venv
-#   uv pip install --python /tmp/mkdocs-venv/bin/python -r docs-requirements.txt
-#   /tmp/mkdocs-venv/bin/mkdocs serve
-mkdocs-material==9.7.7

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2630,3 +2630,14 @@ the target id as the root name, as the no-root path always did; contradictory ev
 CompanionSyncTest twin); pinned here by
 playground::export_name_guard_accepts_missing_and_rejects_mismatch. The command
 reference documents the rule on both engines.
+
+## Increment 100 — Docs toolchain unpinned to match the Java engine (2026-09-03)
+
+The `mkdocs-material` pin is removed: `docs-requirements.txt` is deleted and the docs
+workflow installs `pip install mkdocs-material` unpinned (the pip cache keyed on the
+requirements file goes with it), exactly like the Java engine's `docs.yml` (the
+reference implementation, which never pinned it). The docs site is a non-shipped
+artifact and both engines now build it against the latest Material theme at CI time;
+Dependabot's pip tracking (enabled via the repo UI, not a committed config) simply has
+nothing to bump. Supersedes the Increment-43 scaffold's pinned-`docs-requirements.txt`
+choice for the toolchain only.


### PR DESCRIPTION
## What

Unpin `mkdocs-material` in the docs toolchain to match the Java engine (mercury-composable),
which is the reference implementation and never pinned it. Deletes `docs-requirements.txt`
and installs `pip install mkdocs-material` unpinned in both `docs.yml` jobs, dropping the
pip cache that was keyed on the deleted file and the now-dead path trigger. Increment 100.

## Why

Requested for cross-engine parity: the Java docs workflow builds against the latest
Material theme at CI time, and the docs site is a non-shipped artifact where reproducible
pinning buys little. Both engines now behave identically. Dependabot's pip tracking (enabled
via the repo UI, not a committed config) simply has nothing left to bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>