### PR TITLE
minigraph: traversal log lines become structured records for log analytics

### DIFF
--- a/crates/knowledge-graph/src/executor.rs
+++ b/crates/knowledge-graph/src/executor.rs
@@ -59,16 +59,33 @@ fn is_dev_env() -> bool {
 }
 
 /// Stepwise traversal logging (field request 2026-09-09): the same trail the
-/// dry-run GraphTraveler narrates to the Playground console, as INFO log lines
-/// labeled with the graph id and the run's trace id (fallback: flow instance
-/// id) so OTel dashboards can join app logs with exported spans. On by
-/// default; DevOps can override the runtime parameter
+/// dry-run GraphTraveler narrates to the Playground console, as INFO
+/// structured records so OTel dashboards can join app logs with exported
+/// spans. On by default; DevOps can override the runtime parameter
 /// (`graph.traversal.log=false`) to reduce log noise. Java parity:
 /// `GraphExecutor.traversalLog`.
 fn traversal_log() -> bool {
     static TRAVERSAL_LOG: OnceLock<bool> = OnceLock::new();
     *TRAVERSAL_LOG.get_or_init(|| {
         AppConfigReader::get_instance().get_property_or("graph.traversal.log", "true") == "true"
+    })
+}
+
+/// A traversal log record, logged as a JSON object (the telemetry-stream
+/// precedent) so the json and compact formats embed it as a nested structure
+/// that log-analytics dashboards (Dynatrace, Splunk, ...) index as
+/// key-values; the text format prints the compact JSON string. Keys: `id` =
+/// the correlation label (the run's trace id, falling back to the flow
+/// instance id), `text` = the traveler-style message, `graph` = the graph id.
+/// The executor runs zero-traced (the trace is captured once from the
+/// initiating event, not re-spanned per node), so the app-log-context block
+/// never accompanies these lines — the record's `id` key is the correlation
+/// surface. Java parity: `GraphExecutor.traversalRecord`.
+fn traversal_record(text: String, graph_id: &str, correlation_label: String) -> serde_json::Value {
+    serde_json::json!({
+        "id": correlation_label,
+        "text": text,
+        "graph": graph_id,
     })
 }
 
@@ -252,12 +269,12 @@ async fn handle_skill_response(platform: &Platform, po: &PostOffice, response: &
             .map(|v| display(&v))
             .unwrap_or_else(|| "null".to_string());
         log::info!(
-            "Executed {} with skill {} in {:?} ms - {} ({})",
-            node_name,
-            skill_name,
-            spent,
-            instance.graph_id,
-            instance.correlation_label()
+            "{}",
+            traversal_record(
+                format!("Executed {node_name} with skill {skill_name} in {spent:?} ms"),
+                &instance.graph_id,
+                instance.correlation_label()
+            )
         );
     }
     // a skill can set status and error in its node properties instead of
@@ -408,10 +425,12 @@ fn walk<'a>(
         if is_join || !seen {
             if traversal_log() {
                 log::info!(
-                    "Walk to {} - {} ({})",
-                    node.get_alias(),
-                    instance.graph_id,
-                    instance.correlation_label()
+                    "{}",
+                    traversal_record(
+                        format!("Walk to {}", node.get_alias()),
+                        &instance.graph_id,
+                        instance.correlation_label()
+                    )
                 );
             }
             walk_to(platform, po, skill, instance, node, from, parent_span).await?;
@@ -607,10 +626,12 @@ async fn execution_complete(
     if traversal_log() {
         let elapsed = crate::session::now_ms() - instance.start_time_ms();
         log::info!(
-            "Graph traversal completed in {} ms - {} ({})",
-            elapsed,
-            instance.graph_id,
-            instance.correlation_label()
+            "{}",
+            traversal_record(
+                format!("Graph traversal completed in {elapsed} ms"),
+                &instance.graph_id,
+                instance.correlation_label()
+            )
         );
     }
 }
@@ -824,10 +845,30 @@ async fn send_error(
 fn log_aborted(instance: &Arc<GraphInstance>, reason: &str) {
     if traversal_log() {
         log::info!(
-            "Graph traversal aborted: {} - {} ({})",
-            reason,
-            instance.graph_id,
-            instance.correlation_label()
+            "{}",
+            traversal_record(
+                format!("Graph traversal aborted: {reason}"),
+                &instance.graph_id,
+                instance.correlation_label()
+            )
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::traversal_record;
+
+    /// Pins the structured traversal record's contract: keys `id` (correlation
+    /// label), `text` (traveler-style message), and `graph` (graph id) — the
+    /// shape the Java engine logs via `log.info("{}", map)` and this engine
+    /// embeds as a nested structure in the json/compact formats.
+    #[test]
+    fn traversal_record_carries_id_text_graph() {
+        let record = traversal_record("Walk to root".to_string(), "hello", "trace-1".to_string());
+        assert_eq!(record["id"], "trace-1");
+        assert_eq!(record["text"], "Walk to root");
+        assert_eq!(record["graph"], "hello");
+        assert_eq!(record.as_object().map(|o| o.len()), Some(3));
     }
 }

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2835,3 +2835,17 @@ Graph tab. Retired UI machinery: the pinned model path, the session-restore fall
 hook, and the expired-model special-casing. Verified against this engine on the packaged
 bundle: mount fetch, mutation refetches, and away-and-back restore all served by
 `get.live.graph` with zero browser console errors.
+
+## Increment 114 — Traversal log lines become structured records (2026-09-10)
+
+Maintainer refinement after field-testing the stepwise GraphExecutor logging: each
+traversal step now logs a JSON object — keys `id` (the run's trace id, falling back to
+the flow instance id), `text` (the traveler-style message, unchanged vocabulary), and
+`graph` (the graph id) — instead of a single line with inline suffixes. With
+`log.format=json` or `compact` the record embeds as a nested structure that log-analytics
+dashboards (Dynatrace, Splunk) index as key-values; text format prints the compact JSON
+string (this engine's map-log presentation, the telemetry-stream precedent). Confirmed
+during the same round: the executor runs zero-traced, so the app-log-context `context`
+block never accompanies its lines in any format — the record's `id` key is the
+correlation surface, and the configuration reference now says so. Java parity: identical
+record keys, `log.info("{}", Map.of(...))` on the Java side.

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -553,18 +553,21 @@ accepted and stripped. Invalid values fall back to the default. Read by
 | boolean | `true` |
 
 Stepwise traversal logging for deployed graph execution (`graph.executor`) — the same
-trail the Playground dry-run narrates to its console (`Walk to {node}`, `Executed {node}
-with skill {skill} in {time} ms`, `Graph traversal completed in {time} ms`, and `Graph
-traversal aborted: {reason}` on error), emitted as INFO log lines suffixed with the graph
-id and the run's **trace id** (fallback: the flow instance id when tracing is off) — so an
-OpenTelemetry dashboard can join these app-log lines with the exported spans and metrics.
-The inline label complements the app-context-log feature: with `log.format=json` or
-`compact`, each record additionally carries the structured `context` key-values (span id,
-business correlation id); app-context-log is disabled in plain `text` format (to reduce
-log volume), where the inline trace id keeps the correlation visible regardless. On by
-default; set it to `false` (for example with the runtime override
+trail the Playground dry-run narrates to its console, emitted as INFO **structured
+records** (a JSON object as the log message). Each record carries three keys: `text` —
+the traveler-style message (`Walk to {node}`, `Executed {node} with skill {skill} in
+{time} ms`, `Graph traversal completed in {time} ms`, or `Graph traversal aborted:
+{reason}`), `graph` — the graph id, and `id` — the run's **trace id** (fallback: the flow
+instance id when tracing is off), so an OpenTelemetry dashboard can join these app-log
+lines with the exported spans and metrics. With `log.format=json` or `compact` the
+record embeds as a nested structure that log-analytics platforms (Dynatrace, Splunk, ...)
+index as key-values; in plain `text` format the record prints as its compact JSON string.
+Note that the executor deliberately runs zero-traced (the trace is captured once from the
+initiating event, not re-spanned per node), so the app-log-context `context` block does
+**not** accompany these lines in any format — the record's `id` key is the correlation
+surface. On by default; set it to `false` (for example with the runtime override
 `-Dgraph.traversal.log=false`) to reduce log volume on busy installations. Read by
-`crates/knowledge-graph` (executor). Java parity: identical wording and gate.
+`crates/knowledge-graph` (executor). Java parity: identical record keys and gate.
 
 #### `graph.max.loop.interval`
 

--- a/examples/minigraph-playground/resources/application.yml
+++ b/examples/minigraph-playground/resources/application.yml
@@ -22,9 +22,10 @@ location.graph.temp: file:/tmp/graph
 graph.model.automation: 'classpath:/graphs.yaml'
 
 # Stepwise traversal logging for deployed graph execution (graph.executor) —
-# the same trail the Playground dry-run narrates, as INFO log lines labeled
-# with the graph id and the trace id (fallback: flow instance id) so OTel
-# dashboards can join logs with spans. Set to false
+# the same trail the Playground dry-run narrates, as INFO structured records
+# {id, text, graph} where id is the trace id (fallback: flow instance id) so
+# OTel dashboards can join logs with spans; log.format=json/compact embed the
+# record as indexable key-values. Set to false
 # (e.g. -Dgraph.traversal.log=false) to reduce log noise. Java parity.
 graph.traversal.log: true
 

--- a/memory/sessions/2026-09-10-042959.md
+++ b/memory/sessions/2026-09-10-042959.md
@@ -1,0 +1,41 @@
+# Session (2026-09-10T04:29:59.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Traversal log lines become structured records** (branch
+`feature/graph-traversal-structured-log`; Java sibling same name). Eric
+field-tested the #248 stepwise logging and refined: log a MAP so
+log-analytics dashboards (Dynatrace, Splunk) index key-values. Each of the
+four executor sites now logs `traversal_record(text, graph_id, label)` — a
+`serde_json::json!` object with keys `id` (trace id, fallback flow instance
+id), `text` (traveler vocabulary, unchanged), `graph` (graph id) — via
+`log::info!("{record}")`, the telemetry-stream precedent (logging.rs embeds a
+JSON-parseable message as a nested structure in json/compact; text prints the
+compact JSON string — engine-native map presentation, matching how the
+telemetry trace log already differs from Java's HashMap toString in text
+mode). Unit pin `executor::tests::traversal_record_carries_id_text_graph`.
+Increment 114.
+
+**Eric's app-context-log question ANSWERED (diagnosis confirmed in the Java
+reference):** the missing `context` block on executor lines IS caused by
+`@ZeroTracing` — `WorkerHandler.executeFunction` registers the `LogContext`
+(thread-keyed, read by the json/compact appenders) only when the worker's
+`tracing` flag is on, and a zero-tracing function never starts a trace
+bracket, so no LogContext exists for the executor's thread in ANY format.
+By design (the executor deliberately avoids per-hop spans; the trace is
+captured once onto the GraphInstance) — the record's `id` key is the
+correlation surface. Both configuration references corrected (the #346-era
+paragraph claimed the context block accompanies these lines in json/compact —
+empirically false, now documented properly).
+
+Gates: fmt, clippy clean, targeted unit test green (full suite left to CI per
+the contention-flake lesson).
+
+## Memory References
+
+- inv-telemetry-presentation-parity (consulted — record keys/values byte-
+  matched; text-mode map rendering follows each engine's native presentation,
+  the telemetry-log precedent)
+- conv-declare-consulted-references-rust (consulted)


### PR DESCRIPTION
## What

Twin of the Java refinement: the four traversal log sites now emit a JSON-object record — keys `id` (trace id, fallback flow instance id), `text` (traveler vocabulary, unchanged), `graph` — via the engine's map-log presentation (the telemetry-stream precedent): json/compact embed it as a nested indexable structure, text prints the compact JSON string. Unit pin `traversal_record_carries_id_text_graph`; configuration reference documents the zero-traced executor's context-block absence; Increment 114.

## Why

Maintainer refinement after field-testing the stepwise logging (2026-09-10): dashboards index key-values, not inline suffixes. Shipped lock-step with the Java engine — identical record keys and message vocabulary.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>