### PR TITLE
docs: add the reference tier to llms.txt, and guard its link integrity

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,13 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - "scripts/**"
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - "scripts/**"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -34,6 +36,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+
+      - name: Check llms.txt link integrity
+        run: python3 scripts/check-llms-links.py
 
       - name: Install MkDocs toolchain
         run: pip install mkdocs-material

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -9,7 +9,7 @@
 > called out in the docs (e.g. `graph.js` is retired here for security).
 
 > This is a machine-readable map of the **AI-agent documentation in this repo**. Paths are relative
-> to the repo root. It is the Rust port's own reference — where behavior differs from the Java
+> to this file's own directory (`docs/`). It is the Rust port's own reference — where behavior differs from the Java
 > upstream, these docs are authoritative for this repo.
 
 ## Version-matched discovery — the installed operational contract
@@ -35,6 +35,10 @@ These are self-contained; you should not need the engine source or the tutorial 
   `MAPPING`, …).
 - [`minigraph-commands.json`](guides/knowledge-graph/minigraph-commands.json) — the machine-readable
   command catalog; ingest it and validate commands against it before dispatching.
+- [Workflow suspension](guides/knowledge-graph/workflow-suspension.md) — express a long-running
+  process as a sequence of short graph runs: suspend while waiting on a person or another system,
+  persist state to a pluggable store, resume with the same business correlation id without
+  re-executing completed steps.
 - [Built-in skills reference](guides/knowledge-graph/skills-reference.md) — per-skill properties and
   examples.
 
@@ -56,6 +60,8 @@ unchanged; only the functions are written differently (Rust):
   eight execution types, the data-mapping mini-language.
 - [`event-script-flow.json`](guides/event-script/event-script-flow.json) — the machine-readable flow
   schema; ingest and validate against it.
+- [Flow Schema Reference](guides/flow-schema-reference.md) — the field-level reference: every
+  field the flow compiler accepts and the validation it applies at startup.
 - [Event Script Syntax](guides/event-script/syntax.md) — the full reference with worked examples:
   data-mapping catalog (constants, arrays, JSONPath, runtime model variables), all task types,
   pipelines/loops, Simple Plugins (`f:` functions), exception handling, external state machine.
@@ -66,6 +72,9 @@ Needed when a flow task or a graph's `graph.task` calls a custom function:
 - [Function AI agent guide](guides/event-driven/ai-agent-guide.md) — the Rust authoring contract:
   `#[preload]` attribute, `ComposableFunction`/`TypedFunction` traits, pre-write checklist,
   PostOffice RPC patterns, serialization rules, worked example with rest.yaml wiring.
+- [REST Automation](guides/rest-automation.md) — expose a function over HTTP by configuration:
+  `rest.yaml` *is* the router; an entry maps a URL and its methods to a composable function (or
+  an Event Script flow), served directly over hyper. No controllers, no handler registration.
 - [Polyglot Functions](guides/polyglot-functions.md) — write functions in Python or Node.js as
   Event-over-HTTP peers instead: official wrappers (docs: accenture.github.io/mercury-python,
   accenture.github.io/mercury-nodejs) with the engines' preload/envelope/actuator/log contracts;
@@ -76,7 +85,42 @@ Needed when a flow task or a graph's `graph.task` calls a custom function:
   `x-event-stream: data|eof|exception` envelope marker; SSE/chunked+NDJSON standards-only wire;
   dedicated reply-lane pool of 500 with HTTP-503 back-pressure.
 
+## Reference — exact names, keys and contracts
+Reach for these when you need an exact value rather than a how-to: a macro parameter, a
+configuration key, a reserved name, the envelope shape. Every page here was enumerated from this
+repo's own source, so it answers the question without opening `crates/`.
+
+- [Macros reference](guides/macros-reference.md) — the Rust carrier surface, analog of the Java
+  annotations: `#[preload]`, `#[main_application]`, `#[before_application]`, `#[optional_service]`,
+  `#[websocket_service]`, `#[simple_plugin]`, `#[fetch_feature]` — parameters, the crate each
+  imports from, and the link-time `inventory` registration that replaces Java's classpath scan
+  (no manual wiring in `main()`).
+- [Registration Metadata Contract](guides/registration-metadata-contract.md) — the cross-language
+  contract behind `#[preload]` and its family: one metadata model and fixed boot semantics carried
+  by per-language idioms, proven by golden vectors shared verbatim with the Java engine. The
+  acceptance bar for porting the declaration side to a new language.
+- [API Overview](guides/api-overview.md) — the whole runtime surface a function touches:
+  `Platform` (register / query / release a route and its worker pool) and `PostOffice`
+  (fire-and-forget send, RPC with timeout, scheduled delivery, trace-aware APIs).
+- [EventEnvelope reference](guides/event-envelope-reference.md) — the immutable message container:
+  metadata (`id`, `to`, `from`, `reply_to`, `cid`, `trace_id`, `trace_path`, `span_id`, `status`,
+  `exec_time`), headers, body.
+- [Reserved names & headers](guides/reserved-names-and-headers.md) — the do-not-collide list of
+  route names and event/HTTP headers, enumerated from this port's own constants and `#[preload]`
+  declarations (the Java list carries names from subsystems this port does not have).
+- [Configuration reference](guides/configuration-reference.md) — every key the port actually reads,
+  with type, default and the crate reading it; `resources/application.yml`, the `classpath:/` and
+  `file:/` prefixes, `${ENV_VAR:default}` substitution.
+- [Actuators & HTTP client](guides/actuators-and-http-client.md) — the built-in health and
+  introspection endpoints, and the async outbound HTTP client; both without extra wiring.
+- [Event over HTTP](guides/event-over-http.md) — call a function in another instance over the same
+  route-name + envelope contract; the only cross-instance coupling, opt-in by design.
+
 ## Design & project docs (human-facing)
+- The documentation site — [accenture.github.io/mercury](https://accenture.github.io/mercury/) —
+  narrative guides built from `docs/guides/`: getting started, architecture, methodology,
+  observability, and the graph and flow walkthroughs. The pages mapped above are the
+  agent-facing subset; read the site for the story, use this map to look a value up.
 - `draft-design-specs/` — port design notes (platform-core, event-script, knowledge-graph, and
   `ai-companion-sync.md` for the synchronous companion endpoint).
 - `docs/INCREMENTS.md` — the increment ledger.

--- a/scripts/check-llms-links.py
+++ b/scripts/check-llms-links.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Link-integrity check for docs/llms.txt — the AI-agent documentation map.
+
+llms.txt is the map an AI agent follows to find the right page instead of reading
+`crates/`. A path that does not resolve sends the agent nowhere, and the failure is
+silent: nothing renders it, so no site build catches it. This is that guard.
+
+Two path conventions live in the file, and this enforces both as they are actually
+written (the header once claimed the wrong one, which broke every link at once):
+
+  1. markdown links  - `[text](guides/foo.md)` resolve from **docs/**, the file's own
+                       directory. External http(s) links are skipped (no network in CI).
+  2. backticked paths - `` `docs/INCREMENTS.md` ``, `` `draft-design-specs/` `` resolve
+                       from the **repo root**. Only tokens containing "/", ending in
+                       ".md" or "/", and free of ":" are treated as paths — so identifiers
+                       (`graph.task`), a bare filename (`ai-companion-sync.md`) and URI
+                       schemes (`classpath:/`, `file:/`, `flow://`) are never guessed at.
+
+Deliberately NOT a coverage check: this repo's llms.txt is a *curated* agent map, not a
+full site map (maintainer ruling, 2026-09-04), so "every guide must be listed" would be
+wrong here. The Java repo, whose llms.txt is a full site map, enforces coverage instead.
+
+Exit 0 = clean; exit 1 = broken links. Run from anywhere:
+    python3 scripts/check-llms-links.py [--root PATH]
+"""
+import argparse
+import re
+import sys
+from pathlib import Path
+
+MD_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+BACKTICKED = re.compile(r"`([^`]+)`")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=str(Path(__file__).resolve().parent.parent),
+                    help="repo root (default: parent of scripts/)")
+    args = ap.parse_args()
+    root = Path(args.root)
+    llms = root / "docs" / "llms.txt"
+    if not llms.exists():
+        print(f"docs/llms.txt not found under {root}")
+        return 1
+
+    text = llms.read_text(encoding="utf-8")
+    errors: list[str] = []
+    checked = 0
+
+    # 1. markdown links, relative to docs/
+    for target in MD_LINK.findall(text):
+        if target.startswith(("http://", "https://", "mailto:")):
+            continue
+        path = target.split("#", 1)[0].strip()
+        if not path:
+            continue
+        checked += 1
+        if not (llms.parent / path).exists():
+            errors.append(f"[link] does not resolve from docs/: {target}")
+
+    # 2. backticked paths, relative to the repo root
+    for token in BACKTICKED.findall(text):
+        if "/" not in token or not (token.endswith(".md") or token.endswith("/")):
+            continue
+        if ":" in token or token.startswith("${"):
+            continue        # a URI scheme (classpath:/, file:/, flow://), not a repo path
+        checked += 1
+        if not (root / token).exists():
+            errors.append(f"[path] does not resolve from the repo root: `{token}`")
+
+    if errors:
+        print("docs/llms.txt link integrity — broken references:\n")
+        for e in errors:
+            print("  - " + e)
+        print(f"\n{len(errors)} of {checked} reference(s) broken.")
+        return 1
+    print(f"docs/llms.txt link integrity: OK ({checked} references resolve).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds the missing **reference tier** to `docs/llms.txt`, fixes a defect that made every link
in it unfollowable, and adds `scripts/check-llms-links.py` to the docs workflow so neither
can recur.

New **Reference** section: macros, registration metadata contract, API overview,
EventEnvelope, reserved names, configuration, actuators/HTTP client, event over HTTP.
Also `rest.yaml` authoring under Layer 1, the flow schema reference under Layer 2, and
workflow suspension under MiniGraph.

## Why

The map covered the three DSL spec kits well but had no reference tier at all. An agent
needing an *exact value* — a macro parameter, a config key, a reserved route name, the
envelope shape — had nothing to follow and fell back to `crates/`.

**And the map was broken in a way nothing could catch.** The header claimed "Paths are
relative to the repo root", but every link resolves from `docs/`. An agent following the
header literally missed **all 22 links**. `llms.txt` is not rendered, so the strict site
build never sees it.

## Against the benchmark

Doc discovery and token efficiency are what make the AI grammar useful, so the trade is
measured rather than asserted:

| | tokens |
|---|---|
| Map before → after | 1,569 → 2,482 (**+913**) |
| Reference it now routes to | ~45,800 |
| `crates/**/*.rs` — the fallback | ~515,000 |

~900 tokens of map buys one-hop access to 46k tokens of source-verified reference in place
of a hunt through 515k. That ratio is why the entries are dense with the exact tokens an
agent greps for — macro names, config keys, file names — rather than short. A map that is
cheap to read but forces three page-opens fails the benchmark as badly as a bloated one.

## Design note — this is deliberately NOT the Java shape

This repo's `llms.txt` stays a **curated agent map**, not a full site map (maintainer
ruling). Walkthroughs and concept pages stay out; the human-facing section now points at
the documentation site, which did not exist when that section was written.

Consequently the guard here is **link integrity**, not coverage. Porting the Java repo's
new coverage check would be wrong — it would fail on ~20 intentionally-omitted pages. That
distinction is recorded in the script's docstring so the two repos are not "corrected"
toward each other later.

## The guard

`scripts/check-llms-links.py` (stdlib only) runs **first** in the docs workflow, before the
toolchain install, since it needs no dependencies; `deploy` gates on `build`. It enforces
both conventions as actually written — markdown links from `docs/`, backticked repo paths
from the repo root — and excludes identifiers, bare filenames and URI schemes rather than
guessing at them.

The first draft flagged `classpath:/`, `file:/` and `flow://` as broken paths. A gate with
false positives trains people to ignore it, so the rule was narrowed to exclude any token
containing `:`.

## Testing

Verified against three regressions, not just the happy path:

| Regression | Result |
|---|---|
| Mistyped link | 1 of 30 broken |
| Rotted backticked path | 1 of 30 broken |
| The original header defect, written out | **22 of 30 broken** |
| Restored | OK, 30 resolve, exit 0 |

The third row is the point: the defect that actually shipped would have failed CI the
moment it was introduced.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>