### PR TITLE
Claims-fixture gate (Java ADR-0023 twin) + sibling sweep of the coverage-study fixes)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Check llms.txt link integrity
         run: python3 scripts/check-llms-links.py
 
+      - name: Check documentation behavior claims
+        run: python3 scripts/check-doc-claims.py
+
       - name: Install MkDocs toolchain
         run: pip install mkdocs-material
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,3 +44,8 @@ jobs:
 
       - name: Test workspace
         run: cargo test --workspace
+
+      # a test rename must not silently orphan a documentation behavior claim
+      # (docs.yml does not trigger on crates/** changes; this lane does)
+      - name: Check documentation behavior claims
+        run: python3 scripts/check-doc-claims.py

--- a/crates/event-script/tests/claims.rs
+++ b/crates/event-script/tests/claims.rs
@@ -1,0 +1,235 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Claims-registry engine pins (ADR-0023): each scenario pins exactly what a
+//! registered documentation claim states — no more.
+//!
+//! * `decision-invalid-value` — a NON-boolean decision value coerces via
+//!   `str2int(...).max(1)`: a non-numeric string (even the string "false")
+//!   yields -1, clamped to 1, and SILENTLY routes to the FIRST branch with no
+//!   error; a missing/null decision aborts the flow with status 500 and a
+//!   message containing 'invalid decision' (executor `handle_decision`).
+//! * `flows-location-default` — a flows manifest that OMITS `location` loads
+//!   its flow files from the compiler default `classpath:/flows/`.
+//!
+//! This binary compiles ONLY `claims-flows.yaml` (a process-local
+//! `yaml.flow.automation` override), so the fixture manifests and their
+//! exact-set assertions in compiler.rs / flow_runtime.rs are untouched.
+//!
+//! One `#[tokio::test]` wrapper on purpose (the global platform's workers
+//! live on this test's runtime — the flow_runtime.rs pattern); the per-claim
+//! scenarios run sequentially inside it.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use event_script::conversions::from_json;
+use event_script::{flows, FlowExecutor};
+use platform_core::{
+    main_application, preload, trace, AppError, AutoStart, ComposableFunction, EntryPoint,
+    EventEnvelope, Platform,
+};
+
+/// Echoes its input body VERBATIM. As the decision task's process, the
+/// caller-supplied `decision` value reaches the engine's decision router
+/// unconverted — the Java-parity `SimpleDecision` fixture converts to a real
+/// boolean first, so it can never exercise the string-coercion path.
+#[preload(route = "claims.decision.echo", instances = 10)]
+struct ClaimsDecisionEcho;
+
+#[async_trait]
+impl ComposableFunction for ClaimsDecisionEcho {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        Ok(EventEnvelope::new().set_raw_body(input.body().clone()))
+    }
+}
+
+#[main_application]
+struct ClaimsTestApp;
+
+#[async_trait]
+impl EntryPoint for ClaimsTestApp {
+    async fn start(&self, _args: &[String]) -> Result<(), AppError> {
+        Ok(())
+    }
+}
+
+// ---- helpers ----
+
+/// One-time process setup (the same `Once` pattern as flow_runtime.rs):
+/// pin the resource root and the claims-only manifest BEFORE the first
+/// config touch freezes the snapshot.
+fn setup_config() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        platform_core::resources::prepend_resource_root("tests/resources");
+        // this binary loads ONLY the claims manifest — the process override
+        // keeps the fixture manifests (and their exact-set assertions in
+        // other test binaries) out of this registry and vice versa
+        platform_core::overrides::set("yaml.flow.automation", "classpath:/claims-flows.yaml");
+        let holding =
+            std::env::temp_dir().join(format!("mercury-claims-test-{}", std::process::id()));
+        platform_core::overrides::set("transient.data.store", &holding.display().to_string());
+        let _ = platform_core::AppConfigReader::get_instance();
+    });
+}
+
+async fn run_flow(
+    platform: &Platform,
+    flow_id: &str,
+    dataset: serde_json::Value,
+    cid: &str,
+) -> EventEnvelope {
+    FlowExecutor::request(
+        platform,
+        flow_id,
+        from_json(&dataset),
+        cid,
+        Duration::from_secs(8),
+        Some((&trace::new_trace_id(), &format!("FLOW /{flow_id}"))),
+    )
+    .await
+    .unwrap_or_else(|e| panic!("flow {flow_id} failed: {} {}", e.status(), e.message()))
+}
+
+fn decision_dataset(decision: Option<&str>) -> serde_json::Value {
+    let mut query = serde_json::Map::new();
+    if let Some(d) = decision {
+        query.insert("decision".to_string(), serde_json::Value::String(d.into()));
+    }
+    serde_json::json!({
+        "body": {},
+        "header": {"accept": "application/json"},
+        "query": query,
+        "method": "GET",
+    })
+}
+
+fn json_body(reply: &EventEnvelope) -> serde_json::Value {
+    reply.body_as().expect("json body")
+}
+
+// ---- the claims pins ----
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn claims_pins_run_end_to_end() {
+    setup_config();
+    AutoStart::main(vec![]).await.expect("lifecycle");
+    let platform = Platform::get_instance();
+    non_numeric_decision_silently_routes_to_branch_one(&platform).await;
+    manifest_without_location_loads_flows_from_default_classpath(&platform).await;
+}
+
+/// Claim `decision-invalid-value`: engine `handle_decision` coerces any
+/// non-boolean decision with `str2int(display(value)).max(1)`.
+async fn non_numeric_decision_silently_routes_to_branch_one(platform: &Platform) {
+    // (a) a non-numeric string: str2int("pizza") = -1, .max(1) = 1 — the
+    // FIRST branch runs, silently, with no error
+    let reply = run_flow(
+        platform,
+        "claims-decision-coercion",
+        decision_dataset(Some("pizza")),
+        "claims-cid-1",
+    )
+    .await;
+    assert_eq!(
+        reply.status(),
+        200,
+        "a non-numeric decision must not abort the flow: {:?}",
+        reply.body()
+    );
+    assert_eq!(
+        json_body(&reply)["from"],
+        "one",
+        "non-numeric decision must coerce to the FIRST branch"
+    );
+
+    // the STRING "false" is not the boolean false on this path — it is
+    // non-numeric too, so it also routes to branch one (not branch two)
+    let reply = run_flow(
+        platform,
+        "claims-decision-coercion",
+        decision_dataset(Some("false")),
+        "claims-cid-2",
+    )
+    .await;
+    assert_eq!(reply.status(), 200, "string 'false' must not abort");
+    assert_eq!(
+        json_body(&reply)["from"],
+        "one",
+        "the string \"false\" coerces to 1 (first branch), not to branch two"
+    );
+
+    // sanity: a genuine numeric string still selects the 1-based branch
+    let reply = run_flow(
+        platform,
+        "claims-decision-coercion",
+        decision_dataset(Some("2")),
+        "claims-cid-3",
+    )
+    .await;
+    assert_eq!(json_body(&reply)["from"], "two", "numeric routing intact");
+
+    // (b) a MISSING decision (no query parameter -> no 'decision' element in
+    // the dataset) aborts the flow: status 500, message 'invalid decision'
+    let reply = run_flow(
+        platform,
+        "claims-decision-coercion",
+        decision_dataset(None),
+        "claims-cid-4",
+    )
+    .await;
+    assert_eq!(reply.status(), 500, "missing decision must abort the flow");
+    let body = json_body(&reply);
+    assert_eq!(body["type"], "error");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("invalid decision"),
+        "abort message must name the invalid decision: {body}"
+    );
+}
+
+/// Claim `flows-location-default`: `claims-flows.yaml` omits `location`, and
+/// its listed flow files exist ONLY under tests/resources/flows/ — the folder
+/// the compiler default `classpath:/flows/` resolves to.
+async fn manifest_without_location_loads_flows_from_default_classpath(platform: &Platform) {
+    assert!(
+        flows::flow_exists("claims-default-location"),
+        "a manifest without 'location' must load its flows from classpath:/flows/"
+    );
+    assert!(
+        flows::get_all_flows().contains(&"claims-default-location".to_string()),
+        "the default-located flow must be in the registry listing"
+    );
+    // and the flow executes end to end
+    let reply = run_flow(
+        platform,
+        "claims-default-location",
+        serde_json::json!({"body": {}}),
+        "claims-cid-loc",
+    )
+    .await;
+    assert_eq!(reply.status(), 200, "flow body: {:?}", reply.body());
+    assert_eq!(json_body(&reply)["value"], "default-location");
+}

--- a/crates/event-script/tests/resources/README.md
+++ b/crates/event-script/tests/resources/README.md
@@ -12,3 +12,10 @@ Java repo.
 `rust-flows.yaml` + `flows-rust/` are Rust-side supplements (also not Java
 copies): trimmed flows covering features whose canonical fixtures depend on
 later increments (e.g. dynamic fork before sub-flows land in E-7).
+
+`claims-flows.yaml` plus `flows/claims-decision-coercion.yml` and
+`flows/claims-default-location.yml` are Rust-side **claims-gate fixtures**
+(pinning tests named in `docs/guides/claims-registry.json`), not Java copies.
+They must live inside `flows/` because the flows-location-default claim
+exercises the compiler's default `classpath:/flows/` — a verbatim re-sync of
+`flows/` from the Java repo must preserve them.

--- a/crates/event-script/tests/resources/claims-flows.yaml
+++ b/crates/event-script/tests/resources/claims-flows.yaml
@@ -1,0 +1,12 @@
+# Claims-registry engine pins (ADR-0023): manifest for the tests/claims.rs
+# binary only — loaded via a process-local 'yaml.flow.automation' override so
+# the fixture manifests (flows.yaml etc.) and their exact-set assertions in
+# compiler.rs / flow_runtime.rs never see these flows.
+#
+# This manifest deliberately OMITS the 'location' entry: the compiler must
+# fall back to its default flow folder (classpath:/flows/) — the
+# 'flows-location-default' claim. The listed files exist ONLY under
+# tests/resources/flows/.
+flows:
+  - 'claims-decision-coercion.yml'
+  - 'claims-default-location.yml'

--- a/crates/event-script/tests/resources/flows/claims-decision-coercion.yml
+++ b/crates/event-script/tests/resources/flows/claims-decision-coercion.yml
@@ -1,0 +1,42 @@
+# Claims pin 'decision-invalid-value': the decision task's process echoes the
+# caller-supplied decision value VERBATIM (no boolean/int conversion in the
+# function), so the raw string reaches the engine's decision router — unlike
+# the SimpleDecision fixture, which converts to a real boolean first.
+flow:
+  id: 'claims-decision-coercion'
+  description: 'Raw decision values reach the decision router unconverted'
+  ttl: 10s
+
+first.task: 'claims.decision.echo'
+
+tasks:
+  - input:
+      - 'input.query.decision -> value'
+    process: 'claims.decision.echo'
+    output:
+      - 'result.value -> decision'
+    description: 'echo the caller-supplied decision value verbatim'
+    execution: decision
+    next:
+      - 'branch.one'
+      - 'branch.two'
+
+  - name: 'branch.one'
+    input:
+      - 'text(one) -> value'
+    process: 'claims.decision.echo'
+    output:
+      - 'text(application/json) -> output.header.content-type'
+      - 'text(one) -> output.body.from'
+    description: 'first branch'
+    execution: end
+
+  - name: 'branch.two'
+    input:
+      - 'text(two) -> value'
+    process: 'claims.decision.echo'
+    output:
+      - 'text(application/json) -> output.header.content-type'
+      - 'text(two) -> output.body.from'
+    description: 'second branch'
+    execution: end

--- a/crates/event-script/tests/resources/flows/claims-default-location.yml
+++ b/crates/event-script/tests/resources/flows/claims-default-location.yml
@@ -1,0 +1,18 @@
+# Claims pin 'flows-location-default': this file is listed by
+# claims-flows.yaml, a manifest WITHOUT a 'location' entry — it is loadable
+# only because the compiler defaults to classpath:/flows/.
+flow:
+  id: 'claims-default-location'
+  description: 'Loaded through a manifest that omits location (compiler default)'
+  ttl: 10s
+
+first.task: 'claims.decision.echo'
+
+tasks:
+  - input:
+      - 'text(default-location) -> value'
+    process: 'claims.decision.echo'
+    output:
+      - 'result.value -> output.body.value'
+    description: 'echo a marker so execution is observable'
+    execution: end

--- a/crates/knowledge-graph/src/common.rs
+++ b/crates/knowledge-graph/src/common.rs
@@ -960,6 +960,11 @@ mod tests {
     /// positives on longer names.
     #[test]
     fn reserved_model_metadata_is_immutable() {
+        // the set is exactly these nine names (claims-registry pin)
+        assert_eq!(
+            RESERVED_MODEL_METADATA,
+            ["cid", "instance", "flow", "ttl", "trace", "parent", "root", "none", "run"]
+        );
         for key in RESERVED_MODEL_METADATA {
             let target = format!("model.{key}");
             assert!(

--- a/crates/knowledge-graph/tests/claims.rs
+++ b/crates/knowledge-graph/tests/claims.rs
@@ -1,0 +1,183 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Claims-registry engine pin (ADR-0023) — `extension-target-asymmetry`:
+//! `graph.extension` validates a `flow://` target against the flow registry
+//! BEFORE launching anything (a missing flow aborts the run — 400, "does not
+//! exist" — and the node's `exception=` handler is NOT consulted), while a
+//! GRAPH-id target is only discovered missing by the delegated
+//! `graph-executor` flow at run time (404, "not found") — an ordinary
+//! delegate failure that DOES route to the `exception=` handler with the
+//! staged error context (`error.code` / `error.message`).
+//!
+//! This binary compiles ONLY `claims-graphs.yaml` (a process-local
+//! `graph.model.automation` override), so `graphs.yaml` and its exact-count
+//! assertion in compiler.rs are untouched.
+//!
+//! One `#[tokio::test]` wrapper on purpose (the global platform's workers
+//! live on this test's runtime — the graph_runtime.rs pattern).
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use event_script::FlowExecutor;
+use platform_core::{
+    main_application, preload, trace, AppError, AutoStart, ComposableFunction, EntryPoint,
+    EventEnvelope, Platform,
+};
+
+/// Every invocation of the exception-handler node lands here: the pin
+/// asserts the handler is NEVER reached on the flow:// pre-flight failure
+/// and reached EXACTLY ONCE (with the staged error context) on the
+/// missing-graph delegate failure.
+static PROBE_CALLS: Mutex<Vec<serde_json::Value>> = Mutex::new(Vec::new());
+
+#[preload(route = "claims.error.probe", instances = 10)]
+struct ClaimsErrorProbe;
+
+#[async_trait]
+impl ComposableFunction for ClaimsErrorProbe {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let body: serde_json::Value = input.body_as().unwrap_or(serde_json::Value::Null);
+        PROBE_CALLS.lock().expect("probe log").push(body.clone());
+        EventEnvelope::new().set_body(body)
+    }
+}
+
+#[main_application]
+struct ClaimsGraphTestApp;
+
+#[async_trait]
+impl EntryPoint for ClaimsGraphTestApp {
+    async fn start(&self, _args: &[String]) -> Result<(), AppError> {
+        Ok(())
+    }
+}
+
+// ---- helpers (graph_runtime.rs conventions) ----
+
+async fn boot() -> Platform {
+    platform_core::resources::prepend_resource_root("tests/resources");
+    // this binary compiles ONLY the claims graphs — the process override keeps
+    // graphs.yaml (and its exact-count assertion in compiler.rs) untouched
+    platform_core::overrides::set("graph.model.automation", "classpath:/claims-graphs.yaml");
+    AutoStart::main(vec![]).await.expect("lifecycle");
+    Platform::get_instance()
+}
+
+/// The Java `runGraph` analog: POST /api/graph/{graph-id} through the
+/// graph-executor flow.
+async fn run_graph(platform: &Platform, graph_id: &str, body: serde_json::Value) -> EventEnvelope {
+    let dataset = serde_json::json!({
+        "body": body,
+        "header": {},
+        "path_parameter": {"graph_id": graph_id},
+        "method": "POST",
+    });
+    FlowExecutor::request(
+        platform,
+        "graph-executor",
+        event_script::conversions::from_json(&dataset),
+        &format!("cid-{graph_id}"),
+        Duration::from_secs(8),
+        Some((&trace::new_trace_id(), &format!("TEST /graph/{graph_id}"))),
+    )
+    .await
+    .unwrap_or_else(|e| panic!("graph {graph_id} failed: {} {}", e.status(), e.message()))
+}
+
+fn body_text(reply: &EventEnvelope) -> String {
+    let body: serde_json::Value = reply
+        .body_as()
+        .unwrap_or_else(|_| serde_json::Value::String(format!("{:?}", reply.body())));
+    serde_json::to_string(&body).unwrap_or_default()
+}
+
+// ---- the claims pin ----
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn claims_pins_run_end_to_end() {
+    let platform = boot().await;
+    extension_missing_flow_aborts_but_missing_graph_routes_to_handler(&platform).await;
+}
+
+/// Claim `extension-target-asymmetry` (extension.rs `build_forward`,
+/// executor.rs `handle_skill_response`).
+async fn extension_missing_flow_aborts_but_missing_graph_routes_to_handler(platform: &Platform) {
+    // precondition: both claims graphs passed the CompileGraph gate
+    assert!(knowledge_graph::graphs::graph_exists(
+        "claims-ext-missing-flow"
+    ));
+    assert!(knowledge_graph::graphs::graph_exists(
+        "claims-ext-missing-graph"
+    ));
+
+    // (a) extension=flow://no-such-flow: the flow registry is consulted
+    // BEFORE any launch — the skill fails 400 with "does not exist" and the
+    // run aborts; the node's exception= handler is NOT invoked
+    let response = run_graph(platform, "claims-ext-missing-flow", serde_json::json!({})).await;
+    assert_eq!(
+        400,
+        response.status(),
+        "a missing flow:// target must abort the run: {:?}",
+        response.body()
+    );
+    let text = body_text(&response);
+    assert!(
+        text.contains("does not exist"),
+        "abort message must say the flow does not exist: {text}"
+    );
+    assert!(
+        PROBE_CALLS.lock().expect("probe log").is_empty(),
+        "the exception= handler must NOT be invoked on the flow:// pre-flight failure"
+    );
+
+    // (b) extension=<nonexistent graph id>: the delegate rides the
+    // graph-executor flow and fails at run time with 404 "not found" — an
+    // ordinary delegate failure that DOES route to the exception= handler,
+    // which sees the staged error context
+    let response = run_graph(platform, "claims-ext-missing-graph", serde_json::json!({})).await;
+    assert_eq!(
+        200,
+        response.status(),
+        "the handler must recover the run: {:?}",
+        response.body()
+    );
+    let body: serde_json::Value = response.body_as().expect("json body");
+    assert_eq!(
+        body["code"], 404,
+        "the handler must see error.code = 404: {body}"
+    );
+    let message = serde_json::to_string(&body["message"]).unwrap_or_default();
+    assert!(
+        message.contains("not found"),
+        "the handler must see error.message containing 'not found': {body}"
+    );
+    let calls = PROBE_CALLS.lock().expect("probe log");
+    assert_eq!(
+        1,
+        calls.len(),
+        "the exception= handler must run exactly once (and only for the graph case)"
+    );
+    assert_eq!(calls[0]["code"], 404, "staged context reached the handler");
+}

--- a/crates/knowledge-graph/tests/resources/claims-graphs.yaml
+++ b/crates/knowledge-graph/tests/resources/claims-graphs.yaml
@@ -1,0 +1,8 @@
+# Claims-registry engine pins (ADR-0023): manifest for the tests/claims.rs
+# binary only — loaded via a process-local 'graph.model.automation' override,
+# so graphs.yaml and its exact-count assertion in compiler.rs are untouched.
+# No 'location' entry: the default classpath:/graph resolves to
+# tests/resources/graph/.
+graphs:
+  - 'claims-ext-missing-flow'
+  - 'claims-ext-missing-graph'

--- a/crates/knowledge-graph/tests/resources/graph/claims-ext-missing-flow.json
+++ b/crates/knowledge-graph/tests/resources/graph/claims-ext-missing-flow.json
@@ -1,0 +1,119 @@
+{
+  "nodes": [
+    {
+      "alias": "root",
+      "types": [
+        "Root"
+      ],
+      "properties": {
+        "purpose": "claims pin: a graph.extension node whose flow:// target does not exist aborts the run before any call - the exception= handler is NOT consulted",
+        "name": "claims-ext-missing-flow"
+      }
+    },
+    {
+      "alias": "ext",
+      "types": [
+        "Extension"
+      ],
+      "properties": {
+        "skill": "graph.extension",
+        "extension": "flow://no-such-flow",
+        "exception": "catcher",
+        "input": [
+          "text(hello) -> hello"
+        ],
+        "output": [
+          "result -> output.body"
+        ],
+        "purpose": "delegate to a flow id that is not in the flow registry"
+      }
+    },
+    {
+      "alias": "island",
+      "types": [
+        "Island"
+      ],
+      "properties": {
+        "skill": "graph.island",
+        "purpose": "anchor: keeps the jump-only handler node non-orphan while plain traversal stops here"
+      }
+    },
+    {
+      "alias": "catcher",
+      "types": [
+        "Task"
+      ],
+      "properties": {
+        "skill": "graph.task",
+        "task": "claims.error.probe",
+        "input": [
+          "error.code -> code",
+          "error.message -> message"
+        ],
+        "output": [
+          "result -> output.body"
+        ],
+        "purpose": "records every invocation - the pin asserts it is NEVER reached on the flow:// pre-flight failure"
+      }
+    },
+    {
+      "alias": "end",
+      "types": [
+        "End"
+      ],
+      "properties": {}
+    }
+  ],
+  "connections": [
+    {
+      "source": "root",
+      "target": "ext",
+      "relations": [
+        {
+          "type": "run",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "root",
+      "target": "island",
+      "relations": [
+        {
+          "type": "test",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "island",
+      "target": "catcher",
+      "relations": [
+        {
+          "type": "anchor",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "ext",
+      "target": "end",
+      "relations": [
+        {
+          "type": "finish",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "catcher",
+      "target": "end",
+      "relations": [
+        {
+          "type": "finish",
+          "properties": {}
+        }
+      ]
+    }
+  ]
+}

--- a/crates/knowledge-graph/tests/resources/graph/claims-ext-missing-graph.json
+++ b/crates/knowledge-graph/tests/resources/graph/claims-ext-missing-graph.json
@@ -1,0 +1,119 @@
+{
+  "nodes": [
+    {
+      "alias": "root",
+      "types": [
+        "Root"
+      ],
+      "properties": {
+        "purpose": "claims pin: a graph.extension node naming a nonexistent GRAPH id rides the graph-executor flow, fails 404, and routes to its exception= handler",
+        "name": "claims-ext-missing-graph"
+      }
+    },
+    {
+      "alias": "ext",
+      "types": [
+        "Extension"
+      ],
+      "properties": {
+        "skill": "graph.extension",
+        "extension": "no-such-graph-id",
+        "exception": "catcher",
+        "input": [
+          "text(hello) -> hello"
+        ],
+        "output": [
+          "result -> output.body"
+        ],
+        "purpose": "delegate to a graph id that is not in the compiled registry"
+      }
+    },
+    {
+      "alias": "island",
+      "types": [
+        "Island"
+      ],
+      "properties": {
+        "skill": "graph.island",
+        "purpose": "anchor: keeps the jump-only handler node non-orphan while plain traversal stops here"
+      }
+    },
+    {
+      "alias": "catcher",
+      "types": [
+        "Task"
+      ],
+      "properties": {
+        "skill": "graph.task",
+        "task": "claims.error.probe",
+        "input": [
+          "error.code -> code",
+          "error.message -> message"
+        ],
+        "output": [
+          "result -> output.body"
+        ],
+        "purpose": "the exception handler: reads the staged error context (error.code / error.message)"
+      }
+    },
+    {
+      "alias": "end",
+      "types": [
+        "End"
+      ],
+      "properties": {}
+    }
+  ],
+  "connections": [
+    {
+      "source": "root",
+      "target": "ext",
+      "relations": [
+        {
+          "type": "run",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "root",
+      "target": "island",
+      "relations": [
+        {
+          "type": "test",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "island",
+      "target": "catcher",
+      "relations": [
+        {
+          "type": "anchor",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "ext",
+      "target": "end",
+      "relations": [
+        {
+          "type": "finish",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "catcher",
+      "target": "end",
+      "relations": [
+        {
+          "type": "finish",
+          "properties": {}
+        }
+      ]
+    }
+  ]
+}

--- a/crates/platform-core/tests/annotations.rs
+++ b/crates/platform-core/tests/annotations.rs
@@ -97,6 +97,27 @@ impl ComposableFunction for UntypedEcho {
     }
 }
 
+/// The other half of the Java `envInstances` contract (claims-registry pin):
+/// an UNSET `env_instances` key falls back to the annotation's literal.
+#[preload(
+    route = "anno.fallback.echo",
+    env_instances = "claims.no.such.key",
+    instances = 3
+)]
+struct FallbackEcho;
+
+#[async_trait]
+impl ComposableFunction for FallbackEcho {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        Ok(EventEnvelope::new().set_raw_body(input.body().clone()))
+    }
+}
+
 /// Stacked marker (Java `@PreLoad` + `@ZeroTracing`): a traced request to
 /// this route must execute WITHOUT a trace bracket (no telemetry, no
 /// propagation).
@@ -418,9 +439,15 @@ async fn annotation_macros_end_to_end() {
         "unsatisfied condition must skip registration"
     );
     // instance counts: the literal for the typed echo; env_instances (7 from
-    // the override) beats the literal 2 for the untyped one
+    // the override) beats the literal 2 for the untyped one; an UNSET
+    // env_instances key falls back to the literal (claims-registry pin)
     assert_eq!(platform.instances("anno.typed.echo"), Some(4));
     assert_eq!(platform.instances("anno.untyped.echo"), Some(7));
+    assert_eq!(
+        platform.instances("anno.fallback.echo"),
+        Some(3),
+        "unset env_instances key must fall back to the literal"
+    );
 
     // a typed annotated function serves RPC with (de)serialization
     let po = PostOffice::new(&platform);

--- a/crates/platform-core/tests/telemetry.rs
+++ b/crates/platform-core/tests/telemetry.rs
@@ -242,7 +242,8 @@ async fn untraced_request_emits_no_telemetry() {
                 platform: platform.clone(),
                 next: None,
                 seen_cid: cid.clone(),
-                annotate: None,
+                // the hop annotates during the UNTRACED request — must no-op
+                annotate: Some(("claims", "no-op")),
             }),
             1,
         )
@@ -256,9 +257,13 @@ async fn untraced_request_emits_no_telemetry() {
     tokio::time::sleep(Duration::from_millis(150)).await;
     assert!(
         datasets.lock().unwrap().is_empty(),
-        "no trace = no telemetry"
+        "no trace = no telemetry, even when the function annotated"
     );
-    // outside a trace, the business APIs are silent no-ops
+    // outside a trace, the business APIs are silent no-ops (claims-registry
+    // pin: annotate_trace above produced nothing; update_context here still
+    // succeeds without a bracket; the correlation id is absent)
+    po.update_context("claims", "no-op")
+        .expect("update_context outside a trace must be a silent no-op");
     assert_eq!(*cid.lock().unwrap(), None);
 }
 

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2701,3 +2701,29 @@ engine: `docs/ai-grammar-methodology.md` → `docs/mercury-story.md` and
 live references follow (mkdocs nav, the hero's absolute site URLs, the paper's deck
 pointer); the CHANGELOG and earlier increments keep the old paths as history. The old URLs
 are not redirected — the pages had been live for about a day.
+
+## Increment 105 — Claims-fixture gate + the sibling doc sweep (2026-09-06)
+
+The engine adopts the claims-fixture mechanism in lock-step with the Java repo's ADR-0023:
+`docs/guides/claims-registry.json` registers 20 high-value prose **behavior claims**, each
+stating exactly what its named engine test pins — no more. `scripts/check-doc-claims.py`
+verifies both sides (the normative sentence still appears on its page, whitespace-normalized
+case-insensitive containment; the test pin still exists as a fn *definition*, block-comment-
+and call-site-proof) and runs in BOTH `docs.yml` and `rust.yml`, so a test rename fails the
+build even when no doc changed. The registry ships in the packaged contract and `llms.txt`
+— an AI agent may treat registered claims as source-verified. Three new pinning tests land
+(decision coercion-to-branch-1 + flows default location in `event-script/tests/claims.rs`;
+the `graph.extension` missing-target asymmetry in `knowledge-graph/tests/claims.rs`) and
+three existing pins were upgraded to cover their whole claim (the exact nine-name reserved
+model-metadata set; untraced `annotate_trace`/`update_context` as silent no-ops;
+`env_instances` fallback-to-literal on an unset key).
+
+The same round carried the **sibling sweep** of the Java engine's AI-grammar coverage-study
+findings, each item re-verified against THIS engine before editing (never assumed parity):
+`error.code` (not `error.status`) across the flow error dataset pages, full decision
+semantics (non-numeric coerces to branch 1 silently; missing aborts), the `stream: true`
+endpoint field, crates.io usage sections, the nine reserved keys, suspend's HTTP-200 reply,
+export/orphan honesty (neither export nor the CompileGraph gate checks connectivity), and
+the extension target asymmetry with the delegate's wrapped error object shape. Two
+adversarial verify rounds (engine-source refuters with live probes) ran before commit; every
+surviving finding — including three of this round's own over-claims — was applied.

--- a/docs/arch-decisions/ADR.md
+++ b/docs/arch-decisions/ADR.md
@@ -26,6 +26,43 @@ or *Deprecated* (no longer relevant), with its text left in place.
 
 ---
 
+## ADR-0018 — The claims-fixture gate: documentation behavior claims are CI-pinned {#adr-0018}
+**Status:** Accepted · **Date:** 2026-09-06 · **Serves:** vision-mercury · **Formalizes:** claims-fixture-gate
+<!-- id: adr-0018 | status: accepted -->
+
+**Abstract.** `docs/guides/claims-registry.json` registers high-value documentation
+**behavior claims** — a claim states exactly what its named engine test pins, never more.
+`scripts/check-doc-claims.py` verifies both sides of every entry: the claim's normative
+sentence still appears on one of its pages (whitespace-normalized, case-insensitive
+containment — removal or rewording fails, re-casing passes), and its engine test pin
+(`crates/<crate-dir>::<test-file-stem>::<fn>`) still exists as a function *definition* in
+that crate's test tree (call sites, line comments and block-commented-out code do not
+count; an `rglob` fallback resolves pins living in `#[cfg(test)]` modules inside `src/`).
+The pinned tests themselves run in the normal `cargo test --workspace` build. The checker
+runs in BOTH workflows — `docs.yml` (doc edits) and `rust.yml` (deliberately, because a
+test rename does not trigger the docs workflow's path filter) — so neither side of a pin
+can drift silently. The registry is a grammar asset: packaged in the ai-contract-provider
+skill and mapped in `llms.txt`, so an AI agent may treat registered claims as
+source-verified without opening `crates/`. Lock-step twin of the Java engine's ADR-0023;
+the registry format is engine-neutral (only the test-ref grammar differs:
+`module::Class#method` there, `crate::file::fn` here).
+
+**Rationale.** The Java repo's AI-grammar coverage study found that all documentation
+drift lived in ungated prose while every generated/gated surface held — and this port's
+sibling sweep reproduced the pattern (the same `error.status` drift, a stale divergence
+note, an over-claimed export invariant). Shape gates (link integrity, packaging closure,
+compile-time anchors) cannot see a behavior sentence rot; the claims fixture extends
+drift-testing from shape to behavior at the granularity that matters — the specific
+sentences an agent acts on. The "states exactly what its named test pins" contract is
+load-bearing: this round's own adversarial verification found six claims whose prose
+bundled behavior their pin did not exercise, and the fix (narrow the claim or upgrade the
+pin) is exactly the discipline the contract encodes. Alternatives rejected: generating
+prose from tests (kills the narrative layer the grammar exists for), and pinning whole
+pages by checksum (fails on every harmless edit, so it would be bypassed). New claims
+enter via the field feedback circuit, one test-verified sentence at a time.
+
+---
+
 ## ADR-0017 — Route pools: numbered singleton lanes as a first-class platform registration {#adr-0017}
 **Status:** Accepted · **Date:** 2026-08-30 · **Serves:** vision-mercury · **Formalizes:** route-pool-registration-design
 <!-- id: adr-0017 | status: accepted -->

--- a/docs/guides/claims-registry.json
+++ b/docs/guides/claims-registry.json
@@ -1,0 +1,168 @@
+{
+  "registry": "claims-fixture",
+  "version": "1.0",
+  "description": "Machine-readable registry of CI-pinned documentation behavior claims for the Rust engine (the engine-neutral mechanism of the Java repo's ADR-0023). Each claim states exactly what its named engine test pins - no more. The claim's normative sentence must appear on one of its pages (scripts/check-doc-claims.py: whitespace-normalized, case-insensitive containment) and the engine test pin must exist as a fn definition; the pinned tests run in the normal cargo test --workspace build. An AI agent may treat these claims as source-verified.",
+  "test_ref_format": "crates/<crate-dir>::<test-file-stem>::<fn>",
+  "claims": [
+    {
+      "id": "error-dataset-code-key",
+      "claim": "The error dataset of an exception handler exposes the failing status as error.code.",
+      "pages": ["docs/guides/event-script/syntax.md", "docs/guides/event-script/flow-grammar.md"],
+      "quote": "error.code - the status code of the exception",
+      "test": "crates/event-script::flow_runtime::flows_run_end_to_end_like_java",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "decision-branching",
+      "claim": "A decision task branches on true/false or a 1-based integer; an integer above the branch count aborts the flow.",
+      "pages": ["docs/guides/event-script/flow-grammar.md"],
+      "quote": "`true`→next[0]/`false`→next[1]; or numeric 1-indexed, multi-way",
+      "test": "crates/event-script::flow_runtime::flows_run_end_to_end_like_java",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "decision-invalid-value",
+      "claim": "A non-boolean, non-numeric decision value coerces to 1 and silently selects the first branch; a missing decision aborts the flow.",
+      "pages": ["docs/guides/event-script/syntax.md"],
+      "quote": "silently select the first branch",
+      "test": "crates/event-script::claims::non_numeric_decision_silently_routes_to_branch_one",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "flows-location-default",
+      "claim": "A flows.yaml manifest that omits 'location' loads its flow files from classpath:/flows/.",
+      "pages": ["docs/guides/configuration-reference.md", "docs/guides/flow-schema-reference.md"],
+      "quote": "`location` inside the manifest defaults to `classpath:/flows/`",
+      "test": "crates/event-script::claims::manifest_without_location_loads_flows_from_default_classpath",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "subflow-ttl-catchable",
+      "claim": "A task-level ttl on a flow:// task makes the child time out first, so its 408 is catchable by the parent's exception handler.",
+      "pages": ["docs/guides/event-script/flow-grammar.md"],
+      "quote": "overrides the propagated parent TTL so the sub-flow's timeout is catchable",
+      "test": "crates/event-script::flow_runtime::flows_run_end_to_end_like_java",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "no-handler-error-shape",
+      "claim": "An unhandled flow error reaches the caller as {type: error, status, message} with the matching HTTP status.",
+      "pages": ["docs/guides/flow-schema-reference.md"],
+      "quote": "the flow aborts and the caller receives the error as",
+      "test": "crates/event-script::flow_runtime::flows_run_end_to_end_like_java",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "duplicate-route-reload",
+      "claim": "Registering a duplicate route does not fail the application: the earlier registration is reloaded and the newest function serves.",
+      "pages": ["docs/guides/macros-reference.md"],
+      "quote": "a duplicate route RELOADS the existing one, exactly like Java `Platform.register`",
+      "test": "crates/platform-core::event_bus::route_validation_replacement_and_worker_clamp_match_java",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "env-instances-config-key",
+      "claim": "With env_instances, the configured value beats the annotation's instances literal when the key is set; a missing key falls back to the literal.",
+      "pages": ["docs/guides/macros-reference.md"],
+      "quote": "the instance count is configuration-driven — the literal loses to the configured value when the key is set",
+      "test": "crates/platform-core::annotations::annotation_macros_end_to_end",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "stream-field-parsed",
+      "claim": "rest.yaml's stream: true is parsed by the engine and streaming replies ride a dedicated ordered reply lane.",
+      "pages": ["docs/guides/http-streaming.md", "docs/guides/rest-automation.md"],
+      "quote": "Add `stream: true` to the endpoint definition in rest.yaml",
+      "test": "crates/platform-core::event_stream::sse_segments_arrive_progressively_with_terminal_done_event",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "config-override-precedence",
+      "claim": "A value in the runtime override registry (the -Dkey=value mechanism) beats the same key's configuration-file value.",
+      "pages": ["docs/guides/configuration-reference.md"],
+      "quote": "win over configuration-file values",
+      "test": "crates/platform-core::config::override_registry_beats_the_file_value",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "config-manifest-merge-order",
+      "claim": "Configuration files merge in the manifest order - a later manifest file's value overrides an earlier one's, and keys unique to one file survive the merge.",
+      "pages": ["docs/guides/configuration-reference.md"],
+      "quote": "merge in the manifest order",
+      "test": "crates/platform-core::config::later_manifest_files_override_earlier_ones",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "msgpack-typed-roundtrip",
+      "claim": "Envelope bodies are typed through serde on set_body/body_as - a small i64 round-trips as i64 with no Java-style Integer downcast surprise.",
+      "pages": ["docs/guides/event-envelope-reference.md"],
+      "quote": "typed values pass through `serde` on `set_body`/`body_as`",
+      "test": "crates/platform-core::event_bus::envelope_round_trips_through_msgpack",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "trace-noop-outside-bracket",
+      "claim": "Trace annotation and context calls are silent no-ops outside a trace bracket.",
+      "pages": ["docs/guides/observability.md"],
+      "quote": "outside a trace both calls are no-ops",
+      "test": "crates/platform-core::telemetry::untraced_request_emits_no_telemetry",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "inspect-returns-subtrees",
+      "claim": "The Playground inspect command resolves whole subtrees, not only leaf keys.",
+      "pages": ["docs/guides/knowledge-graph/command-reference.md"],
+      "quote": "a whole namespace: input | output | model | error",
+      "test": "crates/knowledge-graph::playground::playground_command_grammar_and_companion",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "export-identity-guard",
+      "claim": "Export validates the declared root name only when one is declared; a missing or blank root name is accepted and self-named.",
+      "pages": ["docs/guides/knowledge-graph/command-reference.md"],
+      "quote": "missing or blank root name is accepted",
+      "test": "crates/knowledge-graph::playground::export_name_guard_accepts_missing_and_rejects_mismatch",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "root-purpose-gate-only",
+      "claim": "A graph whose root node lacks a purpose fails the CompileGraph deployment gate.",
+      "pages": ["docs/guides/knowledge-graph/build-your-first-graph.md"],
+      "quote": "structure, the root node's `purpose`, data-mapping syntax",
+      "test": "crates/knowledge-graph::compiler::manifest_listed_graphs_are_compiled",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "reserved-model-keys-nine",
+      "claim": "The reserved model-metadata key set is exactly nine names: cid, instance, flow, ttl, trace, parent, root, none, run - and every one is rejected as a data-mapping write target.",
+      "pages": ["docs/guides/knowledge-graph/workflow-suspension.md"],
+      "quote": "The nine reserved model-metadata keys",
+      "test": "crates/knowledge-graph::common::reserved_model_metadata_is_immutable",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "compiled-or-404",
+      "claim": "A graph is deployed only when manifest-listed and passing CompileGraph; a failed or unlisted graph is absent from the executable registry.",
+      "pages": ["docs/guides/knowledge-graph/build-your-first-graph.md"],
+      "quote": "A graph that fails the gate, or is not listed",
+      "test": "crates/knowledge-graph::compiler::invalid_manifest_graphs_are_not_compiled",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "suspended-reply-200",
+      "claim": "A suspended run replies HTTP 200 with {type: suspended, cid} - the run completed normally by suspending.",
+      "pages": ["docs/guides/knowledge-graph/workflow-suspension.md"],
+      "quote": "the run completed normally by suspending",
+      "test": "crates/knowledge-graph::graph_runtime::suspend_resume_matches_java_semantics",
+      "since": "4.12.3+"
+    },
+    {
+      "id": "extension-target-asymmetry",
+      "claim": "A missing flow:// target aborts the run before any call and is not exception=-routable; a missing graph id surfaces as the delegate's 404 reply, catchable by the exception= route.",
+      "pages": ["docs/guides/knowledge-graph/skills-reference.md"],
+      "quote": "a missing `flow://{flow-id}` aborts the run *before* any call is made",
+      "test": "crates/knowledge-graph::claims::extension_missing_flow_aborts_but_missing_graph_routes_to_handler",
+      "since": "4.12.3+"
+    }
+  ]
+}

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -565,7 +565,7 @@ the window aborts the traversal. Read by `crates/knowledge-graph`.
 How many visits to the same node within `graph.max.loop.interval` count as a runaway loop
 (floor 2). Read by `crates/knowledge-graph`.
 
-#### `redis.*` (the `minigraph-state-redis` extension crate)
+#### `redis.*` (the `minigraph-state-redis` extension crate — crates.io: `mercury-minigraph-state-redis`)
 
 | Key | Type | Default |
 |---|---|---|

--- a/docs/guides/event-script/flow-grammar.md
+++ b/docs/guides/event-script/flow-grammar.md
@@ -88,7 +88,7 @@ Every `input`/`output` entry is `'source -> target'` (one `->` per rule; a three
 | `input.*` | the HTTP request dataset (`input.body`, `input.header.*`, `input.query.*`, `input.path_parameter.*`, `input.method`, …) |
 | `model.*` | flow-instance state (dot/bracket/`{model.key}` dynamic keys) |
 | `model.parent.*` / `model.root.*` | parent-flow state (in sub-flows) |
-| `error.*` | exception context in a handler (`error.task/.status/.message/.stack`) |
+| `error.*` | exception context in a handler (`error.task/.code/.message`) |
 | `$.…` | a JSONPath expression |
 | `result` / `input` / `header` / `status` / `datatype` | (in `output` rules) the function's result, the task input, response headers, status code, or result type name |
 | constants | `text(…)`, `int(…)`, `long(…)`, `float(…)`, `double(…)`, `boolean(…)`, `map(k=v,…)`, `file(text:/json:/binary:path)`, `classpath(…)` |

--- a/docs/guides/event-script/syntax.md
+++ b/docs/guides/event-script/syntax.md
@@ -478,9 +478,11 @@ to a task or the generic exception handler that attaches to the flow itself.
 The error dataset includes the following:
 
 1. error.task - this is the task name of the task that throws exception
-2. error.status - the status code of the exception
+2. error.code - the status code of the exception
 3. error.message - the error message
-4. error.stack - stack trace if any
+
+> The Rust engine produces **no stack trace**: an `error.stack` mapping (a Java-engine key,
+> present there only when a stack trace exists) is tolerated but resolves null.
 
 The external state machine namespace uses the namespace `ext:` to indicate that the key-value is external.
 
@@ -1019,6 +1021,13 @@ tasks:
       - 'decision.case.one'
       - 'decision.case.two'
 ```
+
+**Runtime semantics for a bad decision value** — a `null` or missing decision aborts the flow
+("returned invalid decision"), and an integer **above** the branch count aborts likewise; but
+`0`, negative integers, and any non-boolean, non-numeric value (e.g. the *string* `"false"`)
+are coerced through integer conversion clamped to a minimum of `1`, so they **silently select
+the first branch**. Return a real boolean or a valid 1-based integer from the function, or
+stage the value through a typed model variable — never rely on coercion.
 
 ### Response task
 

--- a/docs/guides/flow-schema-reference.md
+++ b/docs/guides/flow-schema-reference.md
@@ -331,8 +331,10 @@ Runs the function, then passes control to exactly one `next` task.
 Branches on the value its `output` maps to `decision`. `true` (or `1`) routes to the first
 `next` entry, `false` (or `2`) to the second; an integer `N` is **1-based** — `N` routes to
 the Nth entry, so a decision can fan to more than two tasks. Requires at least two `next`
-entries and the `-> decision` output mapping; a value that is missing or out of range aborts
-the flow with status 500.
+entries and the `-> decision` output mapping; a missing value or an integer above the branch
+count aborts the flow with status 500, while `0`, negative integers, and non-numeric values
+are coerced through integer conversion clamped to a minimum of 1 and **silently select the
+first branch**.
 
 #### `parallel`
 
@@ -406,10 +408,9 @@ catchable by this flow's exception handler.
 :   The error message (a nested sub-flow error is unwrapped to its message).
 
 !!! note "Rust port"
-    The Java reference documents these keys as `error.status` and `error.stack`. The engine's
-    error dataset — here exactly as in the canonical fixture flows — uses **`error.code`**
-    for the status code, and the Rust engine produces **no stack trace**: an `error.stack`
-    mapping is tolerated but resolves null.
+    Both engines expose the status code as **`error.code`**. The Java engine additionally
+    supplies `error.stack` when a stack trace exists; the Rust engine produces **no stack
+    trace** — an `error.stack` mapping is tolerated but resolves null.
 
 If the flow-level handler itself throws, the flow aborts rather than looping (exception-loop
 guard). Without any handler, the flow aborts and the caller receives the error as

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -160,6 +160,22 @@ is kept verbatim from the Java original so files port between the two implementa
 Spring-specific key names are retired in the Rust port (`APP_PROFILES_ACTIVE`,
 `application.name`).
 
+## Use from crates.io
+
+The seven library crates publish under `mercury-`prefixed package names, while the lib
+(code-facing) names stay short:
+
+```toml
+[dependencies]
+mercury-platform-core = "4.12"      # code: use platform_core::...
+mercury-event-script = "4.12"       # code: use event_script::...
+mercury-knowledge-graph = "4.12"    # code: use knowledge_graph::...
+```
+
+The macro crates (`mercury-platform-macros`, `mercury-event-script-macros`,
+`mercury-knowledge-graph-macros`) are pulled in automatically; add
+`mercury-minigraph-state-redis` for the Redis suspend/resume state store.
+
 ## Next steps
 
 - Write your own function: [the authoring walkthrough](event-driven/write-your-first-function.md)

--- a/docs/guides/http-streaming.md
+++ b/docs/guides/http-streaming.md
@@ -67,6 +67,8 @@ A streaming producer is an interceptor function - it receives the raw event enve
 (including `reply_to` and correlation id) and replies by sending events itself:
 
 ```rust
+use platform_core::{preload, AppError, ComposableFunction, EventEnvelope, EventStreamWriter, Platform};
+
 #[preload(route = "v1.token.producer", instances = 50, interceptor)]
 struct TokenProducer;
 

--- a/docs/guides/knowledge-graph/build-your-first-graph.md
+++ b/docs/guides/knowledge-graph/build-your-first-graph.md
@@ -168,13 +168,14 @@ export graph as my-first-graph
 
 ```
 > export graph as my-first-graph
-Added name=my-first-graph to Root node
 Graph exported to /tmp/graph/my-first-graph.json
 Described in /api/graph/model/my-first-graph/436-4
 ```
 
-Export fails if any node is an orphan — every node must connect to at least one other
-(see [the invariants](command-reference.md#invariants)).
+Export does not check connectivity — nor does the CompileGraph deployment gate (it
+re-validates structure, mapping syntax, and the root/end rules, not orphans) — but the
+authoring convention is **no node left unconnected** (wire configuration nodes under an
+island; see [the invariants](command-reference.md#invariants)).
 
 ## Step 6 — deploy it and call it over REST
 

--- a/docs/guides/knowledge-graph/command-reference.md
+++ b/docs/guides/knowledge-graph/command-reference.md
@@ -255,8 +255,10 @@ import node {node} from {name}
   (`Expect root node name=...`) — protecting `graph123.json` from another graph's content —
   while a **missing or blank root name is accepted**, and the export assigns the target id
   as the root name (the same self-naming a brand-new export performs).
-- `export` writes JSON to `location.graph.temp`; it adds `name={name}` to the root node and
-  **fails if any node is an orphan** (every node must connect to ≥1 other).
+- `export` writes JSON to `location.graph.temp` and adds `name={name}` to the root node.
+  (Orphan nodes are not rejected at export — and the CompileGraph deployment gate does not
+  check connectivity either; the authoring convention *no node left unconnected* is upheld
+  by review, not by the engine.)
 - The export reply includes `Described in /api/graph/model/{name}/{token}` — a read-only HTTP
   view of the exported model.
 
@@ -784,13 +786,17 @@ the `COMPUTE` doubles through `f:add` (both forms are engine-verified).
 
 ## Invariants {#invariants}
 
-Hard rules the engine enforces — violate them and generation fails:
+Hard rules the engine enforces — violate them and generation fails (invariant 4 is the one
+exception: an authoring convention, marked below):
 
 1. The root node is named `root`; the end node is named `end`.
 2. A node has **0 or 1** skill.
 3. Node **names** are **lowercase letters, digits and hyphen** (`root`/`end` reserved). Node **types** are
    descriptive labels — shipped examples capitalize structural types (see [lexical](#lexical)).
-4. Every node **in the traversal path** must connect to ≥1 node, or `export` fails.
+4. *(authoring convention — not engine-enforced)* Every node **in the traversal path**
+   should connect to ≥1 node. Neither export nor the CompileGraph gate checks connectivity
+   (the gate re-validates structure, mapping syntax, the root/end rules, and the
+   suspend/ttl/metadata rules — not orphans).
    `Dictionary` and `Provider` configuration nodes are referenced *by name* (`dictionary[]=`,
    `provider=`) and are **not traversed** — but the convention is still **no node left
    unconnected**: wire them under a `graph.island` node

--- a/docs/guides/knowledge-graph/composing-the-layers.md
+++ b/docs/guides/knowledge-graph/composing-the-layers.md
@@ -176,6 +176,9 @@ flow:
 first.task: 'graph.executor'
 
 tasks:
+  # the shipped graph-executor.yml also contains the graph.exception.handler task that the
+  # flow-level exception: above refers to (graph.exception.handler is an engine built-in) -
+  # include the handler task when copying this pattern into your own flow
   - input:
       - 'model.instance -> header.instance'
       - 'input.path_parameter.graph_id -> header.graph'

--- a/docs/guides/knowledge-graph/skills-reference.md
+++ b/docs/guides/knowledge-graph/skills-reference.md
@@ -233,8 +233,14 @@ output[]=result.sales_performance -> output.body.sales_performance
 
 - `extension={graph-id}` resolves among the **deployed graph models** (compiled at startup from
   the app's `resources/graph` folder — the same ids callable at `POST /api/graph/{graph-id}`).
-  A session draft is **not** addressable — export and deploy it first. A missing id fails the
-  node fast at run time.
+  A session draft is **not** addressable — export and deploy it first. Missing targets are
+  **asymmetric**: a missing `flow://{flow-id}` aborts the run *before* any call is made
+  (`node {n} -  flow://x does not exist` — double space after the dash, both engines; the
+  `exception=` route cannot catch it), while a missing `{graph-id}` surfaces as the
+  delegate's `404` reply — catchable by the node's `exception=` route, where the handler
+  sees `error.code=404` and, in `error.message`, the delegate's whole error object
+  (`{message: "{id} not found", status: 404, type: "error"}` — the plain text is at
+  `error.message.message`, not `error.message` itself).
 - Each `input[]` **target** is a bare key that becomes the sub-graph's `input.body.{key}` (e.g.
   `input[]=input.body.person_id -> person_id` feeds the sub-graph's `input.body.person_id`).
   There is **no whole-body `*` target** on `graph.extension` — map named keys (the `*` merge idiom

--- a/docs/guides/knowledge-graph/workflow-suspension.md
+++ b/docs/guides/knowledge-graph/workflow-suspension.md
@@ -58,7 +58,8 @@ the application, and any application instance can pick it up when the reply arri
 The reply — the batch completion, the manager's approval, the user's email — may take
 minutes, hours or days. Parking a live graph instance for that long would
 pin memory, defeat timeouts, and not survive a restart. Suspension inverts the problem:
-the run **ends** — the caller gets a `{"type": "suspended", "cid": ...}` reply — and the
+the run **ends** — the caller gets a `{"type": "suspended", "cid": ...}` reply (HTTP `200`:
+the run completed normally by suspending) — and the
 workflow's durable memory (the `model` namespace) waits in the state store under the
 business correlation ID with a time-to-live you choose. The resumed run is an ordinary
 graph execution that happens to start with restored state. Because the record key is the
@@ -365,8 +366,10 @@ curl -s -X POST http://127.0.0.1:8085/api/graph/tutorial-14 \
   subgraph and resume in another. A delegated subgraph inherits the parent's business
   correlation ID and is fully resumable on its own; the parent orchestrates —
   see [the orchestrator pattern](#orchestrator-pattern).
-- Reserved model keys (`model.cid`, `model.instance`, `model.flow`, `model.ttl`,
-  `model.trace`, `model.run`) are never persisted — the resumed run's own identity is
+- The nine reserved model-metadata keys (`model.cid`, `model.instance`, `model.flow`,
+  `model.ttl`, `model.trace`, `model.parent`, `model.root`, `model.none`, `model.run` — the
+  full set in the [skills reference](skills-reference.md)) are never persisted — the resumed
+  run's own identity is
   authoritative. `model.run` is part of the read-only flow metadata family: `graph.resume`
   is its only writer, and the flow compiler rejects any data mapping that targets it
   (like the other reserved keys).
@@ -431,7 +434,7 @@ anything else plugs in the same way.
 ```
 
 Store the body **opaquely** (the reference implementations use MsgPack — binary values
-round-trip; note the platform's [serialization gotchas](../api-overview.md))
+round-trip; note the platform's [serialization rules](../event-envelope-reference.md#serialization))
 and reply 2xx only when the record is durable — the reply is the acknowledgement
 `graph.suspend` requires before the graph completes; any error fails the suspension.
 
@@ -462,7 +465,8 @@ independently under a shared business correlation ID. The consume strategy is
 `GET`+`DEL` transaction on older servers — detected once per connection from
 `INFO server` and stated in the startup log, since enterprise deployments rarely control
 their managed Redis version (and the community Windows binary used by `redis-standalone`
-is 5.0.14). Include the jar and the two functions register automatically; the connection
+is 5.0.14). Add the crate (`mercury-minigraph-state-redis = "4.12"` — the two functions
+register automatically at link time); the connection
 is lazy, so the application boots normally without Redis until a workflow actually
 suspends. Configuration uses the same
 `redis.*` keys as the sync-over-async extension (`redis.host`, `redis.port`,

--- a/docs/guides/rest-automation.md
+++ b/docs/guides/rest-automation.md
@@ -171,6 +171,17 @@ sent to this route (with the endpoint's timeout). The contract:
     Only the simple form — one route for the endpoint — is ported. The Java routing specs
     (`'default: svc'`, `'header: svc'`, `'header: value: svc'`) are not yet available.
 
+#### `stream`
+
+| Type | Default |
+|---|---|
+| boolean | `false` |
+
+`stream: true` enables progressive response streaming for the endpoint — the reply rides a
+dedicated ordered reply lane from a bounded pool, rendered as SSE for `text/event-stream`
+callers and chunked JSON/text otherwise (pool exhaustion answers HTTP 503). See
+[HTTP Response Streaming](http-streaming.md).
+
 #### `tracing`
 
 | Type | Default |
@@ -348,8 +359,10 @@ anything else, or no content type
 !!! note "Rust port"
     The XML-to-map parse is deferred with the rest of the XML surface (the Java
     `SimpleXmlParser`/writer pair is not ported) — XML bodies pass through as raw text on both
-    the server and the HTTP-client side. Request/response **streaming** is also deferred:
-    bodies are aggregated, matching Java's fixed-length path. The Java `custom.content.types`
+    the server and the HTTP-client side. Request-body **streaming** is deferred (upload bodies
+    are aggregated, matching Java's fixed-length path), but **response streaming shipped**:
+    declare `stream: true` on the endpoint — see
+    [HTTP Response Streaming](http-streaming.md). The Java `custom.content.types`
     mapping feature is not ported.
 
 ## The response

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -38,7 +38,10 @@ These are self-contained; you should not need the engine source or the tutorial 
 - [Workflow suspension](guides/knowledge-graph/workflow-suspension.md) — express a long-running
   process as a sequence of short graph runs: suspend while waiting on a person or another system,
   persist state to a pluggable store, resume with the same business correlation id without
-  re-executing completed steps.
+  re-executing completed steps. Deployment gating itself is documented in
+  [Build your first graph](guides/knowledge-graph/build-your-first-graph.md): a graph is
+  executable at `POST /api/graph/{graph-id}` only when manifest-listed AND passing
+  CompileGraph — compiled-or-404.
 - [Built-in skills reference](guides/knowledge-graph/skills-reference.md) — per-skill properties and
   examples.
 
@@ -57,11 +60,13 @@ unchanged; only the functions are written differently (Rust):
 - [Flow AI agent guide](guides/event-script/ai-agent-guide.md) — authoring flows deterministically:
   compile contract, pre-write checklist, recipe, worked examples.
 - [Flow grammar](guides/event-script/flow-grammar.md) — the rules: flow structure, task fields, the
-  eight execution types, the data-mapping mini-language.
+  eight execution types incl. `decision` branching (true/false or 1-based numeric), the exception
+  context (`error.task/.code/.message`), the data-mapping mini-language.
 - [`event-script-flow.json`](guides/event-script/event-script-flow.json) — the machine-readable flow
   schema; ingest and validate against it.
 - [Flow Schema Reference](guides/flow-schema-reference.md) — the field-level reference: every
-  field the flow compiler accepts and the validation it applies at startup.
+  field the flow compiler accepts and the validation it applies at startup, incl. the sub-flow
+  `ttl` deadline override (a catchable child timeout).
 - [Event Script Syntax](guides/event-script/syntax.md) — the full reference with worked examples:
   data-mapping catalog (constants, arrays, JSONPath, runtime model variables), all task types,
   pipelines/loops, Simple Plugins (`f:` functions), exception handling, external state machine.
@@ -110,7 +115,14 @@ repo's own source, so it answers the question without opening `crates/`.
   declarations (the Java list carries names from subsystems this port does not have).
 - [Configuration reference](guides/configuration-reference.md) — every key the port actually reads,
   with type, default and the crate reading it; `resources/application.yml`, the `classpath:/` and
-  `file:/` prefixes, `${ENV_VAR:default}` substitution.
+  `file:/` prefixes, `${ENV_VAR:default}` substitution, and override precedence (`-Dkey=value`
+  runtime arguments win over any configuration-file value; files merge in manifest order).
+- [claims-registry.json](guides/claims-registry.json) — the machine-readable registry of
+  **CI-pinned documentation behavior claims**: each entry names its normative sentence, its pages,
+  and the engine test that pins the behavior; an agent may treat these claims as source-verified.
+- [Observability](guides/observability.md) — tracing and telemetry, incl. the trace-context
+  lifecycle: the context is task-local, torn down when the function returns, and work you
+  `tokio::spawn` from inside a function does not inherit it.
 - [Actuators & HTTP client](guides/actuators-and-http-client.md) — the built-in health and
   introspection endpoints, and the async outbound HTTP client; both without extra wiring.
 - [Event over HTTP](guides/event-over-http.md) — call a function in another instance over the same

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -85,16 +85,16 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   spec (map, don't mirror).
   <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-08-30 | uses: 104 | tier: core | origin: 2026-07-15-215538.md -->
 
-- **The claims-fixture gate drift-tests documentation BEHAVIOR claims (lock-step twin of the
-  Java repo's ADR-0023).** `docs/guides/claims-registry.json` registers high-value prose claims —
+- **The claims-fixture gate drift-tests documentation BEHAVIOR claims (ADR-0018, accepted
+  2026-09-06 — lock-step twin of the Java repo's ADR-0023).** `docs/guides/claims-registry.json`
+  registers high-value prose claims —
   a claim states exactly what its named engine test pins, never more; `scripts/check-doc-claims.py`
   verifies the normative sentence still appears on its page AND the test pin still exists as a fn
   DEFINITION (test ref `crates/<crate-dir>::<test-file-stem>::<fn>`; rglob fallback resolves
   src-embedded `#[cfg(test)]` pins); the pinned tests run in `cargo test --workspace`. Wired into
   BOTH docs.yml and rust.yml — a test rename does not trigger docs.yml's path filter. The registry
   is a grammar asset (packaged contract + llms.txt; agents may treat registered claims as
-  source-verified). New claims enter via the field feedback circuit. Rust ADR-0018 drafted for the
-  ledger, gated on Eric's approval (add the `(ADR-0018)` tag here when it lands).
+  source-verified). New claims enter via the field feedback circuit.
   <!-- id: claims-fixture-gate | created: 2026-09-06 | last_used: 2026-09-06 | uses: 1 | tier: working | origin: 2026-09-07-052947.md -->
 
 - **Playground session broker: an AI agent can HOST a Playground session (2026-09-03, Eric's

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -85,6 +85,18 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
   spec (map, don't mirror).
   <!-- id: port-bottom-up-faithful | created: 2026-07-15 | last_used: 2026-08-30 | uses: 104 | tier: core | origin: 2026-07-15-215538.md -->
 
+- **The claims-fixture gate drift-tests documentation BEHAVIOR claims (lock-step twin of the
+  Java repo's ADR-0023).** `docs/guides/claims-registry.json` registers high-value prose claims —
+  a claim states exactly what its named engine test pins, never more; `scripts/check-doc-claims.py`
+  verifies the normative sentence still appears on its page AND the test pin still exists as a fn
+  DEFINITION (test ref `crates/<crate-dir>::<test-file-stem>::<fn>`; rglob fallback resolves
+  src-embedded `#[cfg(test)]` pins); the pinned tests run in `cargo test --workspace`. Wired into
+  BOTH docs.yml and rust.yml — a test rename does not trigger docs.yml's path filter. The registry
+  is a grammar asset (packaged contract + llms.txt; agents may treat registered claims as
+  source-verified). New claims enter via the field feedback circuit. Rust ADR-0018 drafted for the
+  ledger, gated on Eric's approval (add the `(ADR-0018)` tag here when it lands).
+  <!-- id: claims-fixture-gate | created: 2026-09-06 | last_used: 2026-09-06 | uses: 1 | tier: working | origin: 2026-09-07-052947.md -->
+
 - **Playground session broker: an AI agent can HOST a Playground session (2026-09-03, Eric's
   design, contributed from ai-enabled-repo-demo).**
   `examples/minigraph-playground/scripts/playground-session-broker.mjs` (zero-dependency,

--- a/memory/open-threads/thread-ot-rust-docs-sibling-sweep.md
+++ b/memory/open-threads/thread-ot-rust-docs-sibling-sweep.md
@@ -11,4 +11,7 @@
   method when unblocked: re-verify each Java fix class against the RUST engine (never assume
   parity), skip Kafka items (no Kafka modules here), coordinates become crates.io
   `cargo add` lines. Trigger: Eric's go, after the Java round's learnings are folded in.
+  **EXECUTED 2026-09-07** on branch `feat/claims-fixture-gate` (sweep + the claims-fixture
+  gate's Rust twin, 20 claims, two adversarial verify rounds applied — full narrative:
+  `2026-09-07-052947.md`). PR pending; mark `[x]` with the close record on merge.
   <!-- id: ot-rust-docs-sibling-sweep | created: 2026-09-06 | last_used: 2026-09-06 | uses: 1 | tier: working | origin: 2026-09-07-014642 -->

--- a/memory/sessions/2026-09-07-052947.md
+++ b/memory/sessions/2026-09-07-052947.md
@@ -1,0 +1,59 @@
+# Session (2026-09-07T05:29:47.000Z)
+
+**Agent:** Claude Code
+
+Executed the Rust sibling sweep ([[ot-rust-docs-sibling-sweep]]) — unblocked by Eric
+("proceed with the Rust sibling sweep") after the Java round's learnings landed there as
+the claims-fixture gate (Java ADR-0023). One branch, `feat/claims-fixture-gate`,
+delivers both the sweep and the gate's Rust twin.
+
+**The sweep (map, don't mirror):** every Java coverage-study fix class was re-verified
+against THIS engine before editing; genuine divergences were honored, not papered over.
+Fixes landed on 14 guide pages + llms.txt: `error.code` (never `error.status`) across
+syntax.md / flow-grammar.md / flow-schema-reference.md (the stale "Java reference uses
+error.status" divergence-note premise rewritten — both engines expose `error.code`; the
+surviving divergence is no-stack-ever); full decision semantics (non-numeric coerces to
+branch 1 silently — `str2int().max(1)`, executor.rs:1097 — missing aborts); `stream:
+true` documented in rest-automation.md (the "response streaming shipped" port-note
+rewrite) and http-streaming.md's corrected `use platform_core::{...}` line; crates.io
+"Use from crates.io" section in getting-started.md; nine reserved model keys + suspended
+HTTP-200 + the `mercury-minigraph-state-redis` crate line in workflow-suspension.md;
+export/orphan honesty (export does NOT reject orphans — and per the verify round, the
+CompileGraph gate does not check connectivity either; invariant 4 remarked as an
+authoring convention); `graph.extension` missing-target asymmetry (flow:// aborts
+pre-call, uncatchable; missing graph-id → delegate's 404, catchable, with the delegate's
+WRAPPED error object in `error.message` — plain text at `error.message.message`).
+
+**The gate (lock-step twin of Java ADR-0023):** `docs/guides/claims-registry.json` — 20
+claims, each stating exactly what its named test pins; `scripts/check-doc-claims.py`
+(quote containment + fn-DEFINITION regex, block-comment-stripped, pub(crate)-aware,
+graceful malformed-registry diagnostics); wired into BOTH docs.yml and rust.yml (test
+renames don't trigger docs.yml paths). Registry packaged in the contract (files.list +
+contracts.yaml references incl. http-streaming.md) and mapped in llms.txt. New pins:
+event-script/tests/claims.rs (decision coercion; flows default classpath:/flows/) and
+knowledge-graph/tests/claims.rs (extension asymmetry). Pin upgrades from the adversarial
+round: exact nine-name set assert in common.rs's reserved_model_metadata_is_immutable;
+untraced annotate_trace/update_context no-op coverage in telemetry.rs; env_instances
+fallback-to-literal fixture in annotations.rs. Claims fixtures inside the verbatim
+Java-mirror flows/ folder got a README carve-out (forced there by the location-default
+claim; re-syncs must preserve them).
+
+**Verification:** two-agent adversarial R3 (docs refuter + gate refuter, live probes)
+returned 14 findings — 2 material (cargo fmt failure on the new test; the error.message
+shape over-claim), 12 minor (six claims bundling behavior beyond their pin → narrowed or
+pin-upgraded; checker robustness; a byte-wrong quoted engine message — double space;
+llms.txt blurb promising content its page lacks; fixture-placement README gap). All
+applied. Eric caught one more live: Ruff FURB167 (`re.M` → `re.MULTILINE`) in the
+checker. Final state: check-doc-claims.py OK (20 claims), check-llms-links.py OK (33
+refs), cargo fmt/clippy/test all green (both new claims binaries + contract packaging +
+regression suites + the three upgraded pin suites). Increment 105 recorded. ADR-0018
+(the ADR-0023 twin) DRAFTED and held for Eric's gate — enters the ledger + tags the
+[[claims-fixture-gate]] fact on his approval, like the Java precedent.
+
+Durable lesson (echoing the Java round): a guard's first legitimate exercise is a test
+of the guard — six of this round's own claims over-stated their pins until the
+adversarial pass forced the narrow-or-upgrade discipline the registry contract encodes.
+
+## Memory References
+- ot-rust-docs-sibling-sweep — executed (thread updated; close on merge)
+- claims-fixture-gate — created (tier: working)

--- a/memory/sessions/2026-09-07-052947.md
+++ b/memory/sessions/2026-09-07-052947.md
@@ -46,9 +46,10 @@ llms.txt blurb promising content its page lacks; fixture-placement README gap). 
 applied. Eric caught one more live: Ruff FURB167 (`re.M` → `re.MULTILINE`) in the
 checker. Final state: check-doc-claims.py OK (20 claims), check-llms-links.py OK (33
 refs), cargo fmt/clippy/test all green (both new claims binaries + contract packaging +
-regression suites + the three upgraded pin suites). Increment 105 recorded. ADR-0018
-(the ADR-0023 twin) DRAFTED and held for Eric's gate — enters the ledger + tags the
-[[claims-fixture-gate]] fact on his approval, like the Java precedent.
+regression suites + the three upgraded pin suites). Increment 105 recorded. Shipped as
+PR #238; CI passed first run (build, test 2m26s, memory guards). ADR-0018 (the ADR-0023
+twin) ACCEPTED by Eric after CI passed — entered the ledger in the same PR and tagged
+the [[claims-fixture-gate]] fact, exactly the Java precedent.
 
 Durable lesson (echoing the Java round): a guard's first legitimate exercise is a test
 of the guard — six of this round's own claims over-stated their pins until the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ not_in_nav: |
   llms.txt
   guides/knowledge-graph/minigraph-commands.json
   guides/event-script/event-script-flow.json
+  guides/claims-registry.json
 
 validation:
   nav:

--- a/scripts/check-doc-claims.py
+++ b/scripts/check-doc-claims.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Claims-fixture gate for documentation BEHAVIOR claims (the Rust edition of the
+mechanism the Java engine ships as check 8 of its doc-canon script; see the Java repo's
+ADR-0023 and this repo's docs/guides/claims-registry.json).
+
+Every registry entry pins a high-value prose claim on both sides:
+  - the claim's normative sentence (`quote`) must still appear on one of its `pages`
+    (whitespace-normalized, case-insensitive containment — removal or rewording fails,
+    re-casing passes);
+  - the claim's engine test pin (`test`: crates/<crate-dir>::<test-file-stem>::<fn>)
+    must still exist as a function DEFINITION in that crate's test tree (a renamed or
+    deleted pin cannot silently orphan a claim). The pinned tests themselves run in the
+    normal `cargo test --workspace` build.
+
+Rationale: the AI grammar coverage study found all documentation drift in ungated prose —
+this gate extends drift testing from shape to behavior.
+
+Exit 0 = clean; exit 1 = drift (with details). Run from anywhere:
+    python3 scripts/check-doc-claims.py [--root PATH]
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REGISTRY_REL = "docs/guides/claims-registry.json"
+
+
+def norm(s: str) -> str:
+    return re.sub(r"\s+", " ", s).strip().lower()
+
+
+def rel(p: Path, root: Path) -> str:
+    try:
+        return str(p.relative_to(root))
+    except ValueError:
+        return str(p)
+
+
+def read_text(p: Path) -> str | None:
+    try:
+        return p.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=str(Path(__file__).resolve().parent.parent),
+                    help="repo root (default: parent of scripts/)")
+    args = ap.parse_args()
+    root = Path(args.root)
+    registry = root / REGISTRY_REL
+    errors: list[str] = []
+
+    if not registry.exists():
+        print(f"claims registry not found at {REGISTRY_REL}; nothing to check.")
+        return 0
+
+    try:
+        claims = json.loads(registry.read_text(encoding="utf-8")).get("claims", [])
+    except json.JSONDecodeError as e:
+        print(f"[claims] registry is not valid JSON: {e}")
+        return 1
+
+    for c in claims:
+        if not isinstance(c, dict):
+            errors.append(f"non-object entry in claims list: {str(c)[:60]}")
+            continue
+        cid = c.get("id", "?")
+        pages_raw = c.get("pages", [])
+        if not isinstance(pages_raw, list) or not all(
+                isinstance(p, str) for p in pages_raw):
+            errors.append(f"{cid}: 'pages' must be a list of path strings")
+            continue
+        page_texts: list[str] = []
+        for p in (root / page for page in pages_raw):
+            if not p.is_file():
+                errors.append(f"{cid}: page not found: {rel(p, root)}")
+                continue
+            text = read_text(p)
+            if text is None:
+                errors.append(f"{cid}: page not readable: {rel(p, root)}")
+            else:
+                page_texts.append(text)
+        quote = norm(c.get("quote", "") or "")
+        if not quote:
+            errors.append(f"{cid}: empty quote")
+        elif not any(quote in norm(t) for t in page_texts):
+            errors.append(f"{cid}: pinned sentence not found on any of its pages: "
+                          f"\"{c.get('quote', '')[:80]}\"")
+        test = c.get("test", "") or ""
+        if test:
+            ref = re.fullmatch(r"([\w./-]+)::([\w-]+)::(\w+)", test)
+            if not ref:
+                errors.append(f"{cid}: malformed test ref "
+                              f"(want crates/<crate>::<test-file-stem>::<fn>): {test}")
+                continue
+            crate_dir, stem, fn = ref.groups()
+            crate = root / crate_dir
+            candidates = [crate / "tests" / f"{stem}.rs"]
+            if not candidates[0].is_file() and crate.exists():
+                candidates = list(crate.rglob(f"{stem}.rs"))
+            # match a fn DEFINITION (any visibility, incl. pub(crate)), not a
+            # call site or comment; /* */ blocks are stripped first so a
+            # commented-out pin cannot keep a claim green
+            def_rx = re.compile(
+                rf"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+{re.escape(fn)}\s*[(<]",
+                re.MULTILINE)
+            sources = [read_text(p) for p in candidates if p.is_file()]
+            sources = [re.sub(r"/\*.*?\*/", "", s, flags=re.DOTALL)
+                       for s in sources if s is not None]
+            if not sources:
+                errors.append(f"{cid}: test file not found: {test}")
+            elif not any(def_rx.search(s) for s in sources):
+                errors.append(f"{cid}: test fn '{fn}' not defined in {stem}.rs")
+
+    if errors:
+        print("Documentation behavior-claim drift detected:\n")
+        for e in errors:
+            print("  - " + e)
+        print(f"\n{len(errors)} issue(s). See docs/guides/claims-registry.json.")
+        return 1
+    print(f"docs/guides/claims-registry.json: OK ({len(claims)} claims pinned on both sides).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/system/ai-contract-provider/resources/contracts.yaml
+++ b/system/ai-contract-provider/resources/contracts.yaml
@@ -32,6 +32,7 @@ contracts:
       - 'platform_core::automation::routing::RoutingTable'
     references:
       - 'references/guides/rest-automation.md'
+      - 'references/guides/http-streaming.md'
 
   - id: 'event-script'
     module: 'event-script'

--- a/system/ai-contract-provider/resources/skill/files.list
+++ b/system/ai-contract-provider/resources/skill/files.list
@@ -4,6 +4,7 @@ references/background/port-scope.md
 references/guides/actuators-and-http-client.md
 references/guides/api-overview.md
 references/guides/architecture.md
+references/guides/claims-registry.json
 references/guides/configuration-reference.md
 references/guides/event-driven/ai-agent-guide.md
 references/guides/event-driven/function-execution.md


### PR DESCRIPTION
## What

- **Claims-fixture gate, Rust twin of the Java repo's ADR-0023:** `docs/guides/claims-registry.json`
  registers 20 CI-pinned documentation behavior claims; `scripts/check-doc-claims.py` verifies each
  claim's normative sentence still appears on its page AND its engine test pin still exists as a fn
  definition. Runs in BOTH `docs.yml` and `rust.yml` (a test rename doesn't trigger the docs
  workflow's path filter). The registry ships in the packaged contract and `llms.txt` — agents may
  treat registered claims as source-verified.
- **New pinning tests:** `event-script/tests/claims.rs` (non-numeric decision coerces to branch 1;
  manifest without `location` loads from `classpath:/flows/`) and `knowledge-graph/tests/claims.rs`
  (`graph.extension` missing-target asymmetry). **Pin upgrades:** exact nine-name reserved-metadata
  set; untraced `annotate_trace`/`update_context` no-ops; `env_instances` fallback-to-literal.
- **Sibling sweep** of the Java coverage-study findings across 14 guide pages + `llms.txt`, each item
  re-verified against THIS engine first: `error.code` (never `error.status`) + the rewritten
  divergence note; full decision semantics; `stream: true`; crates.io usage sections; nine reserved
  keys; suspend's HTTP-200; export/orphan honesty (neither export nor the CompileGraph gate checks
  connectivity); the extension asymmetry with the delegate's wrapped error-object shape.

## Why

The Java engine's AI-grammar coverage study found all documentation drift in ungated prose while
gated surfaces held — and this port reproduced the pattern (same `error.status` drift, a stale
divergence note, an over-claimed export invariant). The claims fixture extends drift-testing from
shape to behavior at the sentence granularity agents act on. Two adversarial verify rounds ran
before commit; all 14 surviving findings were applied — including six of this round's own claims
that over-stated their pins, fixed by the narrow-or-upgrade discipline the registry contract
encodes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>