### PR TITLE
release: version 4.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,48 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`draft-design-specs/`](draft-design-specs/).
 
 ---
+## Version 4.12.6, 9/10/2026
+
+### Added
+
+- **`f:camelCase` and `f:snakeCase` key-normalization simple plugins** (lock-step with
+  the Java engine, Increment 115): legacy systems — often XML-to-JSON transformations —
+  deliver the same logical key as `MyExampleKey`, `My_Example_key`, or `my_example_Key`.
+  The plugins segmentize each key (underscore/hyphen/dot separators; case transitions
+  with the acronym rule — `myXMLKey` becomes `myXmlKey` / `my_xml_key`) and re-case
+  recursively through nested maps and lists; values are never touched, and normalization
+  is idempotent. Beyond legacy cleanup they do impedance matching between key
+  conventions. Identical algorithm, error messages, and shared flow fixture.
+- **Stepwise traversal logging for deployed graph execution** (field request,
+  Increments 111 and 114): the production `graph.executor` emits the dry-run traveler's
+  trail as INFO structured records (`{id, text, graph}`, where `id` is the run's trace
+  id, falling back to the flow instance id) so OTel dashboards can join app logs with
+  exported spans; json/compact formats embed the record as indexable key-values. Gated
+  by `graph.traversal.log` (default `true`). The executor runs zero-traced, so the
+  app-log-context block never accompanies these lines — the record's `id` key is the
+  correlation surface.
+
+### Fixed
+
+- The temp graph-model endpoint (`GET /api/graph/model/{graph_id}/{sequence}`) answered
+  400 for a nonexistent or housekeeping-expired draft — a missing resource now answers
+  **404** as if it is not there (the deployed-graph "compiled or 404" precedent,
+  Increment 112). The `{sequence}` is documented as an artificial cache-buster,
+  deliberately not resource identity.
+
+### Changed
+
+- **Playground webapp lock-step** (Increments 110 and 113, wholesale mirrors of the
+  Java repo's arcs): the UX modernization (Help panel, draggable minimap island, graph
+  run controls, in-place left-slot panels for node authoring and mock graph input,
+  JSON-Path as a payload-only tool, frontend-only undo — Java PR #341 with
+  maintainer-guided rounds), and the UI's switch to the **live session graph**
+  (`GET /api/graph/session/{id}`) as its single graph source — no `describe graph`
+  round-trip or temp-file link for the view; `describe graph` / `export graph` stay
+  human-operator console commands. Bundle rebuilt; the webapp also carries the Java
+  repo's vendor-router chunk fix and nanoid audit bump.
+
+---
 ## Version 4.12.5, 9/9/2026
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ai-contract-provider"
-version = "4.12.5"
+version = "4.12.6"
 dependencies = [
  "async-trait",
  "log",
@@ -114,7 +114,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.12.5"
+version = "4.12.6"
 dependencies = [
  "async-trait",
  "log",
@@ -454,7 +454,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.12.5"
+version = "4.12.6"
 dependencies = [
  "async-trait",
  "log",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.12.5"
+version = "4.12.6"
 dependencies = [
  "async-trait",
  "log",
@@ -756,7 +756,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mercury-event-script"
-version = "4.12.5"
+version = "4.12.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-event-script-macros"
-version = "4.12.5"
+version = "4.12.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-knowledge-graph"
-version = "4.12.5"
+version = "4.12.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-knowledge-graph-macros"
-version = "4.12.5"
+version = "4.12.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-minigraph-state-redis"
-version = "4.12.5"
+version = "4.12.6"
 dependencies = [
  "async-trait",
  "log",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-platform-core"
-version = "4.12.5"
+version = "4.12.6"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-platform-macros"
-version = "4.12.5"
+version = "4.12.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "minigraph-playground"
-version = "4.12.5"
+version = "4.12.6"
 dependencies = [
  "async-trait",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.12.5"
+version = "4.12.6"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury"

--- a/crates/event-script/Cargo.toml
+++ b/crates/event-script/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous"]
 name = "event_script"
 
 [dependencies]
-mercury-platform-core = { version = "4.12.5", path = "../platform-core" }
+mercury-platform-core = { version = "4.12.6", path = "../platform-core" }
 async-trait = "0.1"
 log = "0.4"
 # --- increment E-2: data-mapping engine ---
@@ -31,7 +31,7 @@ chrono = "0.4"
 # (the ZoneId.systemDefault() analog, same crate chrono uses internally)
 chrono-tz = "0.10"
 iana-time-zone = "0.1"
-mercury-event-script-macros = { version = "4.12.5", path = "../event-script-macros" }
+mercury-event-script-macros = { version = "4.12.6", path = "../event-script-macros" }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]

--- a/crates/knowledge-graph/Cargo.toml
+++ b/crates/knowledge-graph/Cargo.toml
@@ -16,12 +16,12 @@ exclude = ["webapp/"]
 name = "knowledge_graph"
 
 [dependencies]
-mercury-platform-core = { version = "4.12.5", path = "../platform-core" }
+mercury-platform-core = { version = "4.12.6", path = "../platform-core" }
 # layer 3 rides layer 2: the data-mapping mini-language (converter, rmpv
 # MultiLevelMap) is shared with event-script, and deployed graphs are
 # exposed through event-script flows
-mercury-event-script = { version = "4.12.5", path = "../event-script" }
-mercury-knowledge-graph-macros = { version = "4.12.5", path = "../knowledge-graph-macros" }
+mercury-event-script = { version = "4.12.6", path = "../event-script" }
+mercury-knowledge-graph-macros = { version = "4.12.6", path = "../knowledge-graph-macros" }
 async-trait = "0.1"
 log = "0.4"
 rmpv = { version = "1", features = ["with-serde"] }

--- a/crates/platform-core/Cargo.toml
+++ b/crates/platform-core/Cargo.toml
@@ -42,7 +42,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["ring",
 rustls-native-certs = "0.8"
 # --- increment 10: annotation macros (Java @PreLoad/@BeforeApplication/@MainApplication) ---
 inventory = "0.3"
-mercury-platform-macros = { version = "4.12.5", path = "../platform-macros" }
+mercury-platform-macros = { version = "4.12.6", path = "../platform-macros" }
 # --- increment 71: ManagedCache (docs/design/managed-cache-port.md — the Caffeine-lineage
 # engine, wrapped; EvictionPolicy::lru per the maintainer's deterministic-eviction ruling) ---
 moka = { version = "0.12", features = ["sync"] }

--- a/extensions/minigraph-state-redis/Cargo.toml
+++ b/extensions/minigraph-state-redis/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["database", "asynchronous"]
 name = "minigraph_state_redis"
 
 [dependencies]
-mercury-platform-core = { version = "4.12.5", path = "../../crates/platform-core" }
+mercury-platform-core = { version = "4.12.6", path = "../../crates/platform-core" }
 async-trait = "0.1"
 log = "0.4"
 rmpv = { version = "1", features = ["with-serde"] }

--- a/memory/sessions/2026-09-10-150848.md
+++ b/memory/sessions/2026-09-10-150848.md
@@ -1,0 +1,32 @@
+# Session (2026-09-10T15:08:48.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**v4.12.6 release prep** (branch `release/v4.12.6`; lock-step with the Java
+engine's v4.12.6 prepared the same morning). Version sweep 4.12.5 → 4.12.6:
+the workspace version and every inter-crate pin (event-script's platform-core
++ macros pins, knowledge-graph's three pins, platform-core's macros pin,
+extensions/minigraph-state-redis deliberately included) plus the Cargo.lock
+refresh (12 crate versions) via a workspace build.
+
+CHANGELOG rolls to Version 4.12.6, 9/10/2026 — Added: the
+f:camelCase/f:snakeCase key-normalization plugins (Increment 115) and the
+stepwise traversal logging as structured records (Increments 111 + 114);
+Fixed: the temp graph-model endpoint 404 (Increment 112); Changed: the
+Playground webapp lock-step arcs — the Java PR #341 UX modernization mirror
+(Increment 110) and the UI's switch to the live session graph as its single
+source (Increment 113). Contents = merged PRs #247–#252.
+
+Gates: `cargo build --workspace` clean on the swept versions; full
+`cargo test --workspace` run for release verification (CI arbitrates any
+local contention flake, per the established lesson).
+
+## Memory References
+
+- eric-release-rhythm-rust (consulted — prep only: branch/sweep/CHANGELOG/
+  build verification; PR-open, merge, tag and crates.io publish are each
+  Eric's gates)
+- inv-telemetry-presentation-parity (consulted — the release ships lock-step
+  with Java v4.12.6, same-day, as every release since graduation)


### PR DESCRIPTION
## What's new in 4.12.6

Lock-step with the Java engine's v4.12.6 (Increments 110–115):

- **Added**: `f:camelCase` / `f:snakeCase` key-normalization simple plugins (identical algorithm and error messages as the Java engine); stepwise traversal logging as INFO structured records `{id, text, graph}` with trace-id correlation, gated by `graph.traversal.log`.
- **Fixed**: the temp graph-model endpoint answers 404 (was 400) for a missing or expired draft.
- **Changed**: Playground webapp lock-step — the UX modernization mirror (Java PR #341) and the UI's switch to the live session graph as its single source; bundle rebuilt.

All seven mercury-* crates publish at 4.12.6.