### PR TITLE
minigraph: stepwise traversal logging for deployed graph execution

### DIFF
--- a/crates/knowledge-graph/src/executor.rs
+++ b/crates/knowledge-graph/src/executor.rs
@@ -58,6 +58,20 @@ fn is_dev_env() -> bool {
     *DEV.get_or_init(|| AppConfigReader::get_instance().get_property_or("app.env", "dev") == "dev")
 }
 
+/// Stepwise traversal logging (field request 2026-09-09): the same trail the
+/// dry-run GraphTraveler narrates to the Playground console, as INFO log lines
+/// labeled with the graph id and the run's trace id (fallback: flow instance
+/// id) so OTel dashboards can join app logs with exported spans. On by
+/// default; DevOps can override the runtime parameter
+/// (`graph.traversal.log=false`) to reduce log noise. Java parity:
+/// `GraphExecutor.traversalLog`.
+fn traversal_log() -> bool {
+    static TRAVERSAL_LOG: OnceLock<bool> = OnceLock::new();
+    *TRAVERSAL_LOG.get_or_init(|| {
+        AppConfigReader::get_instance().get_property_or("graph.traversal.log", "true") == "true"
+    })
+}
+
 /// The interceptor body (Java `handleEvent`).
 pub async fn handle(
     platform: &Platform,
@@ -84,9 +98,21 @@ async fn execute_graph(
     // the span that triggered this graph is the parent span for the graph's
     // first node, establishing telemetry lineage into the graph
     let parent_span = event.span_id().map(str::to_string);
+    // the traversal log labels each line with the run's trace id (fallback:
+    // flow instance id when tracing is off) - capture it once at the start
+    let trace_id = event.trace_id().map(str::to_string);
     let reply_to = event.reply_to().unwrap_or_default().to_string();
     let cid = event.correlation_id().unwrap_or_default().to_string();
-    let outcome = start_traversal(platform, po, headers, &reply_to, &cid, &parent_span).await;
+    let outcome = start_traversal(
+        platform,
+        po,
+        headers,
+        &reply_to,
+        &cid,
+        &trace_id,
+        &parent_span,
+    )
+    .await;
     if let Err(e) = outcome {
         let mut error = EventEnvelope::new()
             .set_to(&reply_to)
@@ -106,9 +132,13 @@ async fn start_traversal(
     headers: &HashMap<String, String>,
     reply_to: &str,
     cid: &str,
+    trace_id: &Option<String>,
     parent_span: &Option<String>,
 ) -> Result<(), AppError> {
     let instance = create_instance(headers, reply_to, cid)?;
+    if let Some(trace) = trace_id {
+        instance.set_trace_id(trace);
+    }
     begin_traversal(platform, po, &instance, parent_span).await
 }
 
@@ -213,6 +243,23 @@ async fn handle_skill_response(platform: &Platform, po: &PostOffice, response: &
         }
     };
     check_frequency(po, &instance, node_name, &parent_span).await;
+    if traversal_log() {
+        // {:?} — Java Float.toString always keeps the decimal point
+        // ("3.0 ms"), the repo's float-parity rule
+        let spent = response.exec_time().unwrap_or(0.0);
+        let skill_name = node
+            .get_property(SKILL)
+            .map(|v| display(&v))
+            .unwrap_or_else(|| "null".to_string());
+        log::info!(
+            "Executed {} with skill {} in {:?} ms - {} ({})",
+            node_name,
+            skill_name,
+            spent,
+            instance.graph_id,
+            instance.correlation_label()
+        );
+    }
     // a skill can set status and error in its node properties instead of
     // failing (e.g. an HTTP status >= 400 from the API fetcher)
     let (process_status, result_error) = {
@@ -359,6 +406,14 @@ fn walk<'a>(
             seen
         };
         if is_join || !seen {
+            if traversal_log() {
+                log::info!(
+                    "Walk to {} - {} ({})",
+                    node.get_alias(),
+                    instance.graph_id,
+                    instance.correlation_label()
+                );
+            }
             walk_to(platform, po, skill, instance, node, from, parent_span).await?;
         }
         Ok(())
@@ -549,6 +604,15 @@ async fn execution_complete(
     }
     let _ = po.send(response.set_raw_body(body)).await;
     instance.set_complete();
+    if traversal_log() {
+        let elapsed = crate::session::now_ms() - instance.start_time_ms();
+        log::info!(
+            "Graph traversal completed in {} ms - {} ({})",
+            elapsed,
+            instance.graph_id,
+            instance.correlation_label()
+        );
+    }
 }
 
 async fn execute_skill(
@@ -734,6 +798,7 @@ async fn handle_error_response(
     }
     let _ = po.send(error).await;
     instance.set_complete();
+    log_aborted(instance, &display(response.body()));
 }
 
 async fn send_error(
@@ -752,4 +817,17 @@ async fn send_error(
     }
     let _ = po.send(error).await;
     instance.set_complete();
+    log_aborted(instance, message);
+}
+
+/// Java parity: `GraphExecutor.logAborted`.
+fn log_aborted(instance: &Arc<GraphInstance>, reason: &str) {
+    if traversal_log() {
+        log::info!(
+            "Graph traversal aborted: {} - {} ({})",
+            reason,
+            instance.graph_id,
+            instance.correlation_label()
+        );
+    }
 }

--- a/crates/knowledge-graph/src/model.rs
+++ b/crates/knowledge-graph/src/model.rs
@@ -39,6 +39,9 @@ struct Metadata {
     correlation_id: Option<String>,
     flow_instance_id: Option<String>,
     reply_to: Option<String>,
+    /// The distributed trace id of the event that started this run, when
+    /// tracing is on — the traversal log's preferred correlation label.
+    trace_id: Option<String>,
     /// The dry-run watcher slot: "owner-run-correlation-id|timer-id" —
     /// owner-tagged so a stale watcher can never act on a newer run.
     run_watcher: Option<String>,
@@ -161,6 +164,29 @@ impl GraphInstance {
             .flow_instance_id = Some(instance_id.to_string());
     }
 
+    /// The run's distributed trace id, when tracing is on (Java parity).
+    pub fn get_trace_id(&self) -> Option<String> {
+        self.metadata
+            .lock()
+            .expect("graph metadata")
+            .trace_id
+            .clone()
+    }
+
+    pub fn set_trace_id(&self, trace_id: &str) {
+        if !trace_id.trim().is_empty() {
+            self.metadata.lock().expect("graph metadata").trace_id = Some(trace_id.to_string());
+        }
+    }
+
+    /// The traversal log's correlation label: the run's trace id, so an OTel
+    /// dashboard can join these app-log lines with the exported spans and
+    /// metrics; falls back to the flow instance id when tracing is off.
+    pub fn correlation_label(&self) -> String {
+        self.get_trace_id()
+            .unwrap_or_else(|| self.get_flow_instance_id())
+    }
+
     pub fn get_reply_to(&self) -> String {
         self.metadata
             .lock()
@@ -207,4 +233,26 @@ pub fn remove_instance(id: &str) -> Option<Arc<GraphInstance>> {
         .write()
         .expect("graph instances poisoned")
         .remove(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The traversal log labels lines with the trace id so OTel dashboards
+    /// can join app logs with spans; an untraced run falls back to the flow
+    /// instance id (Java `GraphExecutor.correlationLabel` parity).
+    #[test]
+    fn correlation_label_prefers_trace_id_and_falls_back_to_flow_instance() {
+        let instance = GraphInstance::new("unit-test");
+        instance.set_flow_instance_id("flow-1");
+        assert_eq!(instance.correlation_label(), "flow-1");
+
+        instance.set_trace_id("  "); // blank trace ids are ignored
+        assert_eq!(instance.get_trace_id(), None);
+        assert_eq!(instance.correlation_label(), "flow-1");
+
+        instance.set_trace_id("trace-abc");
+        assert_eq!(instance.correlation_label(), "trace-abc");
+    }
 }

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2784,3 +2784,30 @@ twin (no `str2date`/OffsetDateTime surface here). The webapp mirror carries the
 community graph-view tuning (Java PR #339 by @skofgar): fit padding 0.1, max zoom 4,
 zoom/pinch behaviors pinned explicitly — 254 webapp tests green and the bundle rebuilt
 into `resources/public`.
+
+## Increment 110 — Playground webapp lock-step: Help profiles, run controls, minimap island (2026-09-09)
+
+Wholesale webapp mirror of the Java PR #341 arc (merged here as PR #247): profile-based
+Help (JSON-Path Overview), backend-acknowledged Instantiate/Run controls with the in-place
+"Mock Graph Input" panel (zero modals), the draggable minimap island with persisted
+position, JSON-Path as a payload-only playground, per-content left-panel width defaults on
+a versioned layout key, and the session live-graph restore (`GET /api/graph/session/{id}`
+when a pinned temp-model path expires). The sync convention was amended: `helpContent.ts`
+and the localHelpCommand test now carry feature content, so they are PORTED (Java file +
+re-applied Rust path lines) instead of preserved wholesale; the Rust `help.md` keeps its
+deliberately divergent prose and received only the Keyboard-shortcuts addition. 324 webapp
+tests green — matching the Java suite exactly — and the bundle rebuilt into
+`resources/public` (index hash legitimately differs: the help markdown is glob-inlined).
+
+## Increment 111 — Stepwise traversal logging for deployed graph execution (2026-09-09)
+
+Field request: the dry-run traveler's stepwise narration, now emitted by the production
+`graph.executor` as INFO log lines — "Walk to {node}", "Executed {node} with skill {skill}
+in {time} ms", "Graph traversal completed in {time} ms", "Graph traversal aborted:
+{reason}" — labeled with the graph id and the run's trace id (fallback: flow instance id)
+so OTel dashboards join app logs with exported spans; with `log.format=json|compact` the
+app-context-log adds the structured context alongside (it is disabled in `text` format,
+where the inline label carries the correlation). Gated by `graph.traversal.log` (default
+true; `-Dgraph.traversal.log=false` to quiet busy installs). Byte-matched wording with the
+Java engine (its `GraphTraversalLoggingTest` pins the trail); here the correlation-label
+fallback is pinned in `model.rs` unit tests.

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -546,6 +546,26 @@ The Playground draft-graph scratch folder. Must be on the local file system
 accepted and stripped. Invalid values fall back to the default. Read by
 `crates/knowledge-graph` (Playground commands).
 
+#### `graph.traversal.log`
+
+| Type | Default |
+|---|---|
+| boolean | `true` |
+
+Stepwise traversal logging for deployed graph execution (`graph.executor`) — the same
+trail the Playground dry-run narrates to its console (`Walk to {node}`, `Executed {node}
+with skill {skill} in {time} ms`, `Graph traversal completed in {time} ms`, and `Graph
+traversal aborted: {reason}` on error), emitted as INFO log lines suffixed with the graph
+id and the run's **trace id** (fallback: the flow instance id when tracing is off) — so an
+OpenTelemetry dashboard can join these app-log lines with the exported spans and metrics.
+The inline label complements the app-context-log feature: with `log.format=json` or
+`compact`, each record additionally carries the structured `context` key-values (span id,
+business correlation id); app-context-log is disabled in plain `text` format (to reduce
+log volume), where the inline trace id keeps the correlation visible regardless. On by
+default; set it to `false` (for example with the runtime override
+`-Dgraph.traversal.log=false`) to reduce log volume on busy installations. Read by
+`crates/knowledge-graph` (executor). Java parity: identical wording and gate.
+
 #### `graph.max.loop.interval`
 
 | Type | Default |

--- a/examples/minigraph-playground/resources/application.yml
+++ b/examples/minigraph-playground/resources/application.yml
@@ -21,6 +21,13 @@ location.graph.temp: file:/tmp/graph
 # location.graph.deployed is obsolete).
 graph.model.automation: 'classpath:/graphs.yaml'
 
+# Stepwise traversal logging for deployed graph execution (graph.executor) —
+# the same trail the Playground dry-run narrates, as INFO log lines labeled
+# with the graph id and the trace id (fallback: flow instance id) so OTel
+# dashboards can join logs with spans. Set to false
+# (e.g. -Dgraph.traversal.log=false) to reduce log noise. Java parity.
+graph.traversal.log: true
+
 # Serializer null handling (Java parity). Default false: null MAP key-values are
 # omitted from JSON and MsgPack output (e.g. a successful /sync response drops the
 # null `error` field), mirroring Gson's default + MsgPack packMap null-skip.

--- a/memory/sessions/2026-09-10-002824.md
+++ b/memory/sessions/2026-09-10-002824.md
@@ -1,0 +1,40 @@
+# Session (2026-09-10T00:28:24.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Stepwise traversal logging twin** (branch `feature/graph-traversal-logging`;
+Java reference on the sibling branch of the same name). Field request: the
+dry-run traveler's narration, now emitted by the production `graph.executor`
+as INFO log lines — `Walk to {node}`, `Executed {node} with skill {skill} in
+{time} ms` (envelope exec_time, `{:?}` float-parity formatting), `Graph
+traversal completed in {elapsed} ms`, `Graph traversal aborted: {reason}` —
+each suffixed `- {graph_id} ({correlation})` where the correlation label is
+the run's **trace id** captured once from the initiating event, falling back
+to the flow instance id (Eric: the OTel dashboard joins app logs with spans;
+app-context-log adds structured context in json/compact formats and is off in
+text, where the inline label carries the correlation). Gate:
+`graph.traversal.log` (default true) via the executor's OnceLock config
+pattern; Java's extra `isInfoEnabled` guard is unnecessary here —
+`log::info!` evaluates arguments inside the macro's own level check.
+
+Changes: `executor.rs` (gate fn, trace capture through `start_traversal`,
+four log sites, `log_aborted` helper), `model.rs` (Metadata `trace_id` +
+`correlation_label()` + unit pin), example `application.yml`, configuration
+reference entry, INCREMENTS 111 — plus **Increment 110 as a catch-up record
+for the PR #247 webapp lock-step** (that arc merged without its increment).
+
+Gates: `cargo fmt`, clippy clean, knowledge-graph suites **10/10**. One
+verification lesson: the first full-crate run failed
+`playground_command_grammar_and_companion` ("graph.math help expected") and
+looked deterministic across an isolated rerun — a stash-bisect proved the
+identical diff green and the failure a **parallel-suite/compile contention
+flake** on this laptop (the same pattern as the v4.12.5 local TLS 408).
+Bisect before believing a red suite implicates an unrelated diff.
+
+## Memory References
+
+- webapp-lockstep-sync-preserved-paths (consulted — confirmed this arc is
+  engine-side only, no webapp mirror obligation)
+- conv-declare-consulted-references-rust (consulted — this declaration habit)


### PR DESCRIPTION
## What

Twin of the Java arc: `graph.executor` emits the dry-run traveler's trail as INFO log lines — `Walk to {node}`, `Executed {node} with skill {skill} in {time} ms` (envelope exec-time, `{:?}` float-parity formatting), `Graph traversal completed in {time} ms`, `Graph traversal aborted: {reason}` — labeled `- {graph_id} ({trace_id})` with the flow instance id as the untraced fallback. Gated by `graph.traversal.log` (default `true`); no `isInfoEnabled` twin needed — `log::info!` evaluates arguments inside the macro's own level check.

- `model.rs`: `GraphInstance` trace-id metadata + `correlation_label()` with a unit pin.
- Config + docs twins (example `application.yml`, configuration reference).
- Increment 111, plus Increment 110 as the catch-up record for the PR #247 webapp lock-step.

## Why

Field enhancement request (2026-09-09), shipped lock-step with the Java engine — byte-matched wording (the Java `GraphTraversalLoggingTest` pins the trail), same gate, same OTel-correlation rationale.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>