### PR TITLE
minigraph: temp graph-model endpoint answers 404 for a missing draft

### DIFF
--- a/crates/knowledge-graph/src/rest.rs
+++ b/crates/knowledge-graph/src/rest.rs
@@ -511,7 +511,10 @@ fn upload_ok() -> EventEnvelope {
 }
 
 /// Java `DescribeGraph` (`show.graph.model`): read a draft graph from the
-/// Playground temp folder.
+/// Playground temp folder. The `{sequence}` path parameter is deliberately
+/// NOT part of the resource identity: it is an artificial counter minted per
+/// describe/export reply to defeat browser caching of this URL — the draft
+/// file alone decides.
 pub async fn show_graph_model(event: EventEnvelope) -> Result<EventEnvelope, AppError> {
     let (path_parameters, _, _) = request_view(&event);
     let Some(filename) = path_parameters.get("graph_id") else {
@@ -519,7 +522,12 @@ pub async fn show_graph_model(event: EventEnvelope) -> Result<EventEnvelope, App
     };
     let file = commands::temp_dir().join(format!("{filename}.json"));
     if !file.exists() {
-        return Err(invalid(format!("Draft graph '{filename}' does not exist")));
+        // a nonexistent (or expired) draft answers 404 as if it does not
+        // exist - the deployed-graph "compiled or 404" precedent (Java parity)
+        return Err(AppError::new(
+            404,
+            format!("Draft graph '{filename}' does not exist"),
+        ));
     }
     let text = std::fs::read_to_string(&file).map_err(|e| invalid(e.to_string()))?;
     let parsed: serde_json::Value =

--- a/crates/knowledge-graph/tests/rest_model_endpoint.rs
+++ b/crates/knowledge-graph/tests/rest_model_endpoint.rs
@@ -1,0 +1,50 @@
+//
+// Copyright 2018-2026 Accenture Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Pins the temp graph-model endpoint's not-found contract: a draft that does
+//! not exist (never described, or expired by housekeeping) answers **404** as
+//! if it is not there — the deployed-graph "compiled or 404" precedent. The
+//! `{sequence}` path parameter is an artificial cache-buster, deliberately not
+//! part of the resource identity (Java `DescribeGraph` parity).
+
+use knowledge_graph::rest::show_graph_model;
+use platform_core::EventEnvelope;
+use rmpv::Value;
+
+fn model_request(graph_id: &str, sequence: &str) -> EventEnvelope {
+    EventEnvelope::new().set_raw_body(Value::Map(vec![
+        (
+            Value::from("parameters"),
+            Value::Map(vec![(
+                Value::from("path"),
+                Value::Map(vec![
+                    (Value::from("graph_id"), Value::from(graph_id)),
+                    (Value::from("sequence"), Value::from(sequence)),
+                ]),
+            )]),
+        ),
+        (Value::from("method"), Value::from("GET")),
+    ]))
+}
+
+#[tokio::test]
+async fn missing_draft_answers_404() {
+    let err = show_graph_model(model_request("no-such-draft", "1"))
+        .await
+        .expect_err("a nonexistent draft must not answer 200");
+    assert_eq!(err.status(), 404);
+    assert_eq!(err.message(), "Draft graph 'no-such-draft' does not exist");
+}

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2811,3 +2811,14 @@ where the inline label carries the correlation). Gated by `graph.traversal.log` 
 true; `-Dgraph.traversal.log=false` to quiet busy installs). Byte-matched wording with the
 Java engine (its `GraphTraversalLoggingTest` pins the trail); here the correlation-label
 fallback is pinned in `model.rs` unit tests.
+
+## Increment 112 — Temp graph-model endpoint answers 404 for a missing draft (2026-09-10)
+
+Maintainer bug ruling: `GET /api/graph/model/{graph_id}/{sequence}` returned 400 for a
+nonexistent or housekeeping-expired draft — a missing resource now answers **404** as if
+it does not exist (the deployed-graph "compiled or 404" precedent), byte-matched with the
+Java engine. The `{sequence}` is documented for what it is: an artificial cache-buster
+minted per describe/export reply, deliberately not part of the resource identity — the
+draft file alone decides. Pinned by `rest_model_endpoint.rs`. The describe/export temp
+snapshot stays a human-operator and companion-agent surface; the Playground UI's move to
+the live session endpoint is the next arc.

--- a/memory/sessions/2026-09-10-005927.md
+++ b/memory/sessions/2026-09-10-005927.md
@@ -1,0 +1,16 @@
+# Session (2026-09-10T00:59:27.000Z)
+
+**Agent:** (auto-stub — replace with your agent name and enrich)
+**Lightweight:** auto-captured by the post-commit hook; summary pending.
+
+Commit `5a8997fa` — minigraph: temp graph-model endpoint answers 404 for a missing draft
+
+```
+ crates/knowledge-graph/src/rest.rs                 | 12 +++++-
+ .../knowledge-graph/tests/rest_model_endpoint.rs   | 50 ++++++++++++++++++++++
+ docs/INCREMENTS.md                                 | 11 +++++
+ 3 files changed, 71 insertions(+), 2 deletions(-)
+```
+
+## Memory References
+(none — auto-stub; enrich per memory/PROTOCOL.md "Close every session", or leave as a lite log)

--- a/memory/sessions/2026-09-10-005927.md
+++ b/memory/sessions/2026-09-10-005927.md
@@ -1,16 +1,29 @@
 # Session (2026-09-10T00:59:27.000Z)
 
-**Agent:** (auto-stub — replace with your agent name and enrich)
-**Lightweight:** auto-captured by the post-commit hook; summary pending.
+**Agent:** Claude Code
 
-Commit `5a8997fa` — minigraph: temp graph-model endpoint answers 404 for a missing draft
+## What happened
 
-```
- crates/knowledge-graph/src/rest.rs                 | 12 +++++-
- .../knowledge-graph/tests/rest_model_endpoint.rs   | 50 ++++++++++++++++++++++
- docs/INCREMENTS.md                                 | 11 +++++
- 3 files changed, 71 insertions(+), 2 deletions(-)
-```
+**Temp graph-model endpoint 404 twin** (branch `feature/graph-model-endpoint-404`,
+commit `5a8997fa`; Java sibling branch same name). Eric's ruling from the PR #341
+verification round: a missing draft answered 400 — now **404** as if it does not
+exist ("compiled or 404" precedent). Design steer mid-round (Eric): the
+`{sequence}` is an ARTIFICIAL cache-buster he added against browser caching —
+deliberately not resource identity — so a planned link-registry (ManagedCache of
+minted links) was dropped as over-engineering; the draft file alone decides.
+Message unchanged ("Draft graph '{name}' does not exist"), status corrected.
+Pinned by `tests/rest_model_endpoint.rs` (direct handler call). Increment 112.
+
+**Next arc agreed (Eric's proposal): the Playground UI switches its graph source
+to the live session endpoint** (`GET /api/graph/session/{id}`) — no temp-file
+round-trip; `describe graph` stays a human-operator console command (temp
+snapshot + link unchanged, also the companion-agent surface). UI-side this
+retires the pinned-model fetch as primary and generalizes the session
+live-graph restore into THE loading path; webapp change lands Java-side first,
+then the wholesale mirror.
 
 ## Memory References
-(none — auto-stub; enrich per memory/PROTOCOL.md "Close every session", or leave as a lite log)
+
+- webapp-lockstep-sync-preserved-paths (consulted — engine fix has no webapp
+  mirror obligation; the UI arc will follow the amended sync ritual)
+- conv-declare-consulted-references-rust (consulted)


### PR DESCRIPTION
## What

Twin of the Java fix: `show_graph_model` answers **404** (was 400) for a nonexistent or housekeeping-expired draft, message unchanged (`Draft graph '{name}' does not exist`). The `{sequence}` path parameter is documented as an artificial cache-buster, deliberately not resource identity. Pinned by `tests/rest_model_endpoint.rs`; Increment 112.

## Why

Maintainer bug ruling (2026-09-09), shipped lock-step with the Java engine. The describe/export temp snapshot stays the human-operator and companion-agent surface; the Playground UI's switch to the live session endpoint is the next arc.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>