### PR TITLE
docs/deck-benchmark-study (c769157a, aa9e6446 + logs), title Deck slide 13 + paper benchmark: measured on both engines (Java sync); claims checker on Python 3.9

### DIFF
--- a/docs/mercury-story.md
+++ b/docs/mercury-story.md
@@ -648,11 +648,21 @@ An AI partner can navigate from a compact discovery map to authoritative guidanc
 repeatedly reading an entire dependency's source. Context consumption can follow the task instead
 of the full dependency tree.
 
-The effect is measurable. On this repository's documentation map (measured 2026-09-04, v4.12.3),
-a roughly 2,500-token discovery map routes an agent to about 46,000 tokens of source-verified
-reference, replacing a hunt through roughly 515,000 tokens of engine source. Completeness that
-costs discovery is a regression: the map must stay small, dense with the exact terms an agent
-searches for, and gated so it cannot silently rot.
+The effect is measured — on both engines. On this repository's documentation map (2026-09-04,
+v4.12.3), a roughly 2,500-token discovery map routes an agent to about 46,000 tokens of
+source-verified reference, replacing a hunt through roughly 515,000 tokens of engine source. An
+empirical study then ran 46 agents through 24 use cases against the Java engine's grammar
+(2026-09-06): 17 of 17 docs-only builds were viable and none wrong — every edge-case gotcha
+trial came out correct; none of the 24 discovery routes was missing (19 obvious in one hop; the
+five ambiguous ones were map-annotation gaps, since annotated); and the median task consumed
+45,800 documentation tokens against a roughly 542,000-token source-corpus ceiling — 8.4 percent.
+
+The study's sharpest finding held here too: every drifted sentence lived in ungated prose, while
+generated and gated surfaces held — this repository's sibling sweep reproduced the same drift
+classes on its own pages before fixing them. Both engines now drift-test their documentation
+behavior claims in CI — 31 claims pinned to engine tests at this writing (20 here, 11 Java).
+Completeness that costs discovery is a regression: the map must stay small, dense with the exact
+terms an agent searches for, and gated so it cannot silently rot.
 
 ### Human-AI Co-Authorship
 

--- a/docs/presentations/mercury-story.html
+++ b/docs/presentations/mercury-story.html
@@ -385,17 +385,24 @@
 
   <!-- 9 · the benchmark -->
   <section class="slide" aria-label="The benchmark">
-    <p class="eyebrow">The benchmark</p>
+    <p class="eyebrow">The benchmark — measured, both engines</p>
     <h2>Doc discovery and token efficiency</h2>
-    <p class="lede">A grammar is useful only if the agent finds the right page in one hop and the
-    map stays cheap. Measured on the Rust engine, 2026-09-04:</p>
+    <p class="lede">A grammar is useful only if the agent finds the right page in one hop, the docs
+    suffice without opening source, and the map stays cheap. This engine's map benchmark
+    (2026-09-04) and an empirical study — 46 agents running 24 use cases against the Java engine's
+    grammar (2026-09-06) — measured exactly that:</p>
     <div class="stats">
-      <div class="stat"><div class="n">~2,500</div><div class="l">tokens — the whole discovery map</div></div>
-      <div class="stat"><div class="n">~46,000</div><div class="l">tokens of source-verified reference it routes to, one hop away</div></div>
-      <div class="stat dim"><div class="n">~515,000</div><div class="l">tokens of engine source — the hunt the map replaces</div></div>
+      <div class="stat"><div class="n">17/17</div><div class="l">docs-only builds viable in the Java study, zero wrong — every edge-case gotcha trial came out correct</div></div>
+      <div class="stat"><div class="n">0/24</div><div class="l">discovery routes missing — 19 obvious in one hop; the 5 ambiguous were map-annotation gaps, since annotated</div></div>
+      <div class="stat"><div class="n">8.4%</div><div class="l">median docs cost against the ~542,000-token source-corpus ceiling — 45,800 tokens for a typical task</div></div>
+      <div class="stat"><div class="n">31</div><div class="l">documentation behavior claims now CI-pinned across both engines (20 here + 11 Java) — the gate the study produced</div></div>
     </div>
-    <p class="muted">Completeness that costs discovery is a regression. The map is dense with the
-    exact tokens an agent searches for — and gated in CI so it cannot silently rot.</p>
+    <p class="muted">The sharpest finding: every drifted sentence lived in ungated prose — generated
+    and gated surfaces held. This engine shows the same economics (its ~2,500-token curated map
+    routes to ~46,000 tokens of source-verified reference instead of ~515,000 of <code>crates/</code>,
+    2026-09-04), and this repo's sibling sweep reproduced the drift classes on its own pages before
+    fixing them — both engines now drift-test behavior claims in CI (ADR-0018 ⇄ the Java engine's
+    ADR-0023). Completeness that costs discovery is a regression.</p>
   </section>
 
   <!-- 10 · the proof -->

--- a/memory/sessions/2026-09-07-144334.md
+++ b/memory/sessions/2026-09-07-144334.md
@@ -1,0 +1,14 @@
+# Session (2026-09-07T14:43:34.000Z)
+
+**Agent:** (auto-stub — replace with your agent name and enrich)
+**Lightweight:** auto-captured by the post-commit hook; summary pending.
+
+Commit `c769157a` — docs: deck slide 13 - the benchmark measured on both engines (Java sync)
+
+```
+ docs/presentations/mercury-story.html | 23 +++++++++++++++--------
+ 1 file changed, 15 insertions(+), 8 deletions(-)
+```
+
+## Memory References
+(none — auto-stub; enrich per memory/PROTOCOL.md "Close every session", or leave as a lite log)

--- a/memory/sessions/2026-09-07-144334.md
+++ b/memory/sessions/2026-09-07-144334.md
@@ -1,7 +1,15 @@
 # Session (2026-09-07T14:43:34.000Z)
 
-**Agent:** (auto-stub — replace with your agent name and enrich)
-**Lightweight:** auto-captured by the post-commit hook; summary pending.
+**Agent:** Claude Code
+**Lightweight:** Deck slide 13 ("Doc discovery and token efficiency") updated in lock-step
+with the Java engine, per Eric's direction: the Java coverage study's headline numbers
+(17/17 docs-only builds viable / 0 wrong; 0/24 discovery routes missing; 8.4% median docs
+cost vs the ~542k-token source-corpus ceiling) join this engine's own map benchmark, with
+the 31-claim cross-engine gate (20 here + 11 Java, ADR-0018 ⇄ ADR-0023) and the
+ungated-prose finding; this edition keeps the local map economics and the sibling-sweep
+reproduction in the muted line (port-attribution idiom — the study ran on the Java
+engine, said so plainly). Numbers drawn from the committed Java study report and the live
+registries. Branch `docs/deck-benchmark-study`, PR pending Eric's gate.
 
 Commit `c769157a` — docs: deck slide 13 - the benchmark measured on both engines (Java sync)
 
@@ -11,4 +19,4 @@ Commit `c769157a` — docs: deck slide 13 - the benchmark measured on both engin
 ```
 
 ## Memory References
-(none — auto-stub; enrich per memory/PROTOCOL.md "Close every session", or leave as a lite log)
+(none)

--- a/memory/sessions/2026-09-07-144334.md
+++ b/memory/sessions/2026-09-07-144334.md
@@ -11,6 +11,12 @@ reproduction in the muted line (port-attribution idiom — the study ran on the 
 engine, said so plainly). Numbers drawn from the committed Java study report and the live
 registries. Branch `docs/deck-benchmark-study`, PR pending Eric's gate.
 
+**Same PR, Eric's follow-up:** the paper's §11 "Sustainable Context Economics" benchmark
+paragraph extended with the same study evidence (lock-step with the Java edition; sibling
+sweep named in the finding paragraph). Running the gate locally also surfaced a real
+portability bug in `scripts/check-doc-claims.py`: the `str | None` union annotation
+crashes on macOS system Python 3.9 — fixed to `Optional[str]` and verified on 3.9.6.
+
 Commit `c769157a` — docs: deck slide 13 - the benchmark measured on both engines (Java sync)
 
 ```

--- a/scripts/check-doc-claims.py
+++ b/scripts/check-doc-claims.py
@@ -23,6 +23,7 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import Optional
 
 REGISTRY_REL = "docs/guides/claims-registry.json"
 
@@ -38,7 +39,9 @@ def rel(p: Path, root: Path) -> str:
         return str(p)
 
 
-def read_text(p: Path) -> str | None:
+# Optional[str], not `str | None`: the annotation is evaluated at def time and
+# must import on Python 3.9 (macOS system python3), not only on CI's 3.10+.
+def read_text(p: Path) -> Optional[str]:
     try:
         return p.read_text(encoding="utf-8")
     except OSError:


### PR DESCRIPTION
## What
- Deck slide 13 pairs this engine's map benchmark with the Java engine's empirical coverage
  study (17/17 viable / 0 wrong, 0/24 routes missing, 8.4% median docs cost, 31 CI-pinned
  claims — 20 here + 11 Java), keeping the local economics and sibling-sweep reproduction in
  the footnote line.
- The paper's §11 benchmark paragraph carries the same evidence, lock-step with the Java edition.
- scripts/check-doc-claims.py: `str | None` → `Optional[str]` — the union annotation crashed on
  macOS system Python 3.9; verified on 3.9.6 and CI's Python.

## Why
Lock-step twin of the Java update: the coverage study (mercury-composable PR #326) and this
repo's sibling sweep (PR #238) made the benchmark claim measurable on both engines. The checker
fix keeps the gate runnable on a stock Mac, not only in CI.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>