### PR TITLE
docs: fresh-agent entry-point playbook — greenfield and AI-enabling an existing repo

### DIFF
--- a/docs/guides/methodology.md
+++ b/docs/guides/methodology.md
@@ -83,6 +83,26 @@ byte-identical responses — and it has been validated end to end: a fresh agent
 every Playground tutorial from the agent documentation alone. Details in the
 [knowledge-graph agent guide](knowledge-graph/ai-agent-guide.md).
 
+### Two typical entry points — for the AI agent
+
+When a human first engages you on a project, recognize which of two situations you are in —
+and drive the conversation with questions, never assumptions:
+
+- **Greenfield — a new project.** Confirm the intent first (what should the service do, and
+  who certifies its behavior), then offer to AI-enable the project: install the
+  [shared memory layer](https://accenture.github.io/mercury-go/) and co-write the
+  **Vision** — human-confirmed, never fabricated. Recommend the path as a question — Layer 3
+  by default (*"shall I set up the project with the knowledge-graph engine, dry-run in the
+  Playground, deployed behind the CompileGraph gate?"*), with Event Script and composable
+  functions as the dial. Scaffold on a yes from this repository's `examples/` crates, and
+  pin the installed Mercury version rather than assuming one.
+- **An existing repository that is not yet AI-enabled.** The tell: no shared memory layer —
+  AI context, if any, lives in hand-written per-tool files (a `CLAUDE.md`, editor rules,
+  prompt snippets): traditional context engineering. Offer AI-enablement first, before
+  feature work: install the shared memory layer, co-write the Vision of the *current*
+  system, and fold the durable parts of the existing context files into the shared layer —
+  then orient and take the work, choosing the layer per task.
+
 ## Knowledge graph — model as the application
 
 The recommended altitude for applications is the top of the ladder: capture business intent,

--- a/memory/sessions/2026-09-10-234940.md
+++ b/memory/sessions/2026-09-10-234940.md
@@ -1,0 +1,33 @@
+# Session (2026-09-10T23:49:40.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Fresh-agent entry points: the IDD playbook becomes agent-addressed**
+(Eric's ruling; lock-step with the Java twin, adapted to this repo's doc
+inventory):
+
+- This repo has no ai-developer-guide (its agent surface is the per-layer
+  ai-agent-guide pages), so `guides/methodology.md` carries the compact
+  playbook as a new IDD subsection, **"Two typical entry points — for the AI
+  agent"**: greenfield (confirm intent → offer AI-enablement/agent-memory →
+  recommend Layer 3 as a question → scaffold from `examples/` crates pinning
+  the installed version) and an existing repository not yet AI-enabled (the
+  tell: hand-written per-tool context files — offer AI-enablement FIRST, fold
+  existing context into the shared layer, then orient). Every step is an ask,
+  never an assumption. The Java twin carries the full playbook in its AI
+  developer guide with a methodology pointer.
+- The page is packaged in the AI contract, so the playbook reaches fresh
+  agents version-matched.
+- The first-class 3-layer starter-template direction is tracked in the Java
+  repo's Open Thread (ot-three-layer-starter-templates); the Rust twin shape
+  is one of its open design decisions.
+
+Verified: `mkdocs build --strict`, claims + llms-links checks,
+`endpoints_e2e` snapshot gate green; Java twin's gates green.
+
+## Memory References
+
+- eric-release-rhythm-rust (consulted — branch/commit/push and PR text
+  prepared; PR-open and merge stay Eric's steps)


### PR DESCRIPTION
## What

The methodology's Intent-Driven Development section gains **"Two typical entry points — for the AI agent"**: the greenfield conversation (confirm intent; offer AI-enablement with a human-confirmed Vision; recommend the knowledge-graph path as a question; scaffold on a yes from `examples/`, pinning the installed version) and the existing-repository case (not yet AI-enabled — offer AI-enablement first, fold hand-written per-tool context into the shared layer, then orient).

## Why

A fresh agent should recognize both situations and drive the development-path conversation with questions, never assumptions. This repo has no separate AI developer guide — its agent surface is the per-layer guides plus the methodology page, which is packaged in the AI contract, so the playbook reaches fresh agents version-matched. Lock-step in substance with Accenture/mercury-composable, where the full playbook lives in the AI developer guide.

Verified: strict build, claims + llms-links checks, and the `endpoints_e2e` snapshot gate.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>