### PR TITLE
release: version 4.12.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,40 @@ The full increment-by-increment record lives in [`docs/INCREMENTS.md`](docs/INCR
 the design rationale in [`draft-design-specs/`](draft-design-specs/).
 
 ---
+## Version 4.12.7, 9/11/2026
+
+A documentation-and-templates release, lock-step with the Java engine's v4.12.7 (whose
+headline fix — the simple-plugin allowlist gate scanning method bodies — is Java-only:
+this port has no runtime plugin loading). No engine behavior change.
+
+### Added
+
+- **Three-layer starter templates** under `templates/` (Increment 116) —
+  `starter-function`, `starter-flow` and `starter-graph` (a zero-code knowledge-graph
+  service behind the CompileGraph gate, "compiled or 404" tested): copy-out crates with
+  explicit metadata and path+version dual dependencies — a copy deletes the `path` keys
+  and the pinned versions resolve from crates.io. The Layer 2 flow YAML and the Layer 3
+  graph model are byte-identical to the Java engine's templates.
+- **AI developer guide** (`guides/ai-developer-guide.md`, Increment 117) — the
+  cross-layer "read this first if you are an AI agent" orientation: the mental model,
+  the fresh-agent entry-point playbook (a greenfield project; AI-enabling an existing
+  repository), brownfield orientation, the layer-choice tree, per-layer authoring
+  snippets and port-honest invariants. Wired into the Foundations nav, `llms.txt` and
+  the packaged AI contract.
+- **The Mercury Family page** (`docs/mercury-family.md`) with a home-page hero button
+  and an Orientation nav entry, following agent-memory's promotion into the family at
+  github.com/Accenture/mercury-go.
+
+### Changed
+
+- The Methodology guide is synthesized around Intent-Driven Development — IDD leads,
+  then the knowledge-graph path, the composable design principles and the event-driven
+  core.
+- Documentation site polish: two-column home page with default-size hero buttons and a
+  relaxed layered-ascent table; story-deck slide 7 states its essence in plain language;
+  the Orientation nav label simplified to "White Paper".
+
+---
 ## Version 4.12.6, 9/10/2026
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ai-contract-provider"
-version = "4.12.6"
+version = "4.12.7"
 dependencies = [
  "async-trait",
  "log",
@@ -114,7 +114,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark-reporter"
-version = "4.12.6"
+version = "4.12.7"
 dependencies = [
  "async-trait",
  "log",
@@ -454,7 +454,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-flow"
-version = "4.12.6"
+version = "4.12.7"
 dependencies = [
  "async-trait",
  "log",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world"
-version = "4.12.6"
+version = "4.12.7"
 dependencies = [
  "async-trait",
  "log",
@@ -756,7 +756,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mercury-event-script"
-version = "4.12.6"
+version = "4.12.7"
 dependencies = [
  "async-trait",
  "base64",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-event-script-macros"
-version = "4.12.6"
+version = "4.12.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-knowledge-graph"
-version = "4.12.6"
+version = "4.12.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-knowledge-graph-macros"
-version = "4.12.6"
+version = "4.12.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-minigraph-state-redis"
-version = "4.12.6"
+version = "4.12.7"
 dependencies = [
  "async-trait",
  "log",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-platform-core"
-version = "4.12.6"
+version = "4.12.7"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "mercury-platform-macros"
-version = "4.12.6"
+version = "4.12.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "minigraph-playground"
-version = "4.12.6"
+version = "4.12.7"
 dependencies = [
  "async-trait",
  "log",
@@ -1551,7 +1551,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "starter-flow"
-version = "4.12.6"
+version = "4.12.7"
 dependencies = [
  "async-trait",
  "log",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "starter-function"
-version = "4.12.6"
+version = "4.12.7"
 dependencies = [
  "async-trait",
  "log",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "starter-graph"
-version = "4.12.6"
+version = "4.12.7"
 dependencies = [
  "async-trait",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.12.6"
+version = "4.12.7"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Accenture/mercury"

--- a/crates/event-script/Cargo.toml
+++ b/crates/event-script/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous"]
 name = "event_script"
 
 [dependencies]
-mercury-platform-core = { version = "4.12.6", path = "../platform-core" }
+mercury-platform-core = { version = "4.12.7", path = "../platform-core" }
 async-trait = "0.1"
 log = "0.4"
 # --- increment E-2: data-mapping engine ---
@@ -31,7 +31,7 @@ chrono = "0.4"
 # (the ZoneId.systemDefault() analog, same crate chrono uses internally)
 chrono-tz = "0.10"
 iana-time-zone = "0.1"
-mercury-event-script-macros = { version = "4.12.6", path = "../event-script-macros" }
+mercury-event-script-macros = { version = "4.12.7", path = "../event-script-macros" }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]

--- a/crates/knowledge-graph/Cargo.toml
+++ b/crates/knowledge-graph/Cargo.toml
@@ -16,12 +16,12 @@ exclude = ["webapp/"]
 name = "knowledge_graph"
 
 [dependencies]
-mercury-platform-core = { version = "4.12.6", path = "../platform-core" }
+mercury-platform-core = { version = "4.12.7", path = "../platform-core" }
 # layer 3 rides layer 2: the data-mapping mini-language (converter, rmpv
 # MultiLevelMap) is shared with event-script, and deployed graphs are
 # exposed through event-script flows
-mercury-event-script = { version = "4.12.6", path = "../event-script" }
-mercury-knowledge-graph-macros = { version = "4.12.6", path = "../knowledge-graph-macros" }
+mercury-event-script = { version = "4.12.7", path = "../event-script" }
+mercury-knowledge-graph-macros = { version = "4.12.7", path = "../knowledge-graph-macros" }
 async-trait = "0.1"
 log = "0.4"
 rmpv = { version = "1", features = ["with-serde"] }

--- a/crates/platform-core/Cargo.toml
+++ b/crates/platform-core/Cargo.toml
@@ -42,7 +42,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["ring",
 rustls-native-certs = "0.8"
 # --- increment 10: annotation macros (Java @PreLoad/@BeforeApplication/@MainApplication) ---
 inventory = "0.3"
-mercury-platform-macros = { version = "4.12.6", path = "../platform-macros" }
+mercury-platform-macros = { version = "4.12.7", path = "../platform-macros" }
 # --- increment 71: ManagedCache (docs/design/managed-cache-port.md — the Caffeine-lineage
 # engine, wrapped; EvictionPolicy::lru per the maintainer's deterministic-eviction ruling) ---
 moka = { version = "0.12", features = ["sync"] }

--- a/docs/INCREMENTS.md
+++ b/docs/INCREMENTS.md
@@ -2861,3 +2861,34 @@ and re-case recursively through nested maps and lists; values are never touched;
 collisions resolve last-wins at the first key's position; normalization is idempotent.
 Lock-step with the Java engine: identical algorithm, error messages, and the shared
 pluggableFunctions/types.yml fixture (BUILTIN_PLUGIN_COUNT floor 48 → 50).
+
+## Increment 116 — Three-layer starter templates (2026-09-11)
+
+Copy-out starter crates under `templates/` for the three layers: `starter-function` (a
+typed AsyncHttpRequest greeting behind REST automation), `starter-flow` (a
+validate→greet flow with state-machine data mapping) and `starter-graph` (a ZERO-CODE
+knowledge-graph service behind the CompileGraph gate — the "compiled or 404" behavior is
+a test case). Workspace members with explicit metadata and `{path, version}` dual
+dependencies: in-repo builds use the path; a copied-out project deletes the `path` keys
+and resolves the pins from crates.io. Engine-truthful patterns proven in the tests: a
+`#[main_application]` EntryPoint is required (the auto_start_main! macro alone is only
+the launcher), and registration-inventory linkage is anchored via
+`flows::get_all_flows()` / `graphs::get_all_graphs()`. The Layer 2 flow YAML and the
+Layer 3 graph model are byte-identical to the Java engine's templates. Sources carry a
+one-line scaffold attribution instead of the license header (field applications are not
+open source). Release version bumps now cover 8 manifests. Lock-step with the Java
+engine's templates, which also ship a Gradle build option (templates only — never a
+reactor concern).
+
+## Increment 117 — AI developer guide: the cross-layer agent orientation (2026-09-11)
+
+`guides/ai-developer-guide.md` — the "read this first if you are an AI agent" umbrella
+page (the Java repo had one; this repo's agent surface was the per-layer guides only):
+the mental model, the fresh-agent entry-point playbook (a greenfield project; an
+existing repository that is not yet AI-enabled — offer AI-enablement first, fold
+per-tool context into the shared memory layer), brownfield orientation for the
+resources/ layout, the layer-choice tree, adding-a-feature snippets, cargo test idioms,
+and port-honest invariants (serde rules; no service mesh; no graph.js). Wired into the
+Foundations nav, a new llms.txt cross-layer orientation section, and the packaged AI
+contract (files.list). The methodology's interim entry-points section slimmed to the
+same pointer the Java twin carries.

--- a/extensions/minigraph-state-redis/Cargo.toml
+++ b/extensions/minigraph-state-redis/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["database", "asynchronous"]
 name = "minigraph_state_redis"
 
 [dependencies]
-mercury-platform-core = { version = "4.12.6", path = "../../crates/platform-core" }
+mercury-platform-core = { version = "4.12.7", path = "../../crates/platform-core" }
 async-trait = "0.1"
 log = "0.4"
 rmpv = { version = "1", features = ["with-serde"] }

--- a/memory/sessions/2026-09-11-040631.md
+++ b/memory/sessions/2026-09-11-040631.md
@@ -1,0 +1,32 @@
+# Session (2026-09-11T04:06:31.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Release v4.12.7 prepared** (lock-step with the Java engine's v4.12.7). This
+side is a documentation-and-templates release — PRs #255–#261: the starter
+template crates (Increment 116), the AI developer guide (Increment 117), the
+Mercury Family page, the IDD methodology synthesis, and the docs polish. No
+engine behavior change: the Java headline fix (plugin-gate body scan) has no
+Rust counterpart — this port has no runtime plugin loading.
+
+- **Version bump**: 8 manifests per [[conv-template-version-sweep-rust]]
+  (its first exercise) — root workspace + the 4 inter-crate-pin tomls + the
+  3 template crates (explicit versions and path+version dep pins) — plus the
+  3 template READMEs' crates.io examples. Zero 4.12.6 stragglers outside
+  target/.
+- **CHANGELOG** Version 4.12.7, 9/11/2026 (Added: templates, AI developer
+  guide, Mercury Family; Changed: IDD methodology, docs polish; the Java-only
+  scope of the gate fix stated plainly). INCREMENTS 116–117 appended.
+- **Verified**: `cargo build --workspace` green (Cargo.lock regenerated —
+  now covers the 3 template crates too) and the full
+  `cargo test --workspace` suite green, run serialized after the Java
+  reactor per the laptop-contention rule.
+
+## Memory References
+
+- eric-release-rhythm-rust (consulted — prep only: PR-open, merge, tag and
+  crates.io publish are each Eric's gated steps)
+- conv-template-version-sweep-rust (consulted — first release exercising
+  the 8-manifest edit list)

--- a/templates/starter-flow/Cargo.toml
+++ b/templates/starter-flow/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "starter-flow"
 description = "Layer 2 starter - Event Script flows"
-version = "4.12.6"
+version = "4.12.7"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
@@ -12,8 +12,8 @@ publish = false
 [dependencies]
 # inside the Mercury repo the path is used; after copying the template out,
 # delete the `path` keys - the version then resolves from crates.io
-mercury-platform-core = { path = "../../crates/platform-core", version = "4.12.6" }
-mercury-event-script = { path = "../../crates/event-script", version = "4.12.6" }
+mercury-platform-core = { path = "../../crates/platform-core", version = "4.12.7" }
+mercury-event-script = { path = "../../crates/event-script", version = "4.12.7" }
 async-trait = "0.1"
 serde_json = "1"
 log = "0.4"

--- a/templates/starter-flow/README.md
+++ b/templates/starter-flow/README.md
@@ -11,8 +11,8 @@ The manifest uses an in-repo `path` for the Mercury crates. In your copy, delete
 `path` keys in `Cargo.toml` — the pinned versions then resolve from crates.io:
 
 ```toml
-mercury-platform-core = "4.12.6"
-mercury-event-script = "4.12.6"
+mercury-platform-core = "4.12.7"
+mercury-event-script = "4.12.7"
 ```
 
 ## Build, test, run

--- a/templates/starter-function/Cargo.toml
+++ b/templates/starter-function/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "starter-function"
 description = "Layer 1 starter - composable functions with REST automation"
-version = "4.12.6"
+version = "4.12.7"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 # inside the Mercury repo the path is used; after copying the template out,
 # delete the `path` keys - the version then resolves from crates.io
-mercury-platform-core = { path = "../../crates/platform-core", version = "4.12.6" }
+mercury-platform-core = { path = "../../crates/platform-core", version = "4.12.7" }
 async-trait = "0.1"
 serde_json = "1"
 log = "0.4"

--- a/templates/starter-function/README.md
+++ b/templates/starter-function/README.md
@@ -10,7 +10,7 @@ The manifest uses an in-repo `path` for the Mercury crates. In your copy, delete
 `path` keys in `Cargo.toml` — the pinned versions then resolve from crates.io:
 
 ```toml
-mercury-platform-core = "4.12.6"
+mercury-platform-core = "4.12.7"
 ```
 
 ## Build, test, run

--- a/templates/starter-graph/Cargo.toml
+++ b/templates/starter-graph/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "starter-graph"
 description = "Layer 3 starter - Active Knowledge Graph as the application"
-version = "4.12.6"
+version = "4.12.7"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
@@ -12,9 +12,9 @@ publish = false
 [dependencies]
 # inside the Mercury repo the path is used; after copying the template out,
 # delete the `path` keys - the version then resolves from crates.io
-mercury-platform-core = { path = "../../crates/platform-core", version = "4.12.6" }
-mercury-event-script = { path = "../../crates/event-script", version = "4.12.6" }
-mercury-knowledge-graph = { path = "../../crates/knowledge-graph", version = "4.12.6" }
+mercury-platform-core = { path = "../../crates/platform-core", version = "4.12.7" }
+mercury-event-script = { path = "../../crates/event-script", version = "4.12.7" }
+mercury-knowledge-graph = { path = "../../crates/knowledge-graph", version = "4.12.7" }
 async-trait = "0.1"
 log = "0.4"
 

--- a/templates/starter-graph/README.md
+++ b/templates/starter-graph/README.md
@@ -12,9 +12,9 @@ The manifest uses an in-repo `path` for the Mercury crates. In your copy, delete
 `path` keys in `Cargo.toml` — the pinned versions then resolve from crates.io:
 
 ```toml
-mercury-platform-core = "4.12.6"
-mercury-event-script = "4.12.6"
-mercury-knowledge-graph = "4.12.6"
+mercury-platform-core = "4.12.7"
+mercury-event-script = "4.12.7"
+mercury-knowledge-graph = "4.12.7"
 ```
 
 ## Build, test, run


### PR DESCRIPTION
## What

Version 4.12.7 — lock-step with the Java engine. The bump covers 8 manifests (workspace + inter-crate pins + the three template crates with their path+version dual dependencies), `Cargo.lock`, the template README examples, CHANGELOG, and Increments 116–117. Full workspace suite green (77 suites) at the new version.

## Why

A documentation-and-templates release: the three-layer starter template crates (Increment 116), the AI developer guide — the cross-layer agent orientation (Increment 117), the Mercury Family page, and the IDD methodology synthesis. No engine behavior change — the Java engine's headline fix (the plugin-gate body scan) has no Rust counterpart, since this port has no runtime plugin loading.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>