### PR TITLE
feat: three-layer starter templates — copy-out projects for new applications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,6 +1550,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "starter-flow"
+version = "4.12.6"
+dependencies = [
+ "async-trait",
+ "log",
+ "mercury-event-script",
+ "mercury-platform-core",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "starter-function"
+version = "4.12.6"
+dependencies = [
+ "async-trait",
+ "log",
+ "mercury-platform-core",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "starter-graph"
+version = "4.12.6"
+dependencies = [
+ "async-trait",
+ "log",
+ "mercury-event-script",
+ "mercury-knowledge-graph",
+ "mercury-platform-core",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ members = [
     "examples/hello-world",
     "examples/hello-flow",
     "examples/minigraph-playground",
+    # starter templates for the three layers (copy one out to begin a new
+    # project; explicit metadata - no workspace inheritance - so a copy
+    # builds as-is, listed here so every build proves they stay current)
+    "templates/starter-function",
+    "templates/starter-flow",
+    "templates/starter-graph",
 ]
 
 [workspace.package]

--- a/docs/guides/ai-developer-guide.md
+++ b/docs/guides/ai-developer-guide.md
@@ -77,17 +77,20 @@ conversation with questions, never assumptions.
    dial explicitly: Event Script when the shape is a known transaction flow; a composable
    function when the need is genuinely custom logic
    ([Choosing the right layer](#layer-choice)).
-4. **Scaffold on a yes — never on silence.** Start from the chosen layer's reference
-   application in `examples/` —
-   [`hello-world`](https://github.com/Accenture/mercury/tree/main/examples/hello-world)
+4. **Scaffold on a yes — never on silence.** Copy the chosen layer's starter template out
+   of the repository's `templates/` directory —
+   [`starter-function`](https://github.com/Accenture/mercury/tree/main/templates/starter-function)
    (Layer 1 functions),
-   [`hello-flow`](https://github.com/Accenture/mercury/tree/main/examples/hello-flow)
+   [`starter-flow`](https://github.com/Accenture/mercury/tree/main/templates/starter-flow)
    (Layer 2 flows), or
-   [`minigraph-playground`](https://github.com/Accenture/mercury/tree/main/examples/minigraph-playground)
-   (Layer 3 graphs with the Playground) — the Layer 1 guide carries a
-   [trim manifest](event-driven/ai-agent-guide.md#scaffolding) for deriving a project from
-   the example. Pin the Mercury version the environment reports
-   (`GET :8999/api/discovery` → `mercury_version`) rather than assuming one.
+   [`starter-graph`](https://github.com/Accenture/mercury/tree/main/templates/starter-graph)
+   (Layer 3, a zero-code knowledge-graph application). Each builds standalone after
+   deleting the in-repo `path` keys in its `Cargo.toml` — the pinned versions then
+   resolve from crates.io. Pin the Mercury version the environment reports
+   (`GET :8999/api/discovery` → `mercury_version`) rather than assuming one; the
+   reference applications in `examples/` remain the richer worked demos, and the Layer 1
+   guide's [trim manifest](event-driven/ai-agent-guide.md#scaffolding) still covers
+   deriving from those.
 5. **Hand off to the layer's guide.** The [DSL-specific AI guides](#dsl-guides) carry the
    authoring contracts from here.
 

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -107,7 +107,14 @@ ported — e.g. stateless functions, HTTP-style status codes.)*
 - **`cargo fmt` + `cargo clippy --all-targets` clean** is part of "done" for every change
   (default settings, no custom rustfmt.toml yet).
 - **Apache-2.0 header** comment on every source file (ported from the Java originals'
-  header style).
+  header style). EXCEPTION ruled by Eric 2026-09-11: `templates/*` starter sources carry a
+  ONE-LINE scaffold attribution instead — templates seed field applications that are not
+  open source, so the full Accenture copyright header must not ride into user code.
+- **Release version bumps must include the starter templates (2026-09-11).** Each
+  `templates/*/Cargo.toml` carries an EXPLICIT `version = "<version>"` and mercury-* dep
+  pins (deliberately NOT workspace-inherited, so a copied-out template builds as-is after
+  deleting the in-repo `path` keys) — the release edit list grows from 5 manifests to 8.
+  <!-- id: conv-template-version-sweep-rust | created: 2026-09-11 | last_used: 2026-09-11 | uses: 1 | tier: working | origin: 2026-09-11-005808 -->
 - Each ported module's `//!` doc names the **Java class it ports** (e.g.
   `org.platformlambda.core.util.ConfigReader`) so reviewers can diff behavior side-by-side.
 - **Tests:** unit tests in-module (`#[cfg(test)]`), integration tests in `tests/` with

--- a/memory/instructions.md
+++ b/memory/instructions.md
@@ -40,6 +40,8 @@ crates/
   knowledge-graph-macros ← #[fetch_feature]
   minigraph-state-redis  ← pluggable suspend/resume state store
 examples/<name>/         ← standalone workspace crates, never cargo examples in a library crate
+templates/<name>/        ← copy-out starter projects for the three layers (starter-function,
+                           starter-flow, starter-graph — workspace-built; a copy drops the path keys)
 system/ai-contract-provider ← serves the version-matched AI documentation contract
 docs/ (guides, llms.txt, INCREMENTS.md)   draft-design-specs/   scripts/
 ```

--- a/memory/sessions/2026-09-11-005808.md
+++ b/memory/sessions/2026-09-11-005808.md
@@ -1,0 +1,44 @@
+# Session (2026-09-11T00:58:08.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**The three-layer starter templates land** (lock-step with the Java twin; Eric's
+rulings: in-repo `templates/`, AGENTS.md offers AI-enablement, one-line scaffold
+attribution instead of the full license header):
+
+- **`templates/starter-function` / `starter-flow` / `starter-graph`** — copy-out
+  starter crates for the three layers, workspace members with EXPLICIT metadata
+  (no workspace inheritance) and `{ path, version }` dual deps: in-repo builds
+  use the path; a copied-out project deletes the `path` keys and the pinned
+  versions resolve from crates.io (recorded as
+  [[conv-template-version-sweep-rust]] — the release edit list grows to 8
+  manifests; also the header-convention EXCEPTION note).
+- Engine-truthful adaptations vs the Java twin: a `#[main_application]`
+  EntryPoint is REQUIRED (the auto_start_main! macro alone is just the
+  launcher); an unreferenced dependency's registration inventory is dropped by
+  the linker — starter-flow anchors event-script via
+  `flows::get_all_flows()` in its EntryPoint (the hello-flow pattern), and
+  starter-graph anchors knowledge-graph via `graphs::get_all_graphs()`; the
+  HTTP-facing function is `TypedFunction<AsyncHttpRequest, _>` (the
+  hello-world GreetingApi pattern — a service binding delivers the request
+  OBJECT, not the raw JSON body); the Rust engine provides the graph-executor
+  flow internally (no flows/ dir in starter-graph).
+- The Layer-2 flow YAML and the Layer-3 graph model are BYTE-IDENTICAL to the
+  Java templates' files — engine portability demonstrated inside the templates
+  themselves.
+- Playbook step 4 (ai-developer-guide) now scaffolds from the templates;
+  instructions.md structure tree gained `templates/`. Tests: each starter's
+  e2e suite green (`cargo test` trio) incl. the Layer-3 "compiled or 404" gate
+  case; clippy clean; strict docs build + claims/llms checks green. rust.yml
+  needs no change — workspace membership puts the templates in CI
+  automatically.
+
+## Memory References
+
+- conv-template-version-sweep-rust (created)
+- inv-never-couple-functions (consulted — template functions couple only by
+  route name; AGENTS.md states the contract)
+- eric-release-rhythm-rust (consulted — branch/commit/push and PR text
+  prepared; PR-open and merge stay Eric's steps)

--- a/templates/starter-flow/AGENTS.md
+++ b/templates/starter-flow/AGENTS.md
@@ -1,0 +1,20 @@
+# For AI agents
+
+This project was scaffolded from the mercury (Rust) `templates/starter-flow`
+template (Layer 2 — Event Script flows).
+
+1. **Orient first.** Read the
+   [AI developer guide](https://accenture.github.io/mercury/guides/ai-developer-guide/) —
+   it carries the mental model, the entry-point playbook, and the layer-choice tree.
+   If this repository is not yet AI-enabled, offer the human to install the
+   [shared memory layer](https://accenture.github.io/mercury-go/) and co-write the
+   Vision before feature work (the Vision is human-confirmed, never fabricated).
+2. **Authoring contract.** Orchestration lives in flow YAML
+   (see the [flow grammar](https://accenture.github.io/mercury/guides/event-script/flow-grammar/)
+   and the [Event Script AI agent guide](https://accenture.github.io/mercury/guides/event-script/ai-agent-guide/));
+   business logic lives in functions (`#[preload]` + `ComposableFunction`), coupled only
+   by route name. A REST flow binding needs both `service: "http.flow.adapter"` and `flow:`.
+3. **Copied out of the Mercury repo?** Delete the `path` keys in `Cargo.toml`; the
+   pinned versions resolve from crates.io.
+4. **Build and test:** `cargo test` / `cargo run`. The Mercury dependency version in
+   `Cargo.toml` is the source of truth; verify claims against it rather than assuming.

--- a/templates/starter-flow/Cargo.toml
+++ b/templates/starter-flow/Cargo.toml
@@ -1,0 +1,22 @@
+# Layer 2 starter template. Copy this directory out to begin a new project:
+# metadata is explicit (no workspace inheritance) so the copy builds as-is.
+# The Mercury release sweep updates the version literals.
+[package]
+name = "starter-flow"
+description = "Layer 2 starter - Event Script flows"
+version = "4.12.6"
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+
+[dependencies]
+# inside the Mercury repo the path is used; after copying the template out,
+# delete the `path` keys - the version then resolves from crates.io
+mercury-platform-core = { path = "../../crates/platform-core", version = "4.12.6" }
+mercury-event-script = { path = "../../crates/event-script", version = "4.12.6" }
+async-trait = "0.1"
+serde_json = "1"
+log = "0.4"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util"] }

--- a/templates/starter-flow/README.md
+++ b/templates/starter-flow/README.md
@@ -1,0 +1,50 @@
+# starter-flow — Layer 2 template
+
+A minimal Event Script application: an HTTP endpoint launches a flow that sequences two
+decoupled functions (`v1.validate.request` → `v1.make.greeting`) with declarative data
+mapping. The flow YAML is engine-portable — the same file runs on the Java engine. Copy
+this directory out of the Mercury repository to begin a new project.
+
+## After copying out
+
+The manifest uses an in-repo `path` for the Mercury crates. In your copy, delete the
+`path` keys in `Cargo.toml` — the pinned versions then resolve from crates.io:
+
+```toml
+mercury-platform-core = "4.12.6"
+mercury-event-script = "4.12.6"
+```
+
+## Build, test, run
+
+```bash
+cargo test
+cargo run
+```
+
+Then:
+
+```bash
+curl -s -X POST http://127.0.0.1:8302/api/greeting \
+     -H "content-type: application/json" \
+     -d '{"name": "Mercury"}'
+# → {"greeting": "Hello, Mercury", ...}
+```
+
+## What to look at
+
+| File | Role |
+|:---|:---|
+| `resources/flows/greeting-flow.yml` | The orchestration — task order and data mapping, no code |
+| `resources/flows.yaml` | Registry of active flows |
+| `resources/rest.yaml` | Binds `/api/greeting` to the flow (`service` + `flow`, both required) |
+| `src/main.rs` | The two functions — each knows nothing about the other |
+| `tests/greeting_flow_test.rs` | End-to-end flow test over HTTP |
+
+## Next steps
+
+- Grow the flow: add tasks, a `decision` branch, or an exception handler — see the
+  [Event Script syntax](https://accenture.github.io/mercury/guides/event-script/syntax/).
+- Modeling a whole service as a graph? Move up a layer — see the
+  [starter-graph](../starter-graph) template and the
+  [AI developer guide](https://accenture.github.io/mercury/guides/ai-developer-guide/).

--- a/templates/starter-flow/resources/application.yml
+++ b/templates/starter-flow/resources/application.yml
@@ -1,0 +1,9 @@
+# starter-flow - Layer 2 starter configuration
+application.name: starter-flow
+info.app.description: 'Layer 2 starter - Event Script flows'
+
+# REST automation serves rest.yaml; the flow engine loads flows.yaml — both
+# by their default locations in this resources/ folder.
+rest.automation: true
+# a distinct port so a running application never collides with unit tests
+rest.server.port: 8302

--- a/templates/starter-flow/resources/flows.yaml
+++ b/templates/starter-flow/resources/flows.yaml
@@ -1,0 +1,4 @@
+flows:
+  - 'greeting-flow.yml'
+
+location: 'classpath:/flows/'

--- a/templates/starter-flow/resources/flows/greeting-flow.yml
+++ b/templates/starter-flow/resources/flows/greeting-flow.yml
@@ -1,0 +1,31 @@
+#
+# Orchestration is configuration, not code: this flow sequences two decoupled
+# functions and maps data between them. Business logic stays in the functions.
+# Flow YAML is engine-portable - this same file runs on the Java engine.
+#
+flow:
+  id: 'greeting-flow'
+  description: 'Validate the request, then compose a greeting'
+  ttl: 10s
+
+first.task: 'v1.validate.request'
+
+tasks:
+  - input:
+      - 'input.body.name -> name'
+    process: 'v1.validate.request'
+    output:
+      - 'result.name -> model.name'
+    description: 'Reject requests without a name'
+    execution: sequential
+    next:
+      - 'v1.make.greeting'
+
+  - input:
+      - 'model.name -> name'
+    process: 'v1.make.greeting'
+    output:
+      - 'text(application/json) -> output.header.content-type'
+      - 'result -> output.body'
+    description: 'Compose the greeting from the state machine value'
+    execution: end

--- a/templates/starter-flow/resources/rest.yaml
+++ b/templates/starter-flow/resources/rest.yaml
@@ -1,0 +1,11 @@
+#
+# REST automation - a flow binding needs BOTH keys: 'service' selects the
+# flow adapter and 'flow' selects the flow to launch.
+#
+rest:
+  - service: "http.flow.adapter"
+    methods: ['POST']
+    url: "/api/greeting"
+    flow: 'greeting-flow'
+    timeout: 10s
+    tracing: true

--- a/templates/starter-flow/src/main.rs
+++ b/templates/starter-flow/src/main.rs
@@ -1,0 +1,82 @@
+// Scaffolded from Mercury's starter templates (https://github.com/Accenture/mercury, Apache-2.0)
+
+//! Layer 2 starter — an HTTP endpoint launches an Event Script flow that
+//! sequences two decoupled functions with declarative data mapping.
+//! Orchestration lives in resources/flows/greeting-flow.yml, never in code.
+//! Copy this template out of the Mercury repository to begin a new project
+//! (see README.md and AGENTS.md).
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use platform_core::{
+    main_application, preload, AppError, ComposableFunction, EntryPoint, EventEnvelope,
+};
+
+/// First task of greeting-flow: reject a request without a name. The flow's
+/// input data mapping delivers 'input.body.name' as the "name" key; business
+/// logic stays here, never in the flow YAML.
+#[preload(route = "v1.validate.request", instances = 10)]
+struct ValidateRequest;
+
+#[async_trait]
+impl ComposableFunction for ValidateRequest {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let body: serde_json::Value = input.body_as()?;
+        let name = body["name"].as_str().unwrap_or("").trim().to_string();
+        if name.is_empty() {
+            return Err(AppError::new(
+                400,
+                "Missing 'name' - send a JSON body {\"name\": \"...\"}",
+            ));
+        }
+        EventEnvelope::new().set_body(serde_json::json!({ "name": name }))
+    }
+}
+
+/// Second task of greeting-flow: compose the response. It knows nothing about
+/// the validator - the flow's state machine ('model.name') carries data
+/// between the decoupled tasks.
+#[preload(route = "v1.make.greeting", instances = 10)]
+struct MakeGreeting;
+
+#[async_trait]
+impl ComposableFunction for MakeGreeting {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        input: EventEnvelope,
+        _instance: usize,
+    ) -> Result<EventEnvelope, AppError> {
+        let body: serde_json::Value = input.body_as()?;
+        let name = body["name"].as_str().unwrap_or("");
+        EventEnvelope::new().set_body(serde_json::json!({
+            "greeting": format!("Hello, {name}"),
+            "served_by": "v1.make.greeting",
+        }))
+    }
+}
+
+#[main_application]
+struct StarterApp;
+
+#[async_trait]
+impl EntryPoint for StarterApp {
+    async fn start(&self, _args: &[String]) -> Result<(), AppError> {
+        // one-time application setup goes here; functions and flows are already
+        // registered (referencing the flow registry also anchors the event-script
+        // crate into the link-time inventory)
+        log::info!(
+            "starter-flow ready: {} flow(s) compiled",
+            event_script::flows::get_all_flows().len()
+        );
+        Ok(())
+    }
+}
+
+platform_core::auto_start_main!();

--- a/templates/starter-flow/tests/greeting_flow_test.rs
+++ b/templates/starter-flow/tests/greeting_flow_test.rs
@@ -1,0 +1,58 @@
+// Scaffolded from Mercury's starter templates (https://github.com/Accenture/mercury, Apache-2.0)
+
+//! Boots the whole starter once and drives greeting-flow end to end through
+//! the REST endpoint - the happy path and the validation failure.
+
+use platform_core::{automation, overrides, AutoStart};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+// The application under test is a BIN crate — include its source so the
+// link-time inventory in this test binary carries the app's functions.
+#[allow(dead_code)]
+#[path = "../src/main.rs"]
+mod app;
+
+async fn http_post(port: u16, path: &str, body: &str) -> (u16, String) {
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("connect");
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: localhost\r\ncontent-type: application/json\r\n\
+         accept: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(request.as_bytes()).await.expect("write");
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).await.expect("read");
+    let text = String::from_utf8_lossy(&raw).to_string();
+    let (head, payload) = text.split_once("\r\n\r\n").unwrap_or((text.as_str(), ""));
+    let status: u16 = head
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse().ok())
+        .unwrap_or_else(|| panic!("status code missing in: {text:?}"));
+    (status, payload.to_string())
+}
+
+// One test function on purpose: the app boots ONCE per process (AutoStart is
+// a run-once lifecycle), so all cases run in a single sequential test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn greeting_flow_end_to_end() {
+    overrides::set("rest.server.port", "0"); // an ephemeral port for the test
+    AutoStart::main(vec![]).await.expect("app lifecycle");
+    let port = automation::server_address().expect("server started").port();
+
+    // happy path: the flow validates, then composes the greeting
+    let (status, payload) = http_post(port, "/api/greeting", r#"{"name": "Mercury"}"#).await;
+    assert_eq!(status, 200, "unexpected: {payload}");
+    assert!(payload.contains("Hello, Mercury"), "unexpected: {payload}");
+    assert!(
+        payload.contains("v1.make.greeting"),
+        "unexpected: {payload}"
+    );
+
+    // validation failure: the first task rejects and the flow aborts with 400
+    let (status, payload) = http_post(port, "/api/greeting", r#"{"unexpected": "payload"}"#).await;
+    assert_eq!(status, 400, "unexpected: {payload}");
+}

--- a/templates/starter-function/AGENTS.md
+++ b/templates/starter-function/AGENTS.md
@@ -1,0 +1,20 @@
+# For AI agents
+
+This project was scaffolded from the mercury (Rust) `templates/starter-function`
+template (Layer 1 — composable functions with REST automation).
+
+1. **Orient first.** Read the
+   [AI developer guide](https://accenture.github.io/mercury/guides/ai-developer-guide/) —
+   it carries the mental model, the entry-point playbook, and the layer-choice tree.
+   If this repository is not yet AI-enabled, offer the human to install the
+   [shared memory layer](https://accenture.github.io/mercury-go/) and co-write the
+   Vision before feature work (the Vision is human-confirmed, never fabricated).
+2. **Authoring contract.** Functions follow `#[preload]` + `ComposableFunction` /
+   `TypedFunction` (the
+   [Layer 1 AI agent guide](https://accenture.github.io/mercury/guides/event-driven/ai-agent-guide/)
+   is the full contract); couple only by route name and `EventEnvelope` — never import
+   another user function. HTTP endpoints are declared in `rest.yaml`.
+3. **Copied out of the Mercury repo?** Delete the `path` keys in `Cargo.toml`; the
+   pinned versions resolve from crates.io.
+4. **Build and test:** `cargo test` / `cargo run`. The Mercury dependency version in
+   `Cargo.toml` is the source of truth; verify claims against it rather than assuming.

--- a/templates/starter-function/Cargo.toml
+++ b/templates/starter-function/Cargo.toml
@@ -1,0 +1,21 @@
+# Layer 1 starter template. Copy this directory out to begin a new project:
+# metadata is explicit (no workspace inheritance) so the copy builds as-is.
+# The Mercury release sweep updates the version literals.
+[package]
+name = "starter-function"
+description = "Layer 1 starter - composable functions with REST automation"
+version = "4.12.6"
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+
+[dependencies]
+# inside the Mercury repo the path is used; after copying the template out,
+# delete the `path` keys - the version then resolves from crates.io
+mercury-platform-core = { path = "../../crates/platform-core", version = "4.12.6" }
+async-trait = "0.1"
+serde_json = "1"
+log = "0.4"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util"] }

--- a/templates/starter-function/README.md
+++ b/templates/starter-function/README.md
@@ -1,0 +1,47 @@
+# starter-function — Layer 1 template
+
+A minimal composable application: one function (`v1.greeting`) exposed over HTTP by
+REST automation. Copy this directory out of the Mercury repository to begin a new
+project.
+
+## After copying out
+
+The manifest uses an in-repo `path` for the Mercury crates. In your copy, delete the
+`path` keys in `Cargo.toml` — the pinned versions then resolve from crates.io:
+
+```toml
+mercury-platform-core = "4.12.6"
+```
+
+## Build, test, run
+
+```bash
+cargo test
+cargo run
+```
+
+Then:
+
+```bash
+curl -s -X POST http://127.0.0.1:8301/api/greeting \
+     -H "content-type: application/json" \
+     -d '{"name": "Mercury"}'
+# → {"greeting": "Hello, Mercury", ...}
+```
+
+## What to look at
+
+| File | Role |
+|:---|:---|
+| `src/main.rs` | The composable function (`#[preload]`) — addressed only by its route name |
+| `resources/rest.yaml` | Maps `/api/greeting` to the function; add your endpoints here |
+| `resources/application.yml` | App name, port, `rest.automation` |
+| `tests/greeting_test.rs` | Direct RPC test + end-to-end HTTP test |
+
+## Next steps
+
+- Add functions (`#[preload]` + `ComposableFunction` or `TypedFunction`) and map them
+  in `rest.yaml`.
+- Ready to orchestrate several functions? Move up a layer — see the
+  [starter-flow](../starter-flow) template and the
+  [AI developer guide](https://accenture.github.io/mercury/guides/ai-developer-guide/).

--- a/templates/starter-function/resources/application.yml
+++ b/templates/starter-function/resources/application.yml
@@ -1,0 +1,8 @@
+# starter-function - Layer 1 starter configuration
+application.name: starter-function
+info.app.description: 'Layer 1 starter - composable functions with REST automation'
+
+# REST automation serves rest.yaml endpoints over HTTP
+rest.automation: true
+# a distinct port so a running application never collides with unit tests
+rest.server.port: 8301

--- a/templates/starter-function/resources/rest.yaml
+++ b/templates/starter-function/resources/rest.yaml
@@ -1,0 +1,10 @@
+#
+# REST automation - declare HTTP endpoints without writing controllers.
+# Each entry maps a URL to a function's route name.
+#
+rest:
+  - service: "v1.greeting"
+    methods: ['GET', 'POST']
+    url: "/api/greeting"
+    timeout: 10s
+    tracing: true

--- a/templates/starter-function/src/main.rs
+++ b/templates/starter-function/src/main.rs
@@ -1,0 +1,65 @@
+// Scaffolded from Mercury's starter templates (https://github.com/Accenture/mercury, Apache-2.0)
+
+//! Layer 1 starter — one composable function exposed over HTTP by REST
+//! automation. Copy this template out of the Mercury repository to begin a
+//! new project (see README.md and AGENTS.md).
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use platform_core::automation::AsyncHttpRequest;
+use platform_core::{main_application, preload, AppError, EntryPoint, TypedFunction};
+
+/// The starter's single composable function. It is addressed only by its
+/// route name ("v1.greeting") - rest.yaml maps /api/greeting to it, and the
+/// same function could join an Event Script flow or a knowledge graph
+/// without a code change. The typed AsyncHttpRequest input carries the HTTP
+/// request from the REST edge (query, path, headers, body).
+#[preload(route = "v1.greeting", instances = 10, typed)]
+struct Greeting;
+
+#[async_trait]
+impl TypedFunction<AsyncHttpRequest, serde_json::Value> for Greeting {
+    async fn handle_event(
+        &self,
+        _headers: HashMap<String, String>,
+        request: AsyncHttpRequest,
+        instance: usize,
+    ) -> Result<serde_json::Value, AppError> {
+        let name = request
+            .query_parameter("name")
+            .or_else(|| {
+                request
+                    .body_as::<serde_json::Value>()
+                    .ok()
+                    .and_then(|body| body["name"].as_str().map(str::to_string))
+            })
+            .unwrap_or_default();
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(AppError::new(
+                400,
+                "Missing 'name' - send ?name=... or a JSON body {\"name\": \"...\"}",
+            ));
+        }
+        Ok(serde_json::json!({
+            "greeting": format!("Hello, {name}"),
+            "served_by": "v1.greeting",
+            "instance": instance,
+        }))
+    }
+}
+
+#[main_application]
+struct StarterApp;
+
+#[async_trait]
+impl EntryPoint for StarterApp {
+    async fn start(&self, _args: &[String]) -> Result<(), AppError> {
+        // one-time application setup goes here; functions are already registered
+        log::info!("Started");
+        Ok(())
+    }
+}
+
+platform_core::auto_start_main!();

--- a/templates/starter-function/tests/greeting_test.rs
+++ b/templates/starter-function/tests/greeting_test.rs
@@ -1,0 +1,61 @@
+// Scaffolded from Mercury's starter templates (https://github.com/Accenture/mercury, Apache-2.0)
+
+//! Boots the whole starter once and exercises the greeting end to end
+//! through the REST edge: the JSON-body path, the query-parameter path,
+//! and the validation failure.
+
+use platform_core::{automation, overrides, AutoStart};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+// The application under test is a BIN crate — include its source so the
+// link-time inventory in this test binary carries the app's functions.
+#[allow(dead_code)]
+#[path = "../src/main.rs"]
+mod app;
+
+async fn http_call(port: u16, request_head: &str, body: &str) -> (u16, String) {
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("connect");
+    let request = format!(
+        "{request_head} HTTP/1.1\r\nHost: localhost\r\ncontent-type: application/json\r\n\
+         accept: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(request.as_bytes()).await.expect("write");
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).await.expect("read");
+    let text = String::from_utf8_lossy(&raw).to_string();
+    let (head, payload) = text.split_once("\r\n\r\n").unwrap_or((text.as_str(), ""));
+    let status: u16 = head
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse().ok())
+        .unwrap_or_else(|| panic!("status code missing in: {text:?}"));
+    (status, payload.to_string())
+}
+
+// One test function on purpose: the app boots ONCE per process (AutoStart is
+// a run-once lifecycle), so all cases run in a single sequential test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn greeting_end_to_end() {
+    overrides::set("rest.server.port", "0"); // an ephemeral port for the test
+    AutoStart::main(vec![]).await.expect("app lifecycle");
+    let port = automation::server_address().expect("server started").port();
+
+    // 1. JSON body path
+    let (status, payload) = http_call(port, "POST /api/greeting", r#"{"name": "Mercury"}"#).await;
+    assert_eq!(status, 200, "unexpected: {payload}");
+    assert!(payload.contains("Hello, Mercury"), "unexpected: {payload}");
+
+    // 2. query-parameter path
+    let (status, payload) = http_call(port, "GET /api/greeting?name=Mercury", "").await;
+    assert_eq!(status, 200, "unexpected: {payload}");
+    assert!(payload.contains("Hello, Mercury"), "unexpected: {payload}");
+
+    // 3. validation: a request without a name is rejected with 400
+    let (status, payload) = http_call(port, "POST /api/greeting", r#"{}"#).await;
+    assert_eq!(status, 400, "unexpected: {payload}");
+    assert!(payload.contains("Missing 'name'"), "unexpected: {payload}");
+}

--- a/templates/starter-graph/AGENTS.md
+++ b/templates/starter-graph/AGENTS.md
@@ -1,0 +1,22 @@
+# For AI agents
+
+This project was scaffolded from the mercury (Rust) `templates/starter-graph`
+template (Layer 3 — Active Knowledge Graph as the application).
+
+1. **Orient first.** Read the
+   [AI developer guide](https://accenture.github.io/mercury/guides/ai-developer-guide/) —
+   it carries the mental model, the entry-point playbook, and the layer-choice tree.
+   If this repository is not yet AI-enabled, offer the human to install the
+   [shared memory layer](https://accenture.github.io/mercury-go/) and co-write the
+   Vision before feature work (the Vision is human-confirmed, never fabricated).
+2. **Authoring contract.** The graph model IS the application. Author models with the
+   [MiniGraph command grammar](https://accenture.github.io/mercury/guides/knowledge-graph/command-reference/)
+   and the
+   [knowledge-graph AI agent guide](https://accenture.github.io/mercury/guides/knowledge-graph/ai-agent-guide/);
+   deployment is governed — only graphs listed in `graphs.yaml` that pass the
+   CompileGraph gate at startup are executable (anything else answers 404). Custom
+   logic goes into skill functions (`#[preload]`), never into ad-hoc endpoints.
+3. **Copied out of the Mercury repo?** Delete the `path` keys in `Cargo.toml`; the
+   pinned versions resolve from crates.io.
+4. **Build and test:** `cargo test` / `cargo run`. The Mercury dependency version in
+   `Cargo.toml` is the source of truth; verify claims against it rather than assuming.

--- a/templates/starter-graph/Cargo.toml
+++ b/templates/starter-graph/Cargo.toml
@@ -1,0 +1,23 @@
+# Layer 3 starter template. Copy this directory out to begin a new project:
+# metadata is explicit (no workspace inheritance) so the copy builds as-is.
+# The Mercury release sweep updates the version literals.
+[package]
+name = "starter-graph"
+description = "Layer 3 starter - Active Knowledge Graph as the application"
+version = "4.12.6"
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+
+[dependencies]
+# inside the Mercury repo the path is used; after copying the template out,
+# delete the `path` keys - the version then resolves from crates.io
+mercury-platform-core = { path = "../../crates/platform-core", version = "4.12.6" }
+mercury-event-script = { path = "../../crates/event-script", version = "4.12.6" }
+mercury-knowledge-graph = { path = "../../crates/knowledge-graph", version = "4.12.6" }
+async-trait = "0.1"
+log = "0.4"
+
+[dev-dependencies]
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util"] }

--- a/templates/starter-graph/README.md
+++ b/templates/starter-graph/README.md
@@ -1,0 +1,54 @@
+# starter-graph — Layer 3 template
+
+A minimal Active Knowledge Graph application with **zero imperative code**: the deployed
+graph model (`starter-quote`) validates the request and answers from its own knowledge.
+Changing what the service does means editing the model, not writing code. The model file
+is engine-portable — the same JSON runs on the Java engine. Copy this directory out of
+the Mercury repository to begin a new project.
+
+## After copying out
+
+The manifest uses an in-repo `path` for the Mercury crates. In your copy, delete the
+`path` keys in `Cargo.toml` — the pinned versions then resolve from crates.io:
+
+```toml
+mercury-platform-core = "4.12.6"
+mercury-event-script = "4.12.6"
+mercury-knowledge-graph = "4.12.6"
+```
+
+## Build, test, run
+
+```bash
+cargo test
+cargo run
+```
+
+Then:
+
+```bash
+curl -s -X POST http://127.0.0.1:8303/api/graph/starter-quote \
+     -H "content-type: application/json" \
+     -d '{"item": "widget"}'
+# → {"item": "widget", "unit_price": 100, "currency": "USD", "status": "quoted"}
+```
+
+## What to look at
+
+| File | Role |
+|:---|:---|
+| `resources/graph/starter-quote.json` | The application — a graph whose nodes execute during traversal |
+| `resources/graphs.yaml` | The deployment manifest: only listed graphs that pass the CompileGraph gate are executable ("compiled or 404") |
+| `resources/rest.yaml` | Exposes deployed graphs through the engine's graph-executor flow |
+| `tests/quote_graph_test.rs` | End-to-end graph tests, including the 404 gate behavior |
+
+## Next steps
+
+- Evolve the model: add nodes, decisions, and skills — the
+  [built-in skills reference](https://accenture.github.io/mercury/guides/knowledge-graph/skills-reference/)
+  catalogs what nodes can do without code.
+- Draft and dry-run models interactively in the Playground — see
+  [Playground & AI companion](https://accenture.github.io/mercury/guides/knowledge-graph/playground-and-companion/).
+- Custom logic when the model needs it: attach a skill function (`#[preload]`) to a node —
+  the deliberate seam between the model and code. See the
+  [AI developer guide](https://accenture.github.io/mercury/guides/ai-developer-guide/).

--- a/templates/starter-graph/resources/application.yml
+++ b/templates/starter-graph/resources/application.yml
@@ -1,0 +1,13 @@
+# starter-graph - Layer 3 starter configuration
+application.name: starter-graph
+info.app.description: 'Layer 3 starter - Active Knowledge Graph as the application'
+
+# REST automation serves rest.yaml over HTTP
+rest.automation: true
+# a distinct port so a running application never collides with unit tests
+rest.server.port: 8303
+
+# CompileGraph quality gate (required for deployed graph execution) - validates
+# and compiles the manifest-listed graph models at startup; only graphs that
+# pass the gate are executable ("compiled or 404")
+graph.model.automation: 'classpath:/graphs.yaml'

--- a/templates/starter-graph/resources/graph/starter-quote.json
+++ b/templates/starter-graph/resources/graph/starter-quote.json
@@ -1,0 +1,117 @@
+{
+  "nodes": [
+    {
+      "alias": "root",
+      "types": [
+        "Root"
+      ],
+      "properties": {
+        "name": "starter-quote",
+        "purpose": "Zero-code quote service: validate the request, then answer from the graph's own knowledge - the model IS the application"
+      }
+    },
+    {
+      "alias": "check-input",
+      "types": [
+        "Decision"
+      ],
+      "properties": {
+        "skill": "graph.math",
+        "statement": [
+          "MAPPING: text(={input.body.item}) -> model.item_probe",
+          "IF: {model.item_probe} == '=null'\nTHEN: reject\nELSE: quote"
+        ],
+        "purpose": "A request must name the item to quote"
+      }
+    },
+    {
+      "alias": "reject",
+      "types": [
+        "mapper"
+      ],
+      "properties": {
+        "skill": "graph.data.mapper",
+        "mapping": [
+          "int(400) -> output.status",
+          "text(Missing item. Provide the item name in the 'item' field) -> output.body.message"
+        ],
+        "purpose": "Reject a request without an item - an output.status of 400+ becomes the standard error response"
+      }
+    },
+    {
+      "alias": "quote",
+      "types": [
+        "mapper"
+      ],
+      "properties": {
+        "skill": "graph.data.mapper",
+        "mapping": [
+          "input.body.item -> output.body.item",
+          "int(100) -> output.body.unit_price",
+          "text(USD) -> output.body.currency",
+          "text(quoted) -> output.body.status"
+        ],
+        "purpose": "Compose the quote from the graph's knowledge"
+      }
+    },
+    {
+      "alias": "end",
+      "types": [
+        "End"
+      ],
+      "properties": {}
+    }
+  ],
+  "connections": [
+    {
+      "source": "root",
+      "relations": [
+        {
+          "type": "run",
+          "properties": {}
+        }
+      ],
+      "target": "check-input"
+    },
+    {
+      "source": "check-input",
+      "relations": [
+        {
+          "type": "valid",
+          "properties": {}
+        }
+      ],
+      "target": "quote"
+    },
+    {
+      "source": "check-input",
+      "relations": [
+        {
+          "type": "invalid",
+          "properties": {}
+        }
+      ],
+      "target": "reject"
+    },
+    {
+      "source": "quote",
+      "relations": [
+        {
+          "type": "then",
+          "properties": {}
+        }
+      ],
+      "target": "end"
+    },
+    {
+      "source": "reject",
+      "relations": [
+        {
+          "type": "then",
+          "properties": {}
+        }
+      ],
+      "target": "end"
+    }
+  ]
+}

--- a/templates/starter-graph/resources/graphs.yaml
+++ b/templates/starter-graph/resources/graphs.yaml
@@ -1,0 +1,8 @@
+#
+# The deployment manifest: only graphs listed here (and passing the CompileGraph
+# gate at startup) are executable at POST /api/graph/{graph_id}.
+#
+graphs:
+  - 'starter-quote'
+
+location: 'classpath:/graph'

--- a/templates/starter-graph/resources/rest.yaml
+++ b/templates/starter-graph/resources/rest.yaml
@@ -1,0 +1,12 @@
+#
+# REST automation - deployed graphs are executed through the engine's
+# graph-executor flow; only manifest-listed graphs that pass the CompileGraph
+# gate respond (anything else is HTTP-404, as if nonexistent).
+#
+rest:
+  - service: "http.flow.adapter"
+    methods: ['POST', 'GET']
+    url: "/api/graph/{graph_id}"
+    flow: 'graph-executor'
+    timeout: 30s
+    tracing: true

--- a/templates/starter-graph/src/main.rs
+++ b/templates/starter-graph/src/main.rs
@@ -1,0 +1,28 @@
+// Scaffolded from Mercury's starter templates (https://github.com/Accenture/mercury, Apache-2.0)
+
+//! Layer 3 starter — the Active Knowledge Graph IS the application: the
+//! deployed model (resources/graph/starter-quote.json) validates the request
+//! and answers from its own knowledge, with ZERO imperative business code.
+//! The CompileGraph gate validates and compiles manifest-listed models at
+//! startup; only compiled graphs execute at POST /api/graph/{graph_id}.
+//! Copy this template out of the Mercury repository to begin a new project
+//! (see README.md and AGENTS.md).
+
+use async_trait::async_trait;
+use platform_core::{main_application, AppError, EntryPoint};
+
+#[main_application]
+struct StarterGraphApp;
+
+#[async_trait]
+impl EntryPoint for StarterGraphApp {
+    async fn start(&self, _args: &[String]) -> Result<(), AppError> {
+        log::info!(
+            "starter-graph ready: {} graph(s) compiled",
+            knowledge_graph::graphs::get_all_graphs().len()
+        );
+        Ok(())
+    }
+}
+
+platform_core::auto_start_main!();

--- a/templates/starter-graph/tests/quote_graph_test.rs
+++ b/templates/starter-graph/tests/quote_graph_test.rs
@@ -1,0 +1,69 @@
+// Scaffolded from Mercury's starter templates (https://github.com/Accenture/mercury, Apache-2.0)
+
+//! Boots the whole starter once and drives the deployed graph end to end:
+//! the happy path, the model's own validation, and the "compiled or 404"
+//! deployment gate.
+
+use platform_core::{automation, overrides, AutoStart};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+// The application under test is a BIN crate — include its source so the
+// link-time inventory in this test binary carries the app's registrations.
+#[allow(dead_code)]
+#[path = "../src/main.rs"]
+mod app;
+
+async fn http_post(port: u16, path: &str, body: &str) -> (u16, String) {
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("connect");
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: localhost\r\ncontent-type: application/json\r\n\
+         accept: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(request.as_bytes()).await.expect("write");
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).await.expect("read");
+    let text = String::from_utf8_lossy(&raw).to_string();
+    let (head, payload) = text.split_once("\r\n\r\n").unwrap_or((text.as_str(), ""));
+    let status: u16 = head
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse().ok())
+        .unwrap_or_else(|| panic!("status code missing in: {text:?}"));
+    (status, payload.to_string())
+}
+
+// One test function on purpose: the app boots ONCE per process (AutoStart is
+// a run-once lifecycle), so all cases run in a single sequential test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn deployed_graph_end_to_end() {
+    overrides::set("rest.server.port", "0"); // an ephemeral port for the test
+    AutoStart::main(vec![]).await.expect("app lifecycle");
+    let port = automation::server_address().expect("server started").port();
+
+    // happy path: the zero-code model answers the quote
+    let (status, payload) =
+        http_post(port, "/api/graph/starter-quote", r#"{"item": "widget"}"#).await;
+    assert_eq!(status, 200, "unexpected: {payload}");
+    let body: serde_json::Value = serde_json::from_str(&payload).expect("json");
+    assert_eq!(body["item"], serde_json::json!("widget"));
+    assert_eq!(body["unit_price"], serde_json::json!(100));
+    assert_eq!(body["status"], serde_json::json!("quoted"));
+
+    // the model's own validation: a request without an item is rejected
+    let (status, payload) = http_post(
+        port,
+        "/api/graph/starter-quote",
+        r#"{"unexpected": "payload"}"#,
+    )
+    .await;
+    assert_eq!(status, 400, "unexpected: {payload}");
+    assert!(payload.contains("Missing item"), "unexpected: {payload}");
+
+    // "compiled or 404": a graph absent from the manifest behaves as nonexistent
+    let (status, _) = http_post(port, "/api/graph/no-such-graph", r#"{"item": "widget"}"#).await;
+    assert_eq!(status, 404);
+}


### PR DESCRIPTION
## What

First-class starter templates for the three layers, under `templates/`: **starter-function** (Layer 1, a `TypedFunction<AsyncHttpRequest, _>` HTTP-facing function), **starter-flow** (Layer 2, a validate→greet flow), and **starter-graph** (Layer 3, a zero-code knowledge-graph service behind the CompileGraph gate, with the "compiled or 404" behavior tested).

- Copy-out by design: workspace members with explicit metadata (no workspace inheritance) and `path`+`version` dual dependencies — in-repo builds use the path; a copied-out project deletes the `path` keys and the pinned versions resolve from crates.io (the templates' AGENTS.md and README state the one-step edit).
- The Layer 2 flow YAML and the Layer 3 graph model are **byte-identical** to the Java twin's templates — engine portability demonstrated inside the templates themselves.
- Each template carries a README and an `AGENTS.md` that routes a fresh AI agent to the entry-point playbook and offers AI-enablement; the AI developer guide's scaffold step now points at the templates.
- Template sources carry a one-line scaffold attribution instead of the full license header (ruled exception, recorded in continuity) — field applications built from them are not open source.

## Why

The fresh-agent playbook needs first-class scaffold targets. Lock-step with Accenture/mercury-composable (whose templates also ship a Gradle option — Rust needs none). Engine-truthful adaptations are documented in the session log: the required `#[main_application]` EntryPoint, and registration-inventory linkage anchored via `flows::get_all_flows()` / `graphs::get_all_graphs()`.

Verified: `cargo test` for all three templates, clippy and fmt clean, docs strict build + claims/llms checks green; workspace membership puts the templates in normal CI automatically. Release note: the version bump list grows to 8 manifests (recorded in continuity).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>