### PR TITLE
Docs/deck crossref swap

### DIFF
--- a/docs/mercury-story.md
+++ b/docs/mercury-story.md
@@ -656,6 +656,9 @@ empirical study then ran 46 agents through 24 use cases against the Java engine'
 trial came out correct; none of the 24 discovery routes was missing (19 obvious in one hop; the
 five ambiguous ones were map-annotation gaps, since annotated); and the median task consumed
 45,800 documentation tokens against a roughly 542,000-token source-corpus ceiling — 8.4 percent.
+The economics mirror this repository's map: the Java engine's exhaustive llms.txt is itself only
+about 4,000 tokens, so on both engines a few thousand tokens of map route each task to a few tens
+of thousands of documentation tokens instead of half a million of source.
 
 The study's sharpest finding held here too: every drifted sentence lived in ungated prose, while
 generated and gated surfaces held — this repository's sibling sweep reproduced the same drift

--- a/docs/presentations/mercury-story.html
+++ b/docs/presentations/mercury-story.html
@@ -388,9 +388,10 @@
     <p class="eyebrow">The benchmark — measured, both engines</p>
     <h2>Doc discovery and token efficiency</h2>
     <p class="lede">A grammar is useful only if the agent finds the right page in one hop, the docs
-    suffice without opening source, and the map stays cheap. This engine's map benchmark
-    (2026-09-04) and an empirical study — 46 agents running 24 use cases against the Java engine's
-    grammar (2026-09-06) — measured exactly that:</p>
+    suffice without opening source, and the map stays cheap. This engine's own benchmark
+    (2026-09-04: a ~2,500-token curated map routing to ~46,000 tokens of source-verified reference
+    instead of ~515,000 of <code>crates/</code>) and an empirical study — 46 agents running 24 use
+    cases against the Java engine's grammar (2026-09-06) — measured exactly that:</p>
     <div class="stats">
       <div class="stat"><div class="n">17/17</div><div class="l">docs-only builds viable in the Java study, zero wrong — every edge-case gotcha trial came out correct</div></div>
       <div class="stat"><div class="n">0/24</div><div class="l">discovery routes missing — 19 obvious in one hop; the 5 ambiguous were map-annotation gaps, since annotated</div></div>
@@ -398,11 +399,11 @@
       <div class="stat"><div class="n">31</div><div class="l">documentation behavior claims now CI-pinned across both engines (20 here + 11 Java) — the gate the study produced</div></div>
     </div>
     <p class="muted">The sharpest finding: every drifted sentence lived in ungated prose — generated
-    and gated surfaces held. This engine shows the same economics (its ~2,500-token curated map
-    routes to ~46,000 tokens of source-verified reference instead of ~515,000 of <code>crates/</code>,
-    2026-09-04), and this repo's sibling sweep reproduced the drift classes on its own pages before
-    fixing them — both engines now drift-test behavior claims in CI (ADR-0018 ⇄ the Java engine's
-    ADR-0023). Completeness that costs discovery is a regression.</p>
+    and gated surfaces held. The Java engine shows the same economics (its ~4,000-token exhaustive
+    map routes a median task to 45,800 tokens of documentation against ~542,000 of engine source —
+    the study's corpus inventory), and this repo's sibling sweep reproduced the drift classes on its
+    own pages before fixing them — both engines now drift-test behavior claims in CI (ADR-0018 ⇄ the
+    Java engine's ADR-0023). Completeness that costs discovery is a regression.</p>
   </section>
 
   <!-- 10 · the proof -->

--- a/memory/sessions/2026-09-07-144334.md
+++ b/memory/sessions/2026-09-07-144334.md
@@ -24,5 +24,13 @@ Commit `c769157a` — docs: deck slide 13 - the benchmark measured on both engin
  1 file changed, 15 insertions(+), 8 deletions(-)
 ```
 
+**Cross-reference touch-up (Eric, post-merge):** slide 13's muted line self-referenced
+this engine's own map trio; per Eric the cross-references should point each deck at the
+OTHER engine. This deck now carries its own benchmark in the first-person lede and
+cross-references the Java engine's economics in the muted line (~4,000-token exhaustive
+map, 45,800-token median task, ~542,000 source corpus — the study's inventory); the Java
+deck's muted line keeps the Rust pre-study benchmark, now labeled as such. Branch
+`docs/deck-crossref-swap`.
+
 ## Memory References
 (none)

--- a/memory/sessions/2026-09-07-144334.md
+++ b/memory/sessions/2026-09-07-144334.md
@@ -30,7 +30,10 @@ OTHER engine. This deck now carries its own benchmark in the first-person lede a
 cross-references the Java engine's economics in the muted line (~4,000-token exhaustive
 map, 45,800-token median task, ~542,000 source corpus — the study's inventory); the Java
 deck's muted line keeps the Rust pre-study benchmark, now labeled as such. Branch
-`docs/deck-crossref-swap`.
+`docs/deck-crossref-swap`. Eric's follow-up in the same PR: the Java map sentence mirrored
+into the paper's §11 first paragraph (the Java engine's ~4,000-token exhaustive llms.txt —
+on both engines a few thousand map tokens route each task to tens of thousands of doc
+tokens instead of half a million of source).
 
 ## Memory References
 (none)


### PR DESCRIPTION
## What
Slide 13 now carries this engine's own benchmark in the first-person lede (~2,500-token map →
~46,000 of reference vs ~515,000 of crates/), and the muted line cross-references the Java
engine's economics instead of repeating the local trio: its ~4,000-token exhaustive map,
45,800-token median task, ~542,000-token source corpus (the study's inventory).

- Paper §11: the Java map sentence mirrored — on both engines a few thousand map tokens route
  each task to tens of thousands of documentation tokens instead of half a million of source.

## Why
Both engines' slide 13 cited the same Rust pre-study statistic; each deck should
cross-reference the other engine's numbers. This is the Rust half of the swap.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>