### PR TITLE
docs: agent-memory attribution in the white paper (Java sync) — the now-phase of the maintainer review

### DIFF
--- a/docs/ai-grammar-methodology.md
+++ b/docs/ai-grammar-methodology.md
@@ -464,9 +464,12 @@ The grammar remains language-neutral because the contracts remain language-neutr
 
 ### Project Memory
 
-The project's memory is distinct from the platform's grammar. Vision, Blueprint, continuity,
-session records, and architecture decisions orient each AI session on purpose and state rather
-than only API shape.
+The project's memory is distinct from the platform's grammar — and unlike the mechanisms above,
+Mercury does not implement it. The repository is AI-enabled with **agent-memory**, a
+vendor-neutral shared-memory and cognitive-loop tool that installs and versions the memory layer
+whose content Mercury's contributors maintain. Vision, Blueprint, continuity, session records,
+and architecture decisions orient each AI session on purpose and state rather than only API
+shape.
 
 Together, these mechanisms make guide-first behavior rational. If documentation can drift freely,
 an AI partner learns to distrust it and returns to source. Verification gates preserve trust in
@@ -499,6 +502,11 @@ Current state → Vision → Blueprint → Design → Implementation → Feedbac
 Memory preserves continuity, but judgment remains a shared human responsibility.
 
 > Mechanize the arithmetic. Do not mechanize the judgment.
+
+This step has a concrete, reusable implementation: Mercury's repositories are AI-enabled with
+**agent-memory**, which installs the shared memory layer, gates a human-confirmed Vision
+(bootstrapped as a draft, never fabricated), and orients every subsequent session — the same
+tool that maintains this repository's own `memory/`.
 
 The proof point is **this repository**: the Rust engine was AI-enabled **before its first line of
 code** — the Vision and memory layer landed on 2026-07-15, the code followed — so every increment
@@ -782,5 +790,5 @@ documentation map. All figures are reproducible from the cited artifacts.*
 
 *Mercury Composable is an official Accenture open-source project; this repository is its official
 Rust implementation (github.com/Accenture/mercury). agent-memory is a lightweight, vendor-neutral
-shared-memory and cognitive-loop framework for human-AI collaboration, published under
-Apache-2.0.*
+shared-memory and cognitive-loop tool for human-AI collaboration; it installs and maintains this
+repository's shared `memory/` layer.*

--- a/docs/presentations/ai-grammar-story.html
+++ b/docs/presentations/ai-grammar-story.html
@@ -379,7 +379,7 @@
       <dt>Contract provider</dt><dd>the doc set served as a <b>version-matched contract</b>: discovery endpoint, per-file SHA-256 manifest, exportable Agent Skill</dd>
       <dt>Registration contract</dt><dd>the grammar of <i>declaring</i> functions — one metadata model, per-language carriers, proven by <b>golden vectors</b> shared between engines</dd>
       <dt>Engine parity</dt><dd>Java is the reference; Rust ships in lock-step; flow YAML ports unchanged; python/node functions join as Event-over-HTTP peers</dd>
-      <dt>Memory layer</dt><dd>the <i>project’s</i> grammar — Vision, Blueprint, continuity — so sessions start oriented on intent, not just API shape</dd>
+      <dt>Memory layer</dt><dd>the <i>project’s</i> grammar, via <b>agent-memory</b> — Vision, Blueprint, continuity — so sessions start oriented on intent, not just API shape</dd>
     </dl>
   </section>
 

--- a/memory/sessions/2026-09-05-174821.md
+++ b/memory/sessions/2026-09-05-174821.md
@@ -1,0 +1,21 @@
+# Session (2026-09-05T17:48:21.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** agent-memory attribution now-phase synced from the Java engine (its review
+spec `draft-design-specs/review-ai-grammar-methodology-agent-memory-attribution.md` + ruling):
+the paper's §6 states Project-Memory provenance, §7 Step 1 names agent-memory, the closing
+note says *tool* (installs-and-maintains sentence replaces the dangling license clause), and
+the deck's Memory-layer row reads "via agent-memory". Locators/reference entry deferred until
+agent-memory's promotion to an official Accenture asset — tracked in the Java repo's open
+thread. Commit `40307474` on `docs/agent-memory-attribution`; link gate OK (30 references).
+
+Commit `40307474` — docs: agent-memory attribution now-phase (Java sync)
+
+```
+ docs/ai-grammar-methodology.md           | 12 ++++++++++--
+ docs/presentations/ai-grammar-story.html |  2 +-
+ 2 files changed, 14 insertions(+), 6 deletions(-)
+```
+
+## Memory References
+(none)


### PR DESCRIPTION
## What

Applies the accepted findings of the agent-memory-maintainer review
(`draft-design-specs/review-ai-grammar-methodology-agent-memory-attribution.md`) to the white
paper and deck:

- **F1** — §6 "Project Memory" states its provenance: Mercury does not implement the memory
  system; the repository is AI-enabled with **agent-memory**, which installs and versions the
  layer whose content Mercury's contributors maintain.
- **F2** — §7 Step 1 names agent-memory as the concrete, reusable implementation of "Establish
  Intent and Memory" — the same tool that maintains this repository's own `memory/`.
- **F3 (option B)** — the closing note says *tool* (agent-memory's own self-description) and the
  dangling license clause becomes the installs-and-maintains sentence.
- **F5** — the deck's Memory-layer row reads "the project's grammar, via agent-memory".

**Deferred by maintainer ruling:** F3 option A's locator and F4's reference entry — direct URLs
to agent-memory stay out of this official Accenture publication until agent-memory is promoted to
an official Accenture open-source asset; they land then, at the official URL. Recorded in the
review spec's Resolution section and tracked as an open thread.

## Why

The review's core observation was fair: every memory mechanism the paper leans on is
agent-memory's — described accurately, but presented as anonymous methodology practice while
Mercury's own mechanisms are named and cited. Naming the tool is an accuracy fix; the linking
depth is a positioning decision, phased deliberately.

## Validation

- Doc canon / llms.txt link integrity: OK.
- Both engines edited in lock-step (this PR and its twin).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>