### PR TITLE
test: pin concat null-operand rendering (Java field-fix twin)

### DIFF
--- a/crates/event-script/src/plugins.rs
+++ b/crates/event-script/src/plugins.rs
@@ -647,6 +647,12 @@ mod tests {
             ),
             Ok(Value::from("a b"))
         );
+        // a null operand renders as "null" (String.valueOf semantics; the Java
+        // engine relaxed its getTextValue to match this behavior)
+        assert_eq!(
+            calculate("concat", &[Value::from("a"), Value::Nil, Value::from("b")]),
+            Ok(Value::from("anullb"))
+        );
         assert_eq!(
             calculate(
                 "substring",

--- a/crates/event-script/tests/flow_runtime.rs
+++ b/crates/event-script/tests/flow_runtime.rs
@@ -1219,6 +1219,11 @@ async fn flows_run_end_to_end_like_java() {
         body.get_element("concat"),
         Some(Value::from("Hello World!"))
     );
+    // a null operand renders as "null" (String.valueOf semantics; Java-engine parity)
+    assert_eq!(
+        body.get_element("concat_null"),
+        Some(Value::from("Hellonull World!"))
+    );
     assert_eq!(body.get_element("isNull"), Some(Value::Boolean(true)));
     assert_eq!(body.get_element("isNotNull"), Some(Value::Boolean(true)));
     // binary conversion produced real bytes (Java byte[] parity)

--- a/crates/event-script/tests/resources/flows/pluggableFunctions/types.yml
+++ b/crates/event-script/tests/resources/flows/pluggableFunctions/types.yml
@@ -64,6 +64,7 @@ tasks:
       - 'f:substring(model.text_two, model.substring_start) -> substring_one'
       - 'f:substring(model.text_two, model.substring_start, model.substring_end) -> substring_two'
       - 'f:concat(model.text_one, model.text_two) -> concat'
+      - 'f:concat(model.text_one, model.none, model.text_two) -> concat_null'
       - 'f:b64(model.b64_str) -> model.to_b64_bytes'
       - 'model.to_b64_bytes -> to_b64_bytes'
       - 'f:b64(model.to_b64_bytes) -> to_bytestring'

--- a/memory/sessions/2026-09-09-155833.md
+++ b/memory/sessions/2026-09-09-155833.md
@@ -1,0 +1,28 @@
+# Session (2026-09-09T15:58:33.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+Test-pinning twin of the Java field-fix round (branch `fix/field-fixes` in both repos).
+The Java engine fixed two field issues; on this side, one needed NO code change and one
+does not exist:
+
+- **concat with a null operand**: the Java `getTextValue` was a null-hostile pattern
+  switch (NPE); this engine's `get_text_value` already renders Nil as "null" via
+  `display()` — the Java fix restores parity with THIS engine's behavior. Pinned here so
+  it can never drift: the `pluggableFunctions/types.yml` fixture re-mirrored
+  byte-identical (new `concat_null` row → "Hellonull World!"), asserted in
+  `flow_runtime`, plus a `plugins.rs` unit case (`concat(a, Nil, b)` → "anullb").
+- **minute-boundary ISO date parsing to epoch** (Java `str2date`/OffsetDateTime): no
+  twin exists — this engine has no str2date/OffsetDateTime surface; Java-only fix.
+
+## Validation
+
+- `cargo fmt`; `cargo test -p mercury-event-script` — all 9 suites ok, including the new
+  fixture assertion and unit case.
+
+## Memory References
+
+- inv-telemetry-presentation-parity (consulted — the Java fix aligns to this engine's
+  existing null rendering; the mirrored fixture pins the shared behavior on both sides)


### PR DESCRIPTION
## What

Test-pinning twin of the Java field-fix round — no engine code changes.

- The `pluggableFunctions/types.yml` fixture is re-mirrored byte-identical to
  the Java repo, gaining the `concat_null` row
  (`f:concat(model.text_one, model.none, model.text_two)` →
  `"Hellonull World!"`), asserted in `flow_runtime`.
- A `plugins.rs` unit case pins `concat("a", Nil, "b")` → `"anullb"`.

## Why

The Java engine fixed an NPE in its `getTextValue` for null operands — its
text conversion was a null-hostile pattern switch — restoring parity with THIS
engine's existing `display(Nil)` → `"null"` rendering. Pinning the behavior on
both sides means the shared semantics can never drift silently again. The
Java round's other fix (minute-boundary ISO date parsing) has no twin here —
this engine has no `str2date`/OffsetDateTime surface.

## Validation

- `cargo test -p mercury-event-script`: all 9 suites ok, including the new
  fixture assertion and unit case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>