### PR TITLE
docs: agent-memory attribution locators — official Mercury-family home (Rust twin)

### DIFF
--- a/docs/mercury-story.md
+++ b/docs/mercury-story.md
@@ -789,6 +789,9 @@ And the working posture follows from it:
     <https://arxiv.org/abs/2211.09110>
 19. C. E. Jimenez et al., *SWE-bench: Can Language Models Resolve Real-World GitHub Issues?*,
     ICLR 2024. <https://arxiv.org/abs/2310.06770>
+20. E. Law, *agent-memory: A Lightweight, Vendor-Neutral Memory + Cognitive-Loop System for
+    Predictable AI–Human Delivery*, whitepaper v1.7, September 2026.
+    <https://accenture.github.io/mercury-go/agent-memory-whitepaper/>
 
 ---
 
@@ -803,5 +806,6 @@ documentation map. All figures are reproducible from the cited artifacts.*
 
 *Mercury Composable is an official Accenture open-source project; this repository is its official
 Rust implementation (github.com/Accenture/mercury). agent-memory is a lightweight, vendor-neutral
-shared-memory and cognitive-loop tool for human-AI collaboration; it installs and maintains this
-repository's shared `memory/` layer.*
+shared-memory and cognitive-loop tool for human-AI collaboration and part of the Mercury family
+(github.com/Accenture/mercury-go); it installs and maintains this repository's shared `memory/`
+layer.*

--- a/memory/sessions/2026-09-10-164248.md
+++ b/memory/sessions/2026-09-10-164248.md
@@ -1,0 +1,14 @@
+# Session (2026-09-10T16:42:48.292Z)
+
+**Agent:** Claude Code
+
+Lightweight: `docs/mercury-story.md` — agent-memory attribution locators (Java twin in
+lock-step): the closing note now says agent-memory is part of the Mercury family
+(github.com/Accenture/mercury-go); References #20 added for the agent-memory whitepaper v1.7 at
+accenture.github.io/mercury-go. Trigger: agent-memory's promotion into the Mercury family today
+(tracked in the Java repo's `ot-agent-memory-attribution-locators` thread, now closed). Branch
+`docs/agent-memory-official-locators` from `main`; PR per policy.
+
+## Memory References
+
+(none)


### PR DESCRIPTION
## What

`docs/mercury-story.md` (Rust edition): the closing note's agent-memory sentence now reads "…and part of the Mercury family (github.com/Accenture/mercury-go)", and References gains #20 — the agent-memory whitepaper v1.7 at https://accenture.github.io/mercury-go/agent-memory-whitepaper/. Lightweight session log added. Java twin: the same-named branch on Accenture/mercury-composable (lock-step).

## Why

The deferred half of the agent-memory attribution review (locators + reference entry) was gated on agent-memory becoming official Accenture open source. That happened today — agent-memory joined the Mercury family at github.com/Accenture/mercury-go — so the paper can now cite it at its official URL. No other content changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
