### PR TITLE
Release/v4.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,44 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`draft-design-specs/`](draft-design-specs/).
 
 ---
+## Version 4.12.4, 9/8/2026
+
+### Added
+
+- The `eq` and `ne` simple plugins accept **optional `ignoreCase` / `ignoreType`
+  modifiers** in argument positions 3 and 4: `text(ignoreCase)` compares two strings
+  case-insensitively; `text(ignoreType)` compares the text forms of the two values,
+  allowing the relaxed comparison of numbers and booleans — `"123" == 123`,
+  `"123.456" == 123.456` and `"true" == true`; both together compare the text forms
+  case-insensitively. Lock-step with the Java engine, including error messages
+  (Increment 107).
+- **MiniGraph Playground UI overhaul** (webapp lock-step, Increment 106): an in-place
+  "magnified node" editor for creating and editing nodes (the pop-up dialogs are gone —
+  zero modals), console hide/restore, thumbnail/expanded node modes, an overlap-free
+  content-sized graph layout, Neo4j-style connection authoring (halo-ring drag or
+  click-to-connect, anchored relation popover), selectable edges with per-relation
+  right-click deletion planned as direction-correct compounds, frontend undo
+  (Ctrl/Cmd+Z and per-toast Undo via compensating console commands), and panel-aware
+  graph auto-fit. Verified live against this engine: the compounds and undo pacing ride
+  the engine-identical console messages unchanged.
+- **Claims-fixture gate** (ADR-0018, the Java ADR-0023 twin; Increment 105): 20
+  documentation behavior claims registered in `docs/guides/claims-registry.json`, each
+  pinned to a named engine test; `scripts/check-doc-claims.py` verifies sentence and pin
+  in both the docs and rust workflows. Landed with the sibling sweep of the AI-grammar
+  coverage-study findings, each item re-verified against this engine before editing.
+
+### Changed
+
+- **`eq` and `ne` compare exactly two values**, consistent with `gt`/`lt`. The previous
+  open-ended chained form (three or more plain values, all equal to the first) is
+  removed — a 3rd/4th argument must now be a modifier. Breaking only for flows that
+  used the chained form; the two-value form is unchanged.
+- Documentation: the white paper and deck are finalized as **the Mercury Story**
+  (`docs/mercury-story.md` + the self-contained HTML deck, retitled Intent-Driven
+  Development) with the cross-engine benchmark study — the deck owns this engine's
+  measurements first-person and cross-references the Java economics.
+
+---
 ## Version 4.12.3, 9/4/2026
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ai-contract-provider"
-version = "4.12.3"
+version = "4.12.4"
 dependencies = [
  "async-trait",
  "log",
@@ -114,7 +114,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.12.3"
+version = "4.12.4"
 dependencies = [
  "async-trait",
  "log",
@@ -454,7 +454,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.12.3"
+version = "4.12.4"
 dependencies = [
  "async-trait",
  "log",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.12.3"
+version = "4.12.4"
 dependencies = [
  "async-trait",
  "log",
@@ -756,7 +756,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mercury-event-script"
-version = "4.12.3"
+version = "4.12.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-event-script-macros"
-version = "4.12.3"
+version = "4.12.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-knowledge-graph"
-version = "4.12.3"
+version = "4.12.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-knowledge-graph-macros"
-version = "4.12.3"
+version = "4.12.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-minigraph-state-redis"
-version = "4.12.3"
+version = "4.12.4"
 dependencies = [
  "async-trait",
  "log",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-platform-core"
-version = "4.12.3"
+version = "4.12.4"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-platform-macros"
-version = "4.12.3"
+version = "4.12.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "minigraph-playground"
-version = "4.12.3"
+version = "4.12.4"
 dependencies = [
  "async-trait",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.12.3"
+version = "4.12.4"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury"

--- a/crates/event-script/Cargo.toml
+++ b/crates/event-script/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous"]
 name = "event_script"
 
 [dependencies]
-mercury-platform-core = { version = "4.12.3", path = "../platform-core" }
+mercury-platform-core = { version = "4.12.4", path = "../platform-core" }
 async-trait = "0.1"
 log = "0.4"
 # --- increment E-2: data-mapping engine ---
@@ -31,7 +31,7 @@ chrono = "0.4"
 # (the ZoneId.systemDefault() analog, same crate chrono uses internally)
 chrono-tz = "0.10"
 iana-time-zone = "0.1"
-mercury-event-script-macros = { version = "4.12.3", path = "../event-script-macros" }
+mercury-event-script-macros = { version = "4.12.4", path = "../event-script-macros" }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]

--- a/crates/knowledge-graph/Cargo.toml
+++ b/crates/knowledge-graph/Cargo.toml
@@ -16,12 +16,12 @@ exclude = ["webapp/"]
 name = "knowledge_graph"
 
 [dependencies]
-mercury-platform-core = { version = "4.12.3", path = "../platform-core" }
+mercury-platform-core = { version = "4.12.4", path = "../platform-core" }
 # layer 3 rides layer 2: the data-mapping mini-language (converter, rmpv
 # MultiLevelMap) is shared with event-script, and deployed graphs are
 # exposed through event-script flows
-mercury-event-script = { version = "4.12.3", path = "../event-script" }
-mercury-knowledge-graph-macros = { version = "4.12.3", path = "../knowledge-graph-macros" }
+mercury-event-script = { version = "4.12.4", path = "../event-script" }
+mercury-knowledge-graph-macros = { version = "4.12.4", path = "../knowledge-graph-macros" }
 async-trait = "0.1"
 log = "0.4"
 rmpv = { version = "1", features = ["with-serde"] }

--- a/crates/knowledge-graph/webapp/package-lock.json
+++ b/crates/knowledge-graph/webapp/package-lock.json
@@ -29,7 +29,7 @@
         "typescript": "^5.9.3",
         "vite": "^8.0.16",
         "vite-plugin-svgr": "^4.5.0",
-        "vitest": "^4.1.0"
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1200,16 +1200,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1218,13 +1218,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.10",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1255,9 +1255,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1268,13 +1268,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1282,14 +1282,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1298,9 +1298,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1308,13 +1308,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2176,9 +2176,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -3965,9 +3965,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4271,19 +4271,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4311,12 +4311,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/crates/knowledge-graph/webapp/package.json
+++ b/crates/knowledge-graph/webapp/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.9.3",
     "vite": "^8.0.16",
     "vite-plugin-svgr": "^4.5.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.11"
   }
 }

--- a/crates/platform-core/Cargo.toml
+++ b/crates/platform-core/Cargo.toml
@@ -42,7 +42,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["ring",
 rustls-native-certs = "0.8"
 # --- increment 10: annotation macros (Java @PreLoad/@BeforeApplication/@MainApplication) ---
 inventory = "0.3"
-mercury-platform-macros = { version = "4.12.3", path = "../platform-macros" }
+mercury-platform-macros = { version = "4.12.4", path = "../platform-macros" }
 # --- increment 71: ManagedCache (docs/design/managed-cache-port.md — the Caffeine-lineage
 # engine, wrapped; EvictionPolicy::lru per the maintainer's deterministic-eviction ruling) ---
 moka = { version = "0.12", features = ["sync"] }

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2727,3 +2727,34 @@ export/orphan honesty (neither export nor the CompileGraph gate checks connectiv
 the extension target asymmetry with the delegate's wrapped error object shape. Two
 adversarial verify rounds (engine-source refuters with live probes) ran before commit; every
 surviving finding — including three of this round's own over-claims — was applied.
+
+## Increment 106 — Playground webapp lock-step: the two UI arcs (2026-09-08)
+
+`crates/knowledge-graph/webapp/` replaced wholesale from the Java repo at its main
+`af9f5600` (Java PRs #330 + #331), carrying both Playground UI polishing arcs: the
+console hide/restore toggle, overlap-free content-sized node layout with measured
+relayout, thumbnail/expanded node modes, the in-place "magnified node" editor for
+create and edit (the pop-up dialogs are deleted — the Playground has zero modals),
+Neo4j-style connection authoring (body = move, halo ring = connect; anchored relation
+popover), selectable edges with per-relation right-click deletion planned as
+direction-correct compounds, frontend-only undo via paced compensating console
+commands, and panel-aware graph auto-fit. Engine-layout spots preserved per the
+continuity convention (deploy/clean targets, help glob, fixture imports, the graph.js
+README line). Verified live against THIS engine: per-relation delete, reverse-direction
+preservation and undo reproduce the Java behavior exactly — the engine-identical
+console messages carried the undo executor's mutation-confirmation pacing unchanged
+(254 webapp tests, identical totals to the Java repo).
+
+## Increment 107 — eq/ne: two values + ignoreCase/ignoreType modifiers (2026-09-08)
+
+Lock-step twin of Java PR #332: the `eq`/`ne` simple plugins now compare exactly two
+values (consistent with `gt`/`lt`; the chained all-equal-to-first form is removed) with
+optional 3rd/4th modifiers — `ignoreCase` (strings compare case-insensitively) and
+`ignoreType` (compares the `String.valueOf` text forms: "123" == 123, "true" == true).
+The shared `equals_with_modifiers` helper reuses the crate's parity primitives
+(`conversions::display`, the `to_lowercase()` case-fold idiom); error strings match the
+Java engine byte-for-byte. The `types.yml` fixture re-mirrored byte-identical and
+`flow_runtime` asserts all eleven new keys. Side lesson: CI runs current stable and the
+local toolchain must track it — a 1.95-vs-1.98 rustfmt disagreement over match-arm
+block wrapping failed the format gate until the dispatch was restructured to a shape
+both vintages format identically (and `rustup update stable` closed the skew).

--- a/extensions/minigraph-state-redis/Cargo.toml
+++ b/extensions/minigraph-state-redis/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["database", "asynchronous"]
 name = "minigraph_state_redis"
 
 [dependencies]
-mercury-platform-core = { version = "4.12.3", path = "../../crates/platform-core" }
+mercury-platform-core = { version = "4.12.4", path = "../../crates/platform-core" }
 async-trait = "0.1"
 log = "0.4"
 rmpv = { version = "1", features = ["with-serde"] }

--- a/memory/sessions/2026-09-08-235012.md
+++ b/memory/sessions/2026-09-08-235012.md
@@ -1,0 +1,45 @@
+# Session (2026-09-08T23:50:12.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+Release prep for **v4.12.4** (branch `release/v4.12.4`), lock-step with the Java engine's
+v4.12.4 published earlier today (2026-09-08T23:42Z).
+
+- **Version sweep 4.12.3 → 4.12.4**: the workspace version plus every inter-crate pin —
+  `crates/knowledge-graph` (3 pins), `crates/platform-core`, `crates/event-script`
+  (2 pins), and `extensions/minigraph-state-redis` (deliberately included — the crate a
+  past sweep missed). `cargo update --workspace` rolled the 12 workspace members in
+  `Cargo.lock`; zero `4.12.3` pins remain.
+- **INCREMENTS.md**: Increment 106 (Playground webapp lock-step — the two UI arcs, the
+  engine-layout preservation list, the live verification against this engine) and
+  Increment 107 (eq/ne two-value + `ignoreCase`/`ignoreType` modifiers, the parity
+  primitives used, the rustfmt 1.95-vs-1.98 toolchain-skew lesson) — backfilled at
+  release time like Increment 101 was for 4.12.3.
+- **CHANGELOG**: Version 4.12.4, 9/8/2026 — Added: eq/ne modifiers (lock-step incl.
+  error messages), the Playground UI overhaul, the claims-fixture gate (ADR-0018,
+  Increment 105, which landed after this repo's 4.12.3). Changed: eq/ne two-value
+  semantics (chained form removed), the Mercury Story docs finalization with the
+  cross-engine benchmark study.
+- Validation: `cargo test --workspace`, `cargo clippy --all-targets -D warnings`,
+  `mkdocs build --strict`, `check-llms-links.py`, `check-doc-claims.py` — the same gate
+  set the 4.12.3 release recorded (results in the release PR).
+- Release notes prepared; PR-open, tag, and crates.io publish stay gated on Eric.
+  Continuity `status` updates after publish.
+
+Side item folded into this release: two Java Dependabot PRs (#335 js-yaml 4.3.2, #337
+vitest/mocker 4.1.11) appeared against the Playground webapp after the arcs updated its
+manifest on Java main — patch-level dev-deps, verified against the suite before Eric
+merged them. The webapp mirror here carries the same pins (package.json +
+package-lock.json copied from Java main; `npm ci` + typecheck + 254/254 tests green on
+this side), so the release ships a byte-true webapp mirror.
+
+## Memory References
+
+- webapp-lockstep-sync-preserved-paths (consulted — Increment 106 records the sync per
+  this convention; the pending Dependabot dev-pin drift is noted against it)
+- conventions-rust-baseline (consulted — fmt/clippy clean as part of done; the release
+  gate set mirrors 4.12.3's)
+- inv-telemetry-presentation-parity (consulted — the release exists to keep the engines
+  lock-step at v4.12.4)


### PR DESCRIPTION
## What

Version sweep 4.12.3 → 4.12.4: the workspace version, every inter-crate pin
(`extensions/minigraph-state-redis` deliberately included), and `Cargo.lock`
(12 workspace members). CHANGELOG rolls to Version 4.12.4, 9/8/2026; the
increment ledger gains 106 (Playground webapp lock-step) and 107 (eq/ne
modifiers). A second commit mirrors the Java repo's Dependabot dev pins
(js-yaml 4.3.2, vitest/@vitest/mocker 4.1.11) into the webapp so the release
ships a byte-true mirror.

## Why

Lock-step with the Java engine's v4.12.4, published 2026-09-08. The release
carries everything landed since this repo's 4.12.3:

- **eq/ne optional modifiers** — `text(ignoreCase)` / `text(ignoreType)` for
  case-insensitive and type-lenient comparison; eq/ne now compare exactly two
  values, consistent with gt/lt (the unused chained form is removed). Error
  messages match the Java engine byte-for-byte.
- **MiniGraph Playground UI overhaul** (webapp lock-step) — in-place
  magnified-node editor with zero modal dialogs, Neo4j-style connection
  authoring, per-relation edge deletion with direction-correct removal
  compounds, compensating-command undo, panel-aware auto-fit — verified live
  against this engine.
- **Claims-fixture gate** (ADR-0018, the Java ADR-0023 twin) — 20 documentation
  behavior claims pinned to named engine tests, checked in both workflows,
  landed with the coverage-study sibling sweep.
- **The Mercury Story** docs finalization with the cross-engine benchmark study.

## Validation

- `cargo clippy --all-targets -D warnings`: zero findings.
- `cargo test --workspace`: all suites green (full rebuild under current
  stable 1.98.1, the toolchain CI runs).
- `mkdocs build --strict` clean; `check-llms-links.py` (33 references resolve);
  `check-doc-claims.py` (20 claims pinned on both sides).
- Webapp mirror: `npm ci`, typecheck, 254/254 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>