### PR TITLE
platform-core: one INFO log per route pool lifecycle

### DIFF
--- a/crates/platform-core/src/platform.rs
+++ b/crates/platform-core/src/platform.rs
@@ -233,7 +233,6 @@ impl Platform {
         options: FunctionOptions,
     ) -> Result<(), AppError> {
         validate_route(route)?;
-        self.warn_if_pool_member("Registering", route);
         // Java ServiceDef.setConcurrency: Math.max(1, Math.min(n, 1000)) —
         // zero is accepted (→ 1) and the worker count is capped, silently
         // (F10 parity fix, 2026-07-21; previously 0 was rejected and there
@@ -306,7 +305,6 @@ impl Platform {
             .remove(route);
         match removed {
             Some(entry) => {
-                self.warn_if_pool_member("Releasing", route);
                 entry.stop.notify_one();
                 true
             }
@@ -315,7 +313,8 @@ impl Platform {
     }
 
     /// Register a route pool — a set of private singleton routes
-    /// `{prefix}.{n}` for n = 0 to count-1 (Java `Platform.registerRoutePool`).
+    /// `{prefix}.{n}` for n = 0 to count-1, at least 2 lanes (Java
+    /// `Platform.registerRoutePool`).
     /// Each member runs with one worker, so it is a strict FIFO lane; a caller
     /// may check out a lane for exclusive use to preserve event order while
     /// other lanes serve concurrent traffic. One function instance is shared
@@ -332,8 +331,8 @@ impl Platform {
         function: Arc<dyn ComposableFunction>,
         count: usize,
     ) -> Result<Vec<String>, AppError> {
-        if count == 0 {
-            return Err(AppError::new(400, "Route pool count must be at least 1"));
+        if count < 2 {
+            return Err(AppError::new(400, "Route pool count must be at least 2"));
         }
         validate_route(&format!("{prefix}.0"))?;
         let _mutation = self
@@ -359,6 +358,7 @@ impl Platform {
             .write()
             .expect("pool registry poisoned")
             .insert(prefix.to_string(), count);
+        log::info!("Route pool {prefix} with {count} instances started as async tasks");
         Ok(members)
     }
 
@@ -369,8 +369,6 @@ impl Platform {
             .pool_mutations
             .lock()
             .expect("pool mutation lock poisoned");
-        // remove the pool entry first so the member release calls below are
-        // not reported as individual updates to an active pool
         let count = self
             .pools
             .write()
@@ -379,6 +377,7 @@ impl Platform {
         match count {
             Some(count) => {
                 self.release_pool_members(prefix, count);
+                log::info!("Route pool {prefix} stopped");
                 true
             }
             None => false,
@@ -389,41 +388,6 @@ impl Platform {
         for n in 0..count {
             self.release(&format!("{prefix}.{n}"));
         }
-    }
-
-    /// Log a warning when an individual registration or release touches a
-    /// member of a registered route pool (Java `warnIfPoolMember`) — warned,
-    /// never refused (house reload semantics).
-    fn warn_if_pool_member(&self, action: &str, route: &str) {
-        if let Some(pool) = self.pool_of(route) {
-            log::warn!("{action} {route} which belongs to route pool {pool}");
-        }
-    }
-
-    /// The pool a route belongs to, if any: its prefix is registered and its
-    /// last segment is canonical digits (no leading zeros) within the pool's
-    /// range — a neighbor such as `{prefix}.10` beside a count-3 pool is
-    /// never misclassified. The `< 10` digit-length guard mirrors the Java
-    /// twin exactly.
-    fn pool_of(&self, route: &str) -> Option<String> {
-        let dot = route.rfind('.')?;
-        if dot == 0 {
-            return None;
-        }
-        let prefix = &route[..dot];
-        let count = *self
-            .pools
-            .read()
-            .expect("pool registry poisoned")
-            .get(prefix)?;
-        let suffix = &route[dot + 1..];
-        if !suffix.is_empty() && suffix.len() < 10 && suffix.bytes().all(|b| b.is_ascii_digit()) {
-            let n: usize = suffix.parse().ok()?;
-            if suffix == n.to_string() && n < count {
-                return Some(prefix.to_string());
-            }
-        }
-        None
     }
 
     /// Registered route names (sorted, for stable output).

--- a/crates/platform-core/tests/route_pool.rs
+++ b/crates/platform-core/tests/route_pool.rs
@@ -133,12 +133,16 @@ async fn invalid_arguments_are_rejected() {
     assert!(platform
         .register_route_pool("unit.test.pool.d", echo(), 0)
         .is_err());
+    // a pool needs at least 2 lanes - a single lane is just a private function
+    assert!(platform
+        .register_route_pool("unit.test.pool.d", echo(), 1)
+        .is_err());
     // member names must validate: "{prefix}.{n}" through the standard rules
     assert!(platform
-        .register_route_pool("Unit.Test.Pool", echo(), 1)
+        .register_route_pool("Unit.Test.Pool", echo(), 2)
         .is_err());
     assert!(platform
-        .register_route_pool("unit.test.pool.d.", echo(), 1)
+        .register_route_pool("unit.test.pool.d.", echo(), 2)
         .is_err());
     assert!(!platform.has_route("unit.test.pool.d.0"));
 }
@@ -149,10 +153,10 @@ async fn individual_updates_to_members_are_tolerated_and_cleaned_up() {
     platform
         .register_route_pool("unit.test.pool.e", echo(), 3)
         .expect("pool registration");
-    // an individual release of a member is warned, never refused (house semantics)
+    // an individual release of a member is tolerated, never refused (house semantics)
     assert!(platform.release("unit.test.pool.e.1"));
     assert!(!platform.has_route("unit.test.pool.e.1"));
-    // an individual re-registration over a member reloads it, also warned
+    // an individual re-registration over a member reloads it, also tolerated
     platform
         .register_private("unit.test.pool.e.2", echo(), 1)
         .expect("member reload");

--- a/memory/sessions/2026-09-09-121211.md
+++ b/memory/sessions/2026-09-09-121211.md
@@ -1,0 +1,41 @@
+# Session (2026-09-09T12:12:11.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+Lock-step twin of the Java route-pool logging round (Eric's Java-side change, branch
+`feat/route-pool-log` in both repos): registering a route pool now prints ONE INFO line
+and releasing prints one, per the cross-engine log-presentation contract.
+
+Scope here was smaller than in Java — this engine registers routes silently (no
+per-member "started" lines ever existed), so the twin is:
+
+- `register_route_pool` requires **count ≥ 2** with the matching error message
+  ("Route pool count must be at least 2"; count checked before prefix validation, same
+  order as Java). The one production caller (the SSE reply-lane pool,
+  `RESPONSE_HANDLER_INSTANCES = 500`) is unaffected.
+- New INFO lines: "Route pool {prefix} with {count} instances started as async tasks"
+  (the Java line says "as {kernel|virtual} thread" — the runner-type token has no analog
+  here, so the honest engine term rides the identical searchable stem) and
+  "Route pool {prefix} stopped".
+- `warn_if_pool_member` + `pool_of` deleted with both call sites (the Java twin removed
+  them); member-touch operations stay tolerated, now silently. The stale ordering
+  comment in `release_route_pool` (which existed only for that warning) went with them.
+- Doc comment gains "at least 2 lanes" (javadoc parity).
+- Tests: `invalid_arguments_are_rejected` gains an explicit count-1 case pinning the
+  floor, and the two invalid-prefix cases bump to count 2 so they still reach
+  `validate_route` (count is now checked first — the same silent-coverage-loss fix as
+  the Java RoutePoolTest); "warned" comments corrected to "tolerated".
+
+## Validation
+
+- `cargo fmt`; `cargo clippy -p mercury-platform-core --all-targets` zero findings;
+  full `cargo test -p mercury-platform-core` — all 29 suites ok (route_pool 6/6).
+
+## Memory References
+
+- inv-telemetry-presentation-parity (consulted — the log lines, count floor, and
+  warning removal ship lock-step; the async-tasks wording is a deliberate
+  engine-legitimate divergence on the runner-type token only)
+- conventions-rust-baseline (consulted — fmt + clippy clean as part of done)


### PR DESCRIPTION
## What

Lock-step twin of the Java route-pool logging change. This engine already
registers routes silently — no per-member "started" lines ever existed — so
the twin is scoped to what actually diverged:

- `register_route_pool` now requires **count ≥ 2** with the byte-matching
  error message ("Route pool count must be at least 2"), checked before
  prefix validation in the same order as Java.
- New pool-level INFO lines: "Route pool {prefix} with {count} instances
  started as async tasks" and "Route pool {prefix} stopped". The Java line
  says "as {kernel|virtual} thread"; the runner-type token has no analog in
  this engine, so the honest engine term rides the identical searchable stem.
- The member-touch warning twins (`warn_if_pool_member`/`pool_of`) are
  removed with both call sites — direct member updates stay tolerated,
  silently, matching the Java engine.
- The doc comment gains "at least 2 lanes" (javadoc parity), and the tests
  get the same coverage fix as Java's RoutePoolTest: an explicit count-1 case
  pins the new floor, and the two invalid-prefix cases bump to count 2 so
  they still reach route validation.

## Why

The Event Script and platform log surface is part of the cross-engine
contract: a portable application registering a route pool must fail
identically on both engines, and DevSecOps teams reading both engines' logs
in one aggregation should find the same pool-lifecycle lines.

## Validation

- `cargo clippy -p mercury-platform-core --all-targets`: zero findings.
- Full `cargo test -p mercury-platform-core`: all 29 suites ok
  (route_pool 6/6).
- The one production caller (the SSE reply-lane pool, 500 lanes) is
  unaffected by the count floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>