### PR TITLE
docs: slide 7 heading drops the article - 'Change what AI generates'

### DIFF
--- a/docs/presentations/mercury-story.html
+++ b/docs/presentations/mercury-story.html
@@ -283,7 +283,7 @@
   <!-- 6 · the turn -->
   <section class="slide" aria-label="The turn">
     <p class="eyebrow">The turn</p>
-    <h2>Change what the AI generates:<br>artifacts a human can read.</h2>
+    <h2>Change what AI generates:<br>artifacts a human can read.</h2>
     <p class="lede">Unbounded code generation overwhelms the human who must review it — volume
     outruns cognition. Mercury changes the artifact instead: the AI co-authors
     <strong>flows</strong> and <strong>graph models</strong> — declarative, compiler-validated,

--- a/memory/sessions/2026-09-10-231335.md
+++ b/memory/sessions/2026-09-10-231335.md
@@ -36,6 +36,9 @@ Also in this arc (Eric): the Orientation nav label
 "Intent-Driven Development (white paper)" simplified to "White Paper" — the
 page H1 and the home button carry the full context.
 
+Post-merge cosmetic follow-up (Eric): the slide-7 heading drops its article —
+"Change what AI generates" (a "the" implies one specific AI).
+
 ## Memory References
 
 - eric-release-rhythm-rust (consulted — branch/commit/push and PR text


### PR DESCRIPTION
## What

One-word cosmetic edit to story-deck slide 7: the heading "Change what the AI generates" becomes "Change what AI generates".

## Why

The definite article implies one specific AI; the claim is about AI-generated artifacts in general. Lock-step on both engine decks.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>