### PR TITLE
docs: the Mercury Family — home button, Orientation page, two-column home

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -18,3 +18,12 @@
   overflow-wrap: break-word;
   white-space: normal;
 }
+
+/* Home hero buttons — compact size so all four ("Get started" through
+ * "The Mercury Family") fit the content column on one row. Horizontal
+ * padding is em-based, so it scales down with the font size. */
+.md-typeset .hero-buttons .md-button {
+  font-size: 0.64rem;
+  padding: 0.5em 1.4em;
+  white-space: nowrap;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - navigation
+---
+
 # Mercury Composable for Rust
 
 Mercury Composable lets you build backend applications as **composable, event-driven systems** —
@@ -9,9 +14,12 @@ realized here on **tokio** async/await, with the canonical
 [Java engine](https://accenture.github.io/mercury-composable/) as the behavior specification —
 same three layers, same flow YAML, behavior-synced release by release.
 
+<div class="hero-buttons" markdown>
 [Get started](guides/getting-started.md){ .md-button .md-button--primary }
 [Read the white paper](https://accenture.github.io/mercury/mercury-story/){ .md-button }
 [View the deck](https://accenture.github.io/mercury/presentations/mercury-story.html){ .md-button }
+[The Mercury Family](mercury-family.md){ .md-button }
+</div>
 
 *The white paper — **Intent-Driven Development and the Architecture of Human-AI Collaboration** —
 presents the collaboration model the AI era needs and the Mercury story that proved it: shared

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ same three layers, same flow YAML, behavior-synced release by release.
 [Get started](guides/getting-started.md){ .md-button .md-button--primary }
 [Read the white paper](https://accenture.github.io/mercury/mercury-story/){ .md-button }
 [View the deck](https://accenture.github.io/mercury/presentations/mercury-story.html){ .md-button }
-[The Mercury Family](mercury-family.md){ .md-button }
+[The Mercury Family](https://accenture.github.io/mercury/mercury-family/){ .md-button }
 </div>
 
 *The white paper — **Intent-Driven Development and the Architecture of Human-AI Collaboration** —

--- a/docs/mercury-family.md
+++ b/docs/mercury-family.md
@@ -1,0 +1,46 @@
+# The Mercury Family
+
+**Advanced software foundations for human–AI collaboration** — Accenture open source,
+Apache-2.0.
+
+Mercury is a family of open-source foundations for building software *with* AI, not merely
+faster: composable engines whose applications are assembled from self-contained functions and
+YAML-configured event flows — a shape that human developers and AI agents read equally well —
+plus a shared memory layer that keeps every human and every AI agent on a project oriented on
+the same intent and state.
+
+## Members
+
+| Member | Role | Repository | Documentation |
+| --- | --- | --- | --- |
+| **agent-memory** | Vendor-neutral shared AI memory + cognitive loop — no-code, markdown-only. Gives any repository one committed `memory/` that every AI agent and every contributor shares, with deterministic decay, supersession and a human-gated intent trace. Joined the family September 10, 2026. | [Accenture/mercury-go](https://github.com/Accenture/mercury-go) | [accenture.github.io/mercury-go](https://accenture.github.io/mercury-go/) |
+| **mercury-composable** | The Java engine — composable, event-driven applications in three layers: Platform Core, Event Script, Active Knowledge Graph. | [Accenture/mercury-composable](https://github.com/Accenture/mercury-composable) | [accenture.github.io/mercury-composable](https://accenture.github.io/mercury-composable/) |
+| **mercury** | The Rust engine — a twin implementation of mercury-composable: same three layers, same flow YAML (flow files port unchanged). | [Accenture/mercury](https://github.com/Accenture/mercury) | [accenture.github.io/mercury](https://accenture.github.io/mercury/) |
+| **mercury-python** | Python language pack — write composable functions in Python and call them from flows and knowledge graphs. | [Accenture/mercury-python](https://github.com/Accenture/mercury-python) | [accenture.github.io/mercury-python](https://accenture.github.io/mercury-python/) |
+| **mercury-nodejs** | Node.js language pack — write composable functions in Node.js and call them from flows and knowledge graphs. | [Accenture/mercury-nodejs](https://github.com/Accenture/mercury-nodejs) | [accenture.github.io/mercury-nodejs](https://accenture.github.io/mercury-nodejs/) |
+
+## How the pieces fit
+
+- The **engines** (mercury-composable, mercury) run the application: functions addressed by
+  route name exchange immutable events, YAML flows sequence them, and a knowledge graph
+  provides the semantic layer.
+- The **language packs** (mercury-python, mercury-nodejs) extend the engines so functions can
+  be written in Python or Node.js and called from the same flows and graphs.
+- **agent-memory** carries the *project's* memory — Vision, Blueprint, continuity, session
+  records, architecture decisions — so the humans and AI agents building on the engines
+  orient on purpose and state, not only on API shape. Every Mercury repository is itself
+  AI-enabled with agent-memory: the family uses its own memory layer.
+
+## Using the brand
+
+- **Short form:** *the Mercury family — advanced software foundations for human–AI collaboration.*
+- **Member sentence** (for a member repository's README or site footer):
+
+> Part of the **Mercury family** — Accenture's open-source foundations for human–AI
+> collaboration: [agent-memory](https://accenture.github.io/mercury-go/) ·
+> [mercury-composable](https://accenture.github.io/mercury-composable/) ·
+> [mercury](https://accenture.github.io/mercury/) ·
+> [mercury-python](https://accenture.github.io/mercury-python/) ·
+> [mercury-nodejs](https://accenture.github.io/mercury-nodejs/).
+
+All members are published by Accenture under the Apache License 2.0.

--- a/memory/sessions/2026-09-10-215302.md
+++ b/memory/sessions/2026-09-10-215302.md
@@ -1,0 +1,31 @@
+# Session (2026-09-10T21:53:02.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Docs: the Mercury Family lands on the site** (Eric's request, following
+agent-memory's promotion into the family at github.com/Accenture/mercury-go);
+lock-step with the Java twin:
+
+- `docs/mercury-family.md` — the family page, copied byte-identical from the
+  canonical mercury-go `docs/mercury-family.md` (members table, how the
+  pieces fit, brand usage).
+- The home page carries a fourth hero button, "The Mercury Family", matching
+  the agent-memory home. Eric's constraint: the top nav tab bar has reached
+  its maximum rendered width — the page joins the nav UNDER the Orientation
+  tab, never as a new top-level tab.
+- The four hero buttons got a compact size (the `.hero-buttons` block in
+  `docs/css/extra.css`) so all four fit the content column on one row.
+- The home page went two-column (`hide: navigation` front matter, new to
+  this index.md) per Eric's layout-consistency request.
+
+Verified: `scripts/check-llms-links.py` and `scripts/check-doc-claims.py`
+pass, `mkdocs build --strict` is green (the docs CI gate), and live
+`mkdocs serve` screenshots confirm the one-row button fit, the two-column
+home, and the family page under Orientation with an unchanged top tab bar.
+
+## Memory References
+
+- eric-release-rhythm-rust (consulted — branch/commit/push and PR text
+  prepared; PR-open and merge stay Eric's steps)

--- a/memory/sessions/2026-09-10-215302.md
+++ b/memory/sessions/2026-09-10-215302.md
@@ -25,6 +25,19 @@ pass, `mkdocs build --strict` is green (the docs CI gate), and live
 `mkdocs serve` screenshots confirm the one-row button fit, the two-column
 home, and the family page under Orientation with an unchanged top tab bar.
 
+**Follow-up (same session): PR CI (rust.yml test job) caught a
+packaged-contract constraint the docs gates don't see.** `docs/index.md` is
+packaged into the AI contract snapshot as `references/index.md`
+(`resources/skill/files.list`), and the snapshot fails closed on a relative
+link that leaves the closure — `mercury-family.md` is deliberately NOT
+packaged (brand/orientation material, outside the technical contract, same
+reasoning as its exclusion from llms.txt). Fix: the family button links the
+published site URL absolutely — the same precedent as the white-paper and
+deck buttons on the same page. Verified locally:
+`cargo test -p ai-contract-provider --test endpoints_e2e` green; the Java
+twin's module tests green. Durable rule of thumb: a relative link on the
+home page must stay inside the contract's `files.list` closure.
+
 ## Memory References
 
 - eric-release-rhythm-rust (consulted — branch/commit/push and PR text

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
   - Orientation:
       - Getting Started: guides/getting-started.md
       - Intent-Driven Development (white paper): mercury-story.md
+      - The Mercury Family: mercury-family.md
   - Foundations:
       - Architecture: guides/architecture.md
       - Methodology: guides/methodology.md


### PR DESCRIPTION
## What

The Mercury Family arrives on the documentation site, following agent-memory's promotion into the family (github.com/Accenture/mercury-go):

- New page `docs/mercury-family.md` — a byte-identical copy of the canonical family page from mercury-go: the five members, how the pieces fit, and brand usage.
- The home page gains a fourth hero button, **The Mercury Family**, matching the agent-memory home.
- Nav: the page sits **under the Orientation tab** — the top tab bar has reached its maximum rendered width, so no new top-level tab.
- The four hero buttons are compact-sized (`.hero-buttons` in `docs/css/extra.css`) so all four fit the content column on one row.
- The home page becomes **two-column** (`hide: navigation` front matter) for layout consistency with the agent-memory home.

## Why

Every Mercury-family member should surface the family from its home page, so a reader landing on any member discovers the whole foundation set. Lock-step with Accenture/mercury-composable (same change).

Verified: `check-llms-links.py` and `check-doc-claims.py` pass, `mkdocs build --strict` is green, and the rendering was checked live — one-row buttons, two-column home, family page under Orientation, unchanged tab bar.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>