### PR TITLE
event-script: f:camelCase and f:snakeCase key-normalization plugins

### DIFF
--- a/crates/event-script/src/plugins.rs
+++ b/crates/event-script/src/plugins.rs
@@ -48,7 +48,7 @@ use crate::plugins_e8::value_type_name;
 /// The number of built-in `#[simple_plugin]` declarations the engine itself
 /// ships (this module + `plugins_e8`) — the startup floor the
 /// `SimplePluginLoader` asserts against linker elision.
-pub const BUILTIN_PLUGIN_COUNT: usize = 48;
+pub const BUILTIN_PLUGIN_COUNT: usize = 50;
 
 /// A plugin body (Java `PluginFunction.calculate`): evaluated argument values
 /// in, one value out; a descriptive error is the Java
@@ -488,6 +488,144 @@ fn plugin_set_config(args: &[Value]) -> Result<Value, String> {
         }
         _ => Ok(Value::Boolean(false)),
     }
+}
+
+/// Key-normalization core for `f:camelCase` / `f:snakeCase` (Java
+/// `KeyNormalizationUtils`): legacy systems — often XML-to-JSON
+/// transformations — deliver maps whose key formats vary per source
+/// (MyExampleKey, My_Example_key, my_example_Key). Both plugins segmentize
+/// each key and re-case the segments, recursively through nested maps and
+/// lists (values are never touched; only keys).
+///
+/// Segmentation: underscore, hyphen and dot are separators; a
+/// lower-case-or-digit to upper-case transition starts a new segment; an
+/// upper-case run followed by a lower-case letter splits before its last
+/// upper-case letter (the acronym rule: XMLKey -> XML + Key). Digits ride
+/// with their segment. Empty segments drop; a key with no segments at all
+/// (e.g. "___") is kept as-is. Colliding normalized keys resolve to the
+/// later entry at the first key's position (Java LinkedHashMap semantics).
+/// Normalization is idempotent.
+fn key_segments(key: &str) -> Vec<String> {
+    let chars: Vec<char> = key.chars().collect();
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    for (i, &c) in chars.iter().enumerate() {
+        if c == '_' || c == '-' || c == '.' {
+            if !current.is_empty() {
+                segments.push(std::mem::take(&mut current));
+            }
+            continue;
+        }
+        if let Some(previous) = current.chars().last() {
+            let lower_to_upper =
+                (previous.is_lowercase() || previous.is_numeric()) && c.is_uppercase();
+            let acronym_end = previous.is_uppercase()
+                && c.is_uppercase()
+                && chars.get(i + 1).is_some_and(|next| next.is_lowercase());
+            if lower_to_upper || acronym_end {
+                segments.push(std::mem::take(&mut current));
+            }
+        }
+        current.push(c);
+    }
+    if !current.is_empty() {
+        segments.push(current);
+    }
+    segments
+}
+
+fn to_camel_case(key: &str) -> String {
+    let segments = key_segments(key);
+    if segments.is_empty() {
+        return key.to_string();
+    }
+    let mut out = segments[0].to_lowercase();
+    for segment in &segments[1..] {
+        let lower = segment.to_lowercase();
+        let mut rest = lower.chars();
+        if let Some(first) = rest.next() {
+            out.extend(first.to_uppercase());
+            out.push_str(rest.as_str());
+        }
+    }
+    out
+}
+
+fn to_snake_case(key: &str) -> String {
+    let segments = key_segments(key);
+    if segments.is_empty() {
+        return key.to_string();
+    }
+    segments
+        .iter()
+        .map(|s| s.to_lowercase())
+        .collect::<Vec<_>>()
+        .join("_")
+}
+
+fn normalize_keys(value: &Value, mapper: fn(&str) -> String) -> Value {
+    match value {
+        Value::Map(entries) => {
+            let mut normalized: Vec<(Value, Value)> = Vec::with_capacity(entries.len());
+            for (key, item) in entries {
+                let name = mapper(&get_text_value(key));
+                let item = normalize_keys(item, mapper);
+                // a collision resolves to the later entry at the first key's
+                // position (Java LinkedHashMap put semantics)
+                if let Some(existing) = normalized
+                    .iter_mut()
+                    .find(|(k, _)| k.as_str() == Some(name.as_str()))
+                {
+                    existing.1 = item;
+                } else {
+                    normalized.push((Value::from(name), item));
+                }
+            }
+            Value::Map(normalized)
+        }
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|item| normalize_keys(item, mapper))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+fn normalize_top_level(
+    args: &[Value],
+    plugin: &str,
+    mapper: fn(&str) -> String,
+) -> Result<Value, String> {
+    let [value] = args else {
+        return Err(format!(
+            "One input is required for {plugin} key normalization"
+        ));
+    };
+    match value {
+        Value::Nil => Err(format!(
+            "Input cannot be null for {plugin} key normalization"
+        )),
+        Value::Map(_) | Value::Array(_) => Ok(normalize_keys(value, mapper)),
+        _ => Err(format!(
+            "Input must be a map or a list for {plugin} key normalization"
+        )),
+    }
+}
+
+/// `f:camelCase(mapOrList)` — normalize every key to camelCase, recursively
+/// (Java `CamelCaseNormalization`).
+#[simple_plugin("camelCase")]
+fn plugin_camel_case(args: &[Value]) -> Result<Value, String> {
+    normalize_top_level(args, "camelCase", to_camel_case)
+}
+
+/// `f:snakeCase(mapOrList)` — normalize every key to snake_case, recursively
+/// (Java `SnakeCaseNormalization`).
+#[simple_plugin("snakeCase")]
+fn plugin_snake_case(args: &[Value]) -> Result<Value, String> {
+    normalize_top_level(args, "snakeCase", to_snake_case)
 }
 #[cfg(test)]
 mod tests {
@@ -1264,5 +1402,95 @@ mod tests {
         overrides::clear("set.config.plugin.direct");
         overrides::clear("set.config.plugin.number");
         overrides::clear("set.config.plugin.flag");
+    }
+
+    /// Twin of the Java `KeyNormalizationTest`: the field's legacy key
+    /// variants converge, the acronym rule, hyphen/dot separators, digits
+    /// riding with their segment, recursion through nested maps and lists,
+    /// last-wins collisions, idempotency, and exact Java-parity error
+    /// messages.
+    #[test]
+    fn key_normalization_matches_java_semantics() {
+        assert!(contains_simple_plugin("camelCase"));
+        assert!(contains_simple_plugin("snakeCase"));
+        let map = |k: &str| Value::Map(vec![(Value::from(k), Value::from(1))]);
+        for variant in ["MyExampleKey", "My_Example_key", "my_example_Key"] {
+            assert_eq!(
+                calculate("camelCase", &[map(variant)]),
+                Ok(map("myExampleKey"))
+            );
+            assert_eq!(
+                calculate("snakeCase", &[map(variant)]),
+                Ok(map("my_example_key"))
+            );
+        }
+        // the acronym rule: an upper-case run splits before its last upper
+        assert_eq!(
+            calculate("camelCase", &[map("myXMLKey")]),
+            Ok(map("myXmlKey"))
+        );
+        assert_eq!(
+            calculate("snakeCase", &[map("customerID")]),
+            Ok(map("customer_id"))
+        );
+        assert_eq!(
+            calculate("camelCase", &[map("XMLHttpRequest")]),
+            Ok(map("xmlHttpRequest"))
+        );
+        // hyphen/dot separators; digits ride with their segment
+        assert_eq!(
+            calculate("camelCase", &[map("my-example.key")]),
+            Ok(map("myExampleKey"))
+        );
+        assert_eq!(
+            calculate("snakeCase", &[map("Address1_Line")]),
+            Ok(map("address1_line"))
+        );
+        // recursion: keys normalize at every depth; values are never touched
+        let nested = Value::Map(vec![(
+            Value::from("Outer_Key"),
+            Value::Array(vec![
+                Value::Map(vec![(Value::from("Item_Name"), Value::from("Some_Value"))]),
+                Value::from("scalar"),
+            ]),
+        )]);
+        let expected = Value::Map(vec![(
+            Value::from("outerKey"),
+            Value::Array(vec![
+                Value::Map(vec![(Value::from("itemName"), Value::from("Some_Value"))]),
+                Value::from("scalar"),
+            ]),
+        )]);
+        assert_eq!(calculate("camelCase", &[nested]), Ok(expected));
+        // collision: the later entry wins, at the first key's position
+        let colliding = Value::Map(vec![
+            (Value::from("MyKey"), Value::from(1)),
+            (Value::from("my_key"), Value::from(2)),
+        ]);
+        assert_eq!(
+            calculate("camelCase", &[colliding]),
+            Ok(Value::Map(vec![(Value::from("myKey"), Value::from(2))]))
+        );
+        // idempotency
+        let once = calculate("camelCase", &[map("My_Example_Key")]).unwrap();
+        assert_eq!(
+            calculate("camelCase", std::slice::from_ref(&once)),
+            Ok(once)
+        );
+        // a key with no segments is kept as-is
+        assert_eq!(calculate("snakeCase", &[map("-.-")]), Ok(map("-.-")));
+        // exact Java-parity error messages
+        assert_eq!(
+            calculate("camelCase", &[]),
+            Err("One input is required for camelCase key normalization".to_string())
+        );
+        assert_eq!(
+            calculate("snakeCase", &[Value::Nil]),
+            Err("Input cannot be null for snakeCase key normalization".to_string())
+        );
+        assert_eq!(
+            calculate("camelCase", &[Value::from("MyKey")]),
+            Err("Input must be a map or a list for camelCase key normalization".to_string())
+        );
     }
 }

--- a/crates/event-script/tests/flow_runtime.rs
+++ b/crates/event-script/tests/flow_runtime.rs
@@ -1255,6 +1255,37 @@ async fn flows_run_end_to_end_like_java() {
         body.get_element("parsed_from_model[1]"),
         Some(Value::from(20))
     );
+    // --- key normalization: f:camelCase / f:snakeCase converge legacy key
+    // variants; keys normalize recursively (incl. maps inside lists) and
+    // values are never touched (Java-engine parity)
+    assert_eq!(
+        body.get_element("camel_map.myExampleKey"),
+        Some(Value::from("1"))
+    );
+    assert_eq!(
+        body.get_element("camel_map.customerId"),
+        Some(Value::from("2"))
+    );
+    assert_eq!(
+        body.get_element("snake_map.my_example_key"),
+        Some(Value::from("1"))
+    );
+    assert_eq!(
+        body.get_element("snake_map.customer_id"),
+        Some(Value::from("2"))
+    );
+    assert_eq!(
+        body.get_element("camel_dotted.myExampleKey"),
+        Some(Value::from(3))
+    );
+    assert_eq!(
+        body.get_element("camel_dotted.nestedList[0].itemName"),
+        Some(Value::from("Some_Value"))
+    );
+    assert_eq!(
+        body.get_element("snake_list[0].item_name"),
+        Some(Value::from("Some_Value"))
+    );
 
     // --- the setConfig plugin flow (canonical fixture, byte-identical to the
     // Java engine's set-config.yml): task one sets config parameters through

--- a/crates/event-script/tests/resources/flows/pluggableFunctions/types.yml
+++ b/crates/event-script/tests/resources/flows/pluggableFunctions/types.yml
@@ -83,6 +83,13 @@ tasks:
       - 'f:json(text({"hello": [1, 2, {"nested": "demo"}]})) -> nested_json'
       - 'text([10, 20, 30]) -> model.json_text'
       - 'f:json(model.json_text) -> parsed_from_model'
+      - 'text(1) -> model.legacy.My_Example_key'
+      - 'text(2) -> model.legacy.customerID'
+      - 'f:json(text({"my-example.key": 3, "Nested_List": [{"Item_Name": "Some_Value"}]})) -> model.dotted'
+      - 'f:camelCase(model.legacy) -> camel_map'
+      - 'f:snakeCase(model.legacy) -> snake_map'
+      - 'f:camelCase(model.dotted) -> camel_dotted'
+      - 'f:snakeCase(model.dotted.Nested_List) -> snake_list'
     process: 'no.op'
     output:
       - 'text(application/json) -> output.header.content-type'

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2849,3 +2849,15 @@ during the same round: the executor runs zero-traced, so the app-log-context `co
 block never accompanies its lines in any format — the record's `id` key is the
 correlation surface, and the configuration reference now says so. Java parity: identical
 record keys, `log.info("{}", Map.of(...))` on the Java side.
+
+## Increment 115 — Key-normalization simple plugins: f:camelCase / f:snakeCase (2026-09-10)
+
+Field proposal (Eric): legacy systems — often XML-to-JSON transformations — deliver maps
+whose key formats vary per source (MyExampleKey, My_Example_key, my_example_Key). The two
+new built-in plugins segmentize each key (underscore/hyphen/dot separators, a
+lower-or-digit to upper transition, and the acronym rule: an upper-case run followed by a
+lower-case letter splits before its last upper — myXMLKey becomes myXmlKey / my_xml_key)
+and re-case recursively through nested maps and lists; values are never touched;
+collisions resolve last-wins at the first key's position; normalization is idempotent.
+Lock-step with the Java engine: identical algorithm, error messages, and the shared
+pluggableFunctions/types.yml fixture (BUILTIN_PLUGIN_COUNT floor 48 → 50).

--- a/docs/guides/event-script/syntax.md
+++ b/docs/guides/event-script/syntax.md
@@ -1474,6 +1474,8 @@ For example:
 | **Type Conversion** | listOfMap       | Convert "a map of lists" to "a list of maps" — **order-preserving**: list order follows array index order (guaranteed) |
 | **Type Conversion** | updateListOfMap | Update "a list of maps" with "maps of lists"                                                                          |
 | **Type Conversion** | removeKey       | Remove one or more keys from a map or "list of maps". Syntax: `f:removeKey(source, text(key1), text(key2), …)` — see the worked example below. |
+| **Key Normalization** | camelCase     | Normalize every key of a map (recursively, incl. maps inside lists) to camelCase. See the worked example below. |
+| **Key Normalization** | snakeCase     | Normalize every key of a map (recursively, incl. maps inside lists) to snake_case. See the worked example below. |
 | **Type Conversion** | defaultValue    | If the first argument is null, return the 2nd argument                                                                |
 | **Type Conversion** | parseDate       | Parse a date string to ISO, Local or Milliseconds.                                                                    |
 | **Type Conversion** | parseDateTime   | Parse a date-time string to ISO, Local or Milliseconds.                                                               |
@@ -1736,6 +1738,29 @@ for external consumption:
 For details, please refer to the configuration example in `header-and-json-path-test.yml` under
 `crates/event-script/tests/resources/flows/` and its test in `crates/event-script/tests/`
 (the canonical Java fixtures are reused verbatim by this port).
+
+*camelCase and snakeCase*
+
+Legacy systems — often XML-to-JSON transformations — deliver key formats that vary per source:
+`MyExampleKey`, `My_Example_key` and `my_example_Key` are the same logical key. The
+`camelCase(mapOrList)` and `snakeCase(mapOrList)` plugins segmentize each key and re-case the
+segments: underscore, hyphen and dot are separators; a lower-case-or-digit to upper-case
+transition starts a new segment; and an upper-case run followed by a lower-case letter splits
+before its last upper-case letter (the acronym rule — `myXMLKey` becomes `myXmlKey` /
+`my_xml_key`). Digits ride with their segment (`address1Line`). Values are never touched —
+only keys, at every nesting depth (including maps inside lists). Two distinct source keys can
+normalize to the same target (`MyKey` and `my_key` both become `myKey`); the later entry in
+map order wins. Normalization is idempotent, and a key with no letter or digit segments at
+all (e.g. `"___"`) is kept as-is. Both engines ship the identical algorithm and error
+messages (portable-flow contract).
+
+```yaml
+# converge a legacy payload's mixed key formats before mapping it onward
+- 'f:camelCase(input.body) -> model.normalized'
+
+# a list of maps normalizes element by element
+- 'f:snakeCase(input.body.list) -> output.body.records'
+```
 
 ### Writing your own custom Simple Plugins
 

--- a/docs/guides/event-script/syntax.md
+++ b/docs/guides/event-script/syntax.md
@@ -1754,12 +1754,20 @@ map order wins. Normalization is idempotent, and a key with no letter or digit s
 all (e.g. `"___"`) is kept as-is. Both engines ship the identical algorithm and error
 messages (portable-flow contract).
 
+Beyond legacy cleanup, the plugins also do **impedance matching** between systems with
+different key conventions: an incoming camelCase request payload can be transformed to
+snake_case for processing and forwarding to a downstream system that expects it — one
+mapping statement at either boundary, no per-field mapping.
+
 ```yaml
 # converge a legacy payload's mixed key formats before mapping it onward
 - 'f:camelCase(input.body) -> model.normalized'
 
 # a list of maps normalizes element by element
 - 'f:snakeCase(input.body.list) -> output.body.records'
+
+# impedance matching: a camelCase request payload forwarded to a snake_case system
+- 'f:snakeCase(input.body) -> model.downstream_request'
 ```
 
 ### Writing your own custom Simple Plugins

--- a/memory/sessions/2026-09-10-051950.md
+++ b/memory/sessions/2026-09-10-051950.md
@@ -1,0 +1,38 @@
+# Session (2026-09-10T05:19:50.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Key-normalization simple plugins twin: f:camelCase / f:snakeCase** (branch
+`feature/key-normalization-plugins`; Java sibling same name; Increment 115).
+Eric's field proposal — legacy XML-to-JSON systems deliver mixed key formats
+(MyExampleKey, My_Example_key, my_example_Key) — reviewed for viability first
+(the PluginFunction/#[simple_plugin] SPIs already pass whole Maps/Lists, so no
+mapping-engine change), then ratified with two refinements: the acronym rule
+(an upper-case run followed by a lower-case letter splits before its last
+upper: myXMLKey → myXmlKey / my_xml_key) and hyphen + dot as separators
+alongside underscore.
+
+Implementation: `key_segments`/`to_camel_case`/`to_snake_case`/`normalize_keys`
+in plugins.rs; recursion through nested maps and lists (values untouched);
+collisions last-wins at the first key's position (Java LinkedHashMap
+semantics, hand-rolled over the rmpv Vec-pair map); idempotent; keys with no
+segments kept as-is; BUILTIN_PLUGIN_COUNT floor 48 → 50 (the count assertions
+are >= floors, safe). Error messages byte-matched with Java's
+IllegalArgumentException texts. Pins: unit
+`key_normalization_matches_java_semantics` + the shared
+pluggableFunctions/types.yml fixture extended (byte-identical to Java's) with
+flow_runtime assertions. Docs: event-script/syntax.md table rows (new "Key
+Normalization" category) + worked section.
+
+Gates: fmt, clippy clean, event-script lib 38/38 + flow_runtime + full package
+suites green. One clippy catch: `&[once.clone()]` →
+`std::slice::from_ref(&once)` (cloned_ref_to_slice_refs).
+
+## Memory References
+
+- inv-telemetry-presentation-parity (consulted — the Event Script surface is
+  the cross-engine contract: same-day twins, byte-matched messages, shared
+  fixture)
+- conv-declare-consulted-references-rust (consulted)

--- a/memory/sessions/2026-09-10-051950.md
+++ b/memory/sessions/2026-09-10-051950.md
@@ -30,6 +30,11 @@ Gates: fmt, clippy clean, event-script lib 38/38 + flow_runtime + full package
 suites green. One clippy catch: `&[once.clone()]` →
 `std::slice::from_ref(&once)` (cloned_ref_to_slice_refs).
 
+Follow-up doc round (Eric, same day): the plugins are not only legacy-cleanup
+— they do **impedance matching** between key conventions (e.g. a camelCase
+request payload transformed to snake_case for processing and forwarding).
+Recorded in the syntax.md worked section with an example.
+
 ## Memory References
 
 - inv-telemetry-presentation-parity (consulted — the Event Script surface is


### PR DESCRIPTION
## What

Twin of the Java feature: `f:camelCase` / `f:snakeCase` normalize every key of a map — recursively, including maps inside lists — using the identical segmentation (underscore/hyphen/dot separators, lower-or-digit→upper transitions, the acronym rule) and byte-matched error messages. Collisions resolve last-wins at the first key's position (Java LinkedHashMap semantics over the ordered rmpv map); idempotent. `BUILTIN_PLUGIN_COUNT` floor 48 → 50. Pinned by a unit test and the shared `pluggableFunctions/types.yml` fixture (byte-identical with the Java engine) asserted in `flow_runtime`; `event-script/syntax.md` documents the new Key Normalization category. Increment 115.

## Why

Field proposal (2026-09-10), shipped lock-step with the Java engine — a new built-in simple plugin is part of the portable-flow contract.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>